### PR TITLE
add a docker for drifctl

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+bin/
+Dockerfile
+.cache
+**/*.golden.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.15.2 AS builder
+
+ARG OS="linux"
+ARG ARCH="amd64"
+
+WORKDIR /go/src/app
+COPY go.mod go.sum Makefile ./
+RUN make deps
+COPY . .
+RUN OS_ARCH=${OS}/${ARCH} make release
+
+FROM gcr.io/distroless/base-debian10
+
+ARG OS="linux"
+ARG ARCH="amd64"
+ENV HOME=/app
+
+WORKDIR /app
+COPY --from=builder /go/src/app/bin/driftctl_${OS}_${ARCH} /bin/driftctl
+ENTRYPOINT ["/bin/driftctl"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@
   <img src="https://img.shields.io/github/downloads/cloudskiff/driftctl/total.svg"/>
   <a href="https://codecov.io/gh/cloudskiff/driftctl">
     <img src="https://codecov.io/gh/cloudskiff/driftctl/branch/main/graph/badge.svg?token=8C5R02G5S7"/>
-  </a><br>
+  </a>
+  <img src="https://img.shields.io/docker/pulls/cloudskiff/driftctl"/>
+  <img src="https://img.shields.io/microbadger/layers/cloudskiff/driftctl"/>
+  <img src="https://img.shields.io/docker/image-size/cloudskiff/driftctl"/>
+
+<br>
   Measures infrastructure as code coverage, and tracks infrastructure drift.<br>
   :warning: <strong>This tool is still in beta state and will evolve in the future with potential breaking changes</strong> :warning:
 </p>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ driftctl is available on Linux, macOS and Windows.
 
 Binaries are available in the [release page](https://github.com/cloudskiff/driftctl/releases).
 
+#### Docker
+```bash
+docker run \
+  -v ~/.aws:/app/.aws:ro \
+  -v $(pwd)/terraform.tfstate:/app/terraform.tfstate:ro \
+  -v ~/.driftctl:/app/.driftctl \
+  -e AWS_PROFILE=cloudskiff \
+  cloudskiff/driftctl scan ## with the same option as the binary version
+```
+`-v ~/.aws:/app/.aws:ro` mount your .aws containing credentials and profile
+
+`-v $(pwd)/terraform.tfstate:/app/terraform.tfstate:ro` mount your terraform state
+
+`-v ~/.driftctl:/app/.driftctl` to prevent driftctl downloading the provider at each run, mount a directory to persist it
+
+`-e AWS_PROFILE=cloudskiff` export the profile to use in you aws config
+
+
 #### Manual
 
 ##### Linux
@@ -85,7 +103,6 @@ $ driftctl scan --from tfstate://terraform.tfstate
 # With state stored on a s3 backend
 $ driftctl scan --from tfstate+s3://my-bucket/path/to/state.tfstate
 ```
-
 ## Documentation & support
 
 - [User guide](doc/README.md)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,6 +32,12 @@ os_archs=(
     windows/amd64
 )
 
+if [ -n "$OS_ARCH" ]; then
+  os_archs=("$OS_ARCH")
+fi
+
+echo "ARCH: $os_archs"
+
 if [ $ENV != "release" ]; then
     echo "+ Building env: dev"
     # If its dev mode, only build for ourself


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | 
| ❓ Documentation  | yes

## Description

Added docker file  to build drifctl docker image.
Documentation to run driftctl from docker