### PR TITLE
Handle alert during execution

### DIFF
--- a/doc/contributing/tests.md
+++ b/doc/contributing/tests.md
@@ -220,12 +220,14 @@ func TestAcc_AwsInstance_WithBlockDevices(t *testing.T) {
 					result.AssertResourceHasDrift(
 						mutatedInstanceId,
 						awsresources.AwsInstanceResourceType,
-						diff.Change{
-							Type: diff.CREATE,
-							Path: []string{"Tags", "Env"},
-							From: nil,
-							To:   "Production",
-						},
+                        analyser.Change{
+                            Change: diff.Change{
+                                Type: diff.CREATE,
+                                Path: []string{"Tags", "Env"},
+                                From: nil,
+                                To:   "Production",
+                            },
+                        },
 					)
 				},
 			},

--- a/pkg/alerter/alert.go
+++ b/pkg/alerter/alert.go
@@ -1,0 +1,8 @@
+package alerter
+
+type Alerts map[string][]Alert
+
+type Alert struct {
+	Message              string `json:"message"`
+	ShouldIgnoreResource bool   `json:"-"`
+}

--- a/pkg/alerter/alerter.go
+++ b/pkg/alerter/alerter.go
@@ -1,0 +1,71 @@
+package alerter
+
+import (
+	"fmt"
+
+	"github.com/cloudskiff/driftctl/pkg/resource"
+)
+
+type Alerter struct {
+	alerts   Alerts
+	alertsCh chan Alerts
+	doneCh   chan bool
+}
+
+func NewAlerter() *Alerter {
+	var alerter = &Alerter{
+		alerts:   make(Alerts),
+		alertsCh: make(chan Alerts),
+		doneCh:   make(chan bool),
+	}
+
+	go alerter.run()
+
+	return alerter
+}
+
+func (a *Alerter) run() {
+	defer func() { a.doneCh <- true }()
+	for alert := range a.alertsCh {
+		for k, v := range alert {
+			if val, ok := a.alerts[k]; ok {
+				a.alerts[k] = append(val, v...)
+			} else {
+				a.alerts[k] = v
+			}
+		}
+	}
+}
+
+func (a *Alerter) SetAlerts(alerts Alerts) {
+	a.alerts = alerts
+}
+
+func (a *Alerter) GetAlerts() Alerts {
+	close(a.alertsCh)
+	<-a.doneCh
+	return a.alerts
+}
+
+func (a *Alerter) SendAlert(key string, alert Alert) {
+	a.alertsCh <- Alerts{
+		key: []Alert{alert},
+	}
+}
+
+func (a *Alerter) IsResourceIgnored(res resource.Resource) bool {
+	alert, alertExists := a.alerts[fmt.Sprintf("%s.%s", res.TerraformType(), res.TerraformId())]
+	wildcardAlert, wildcardAlertExists := a.alerts[res.TerraformType()]
+	shouldIgnoreAlert := a.shouldBeIgnored(alert)
+	shouldIgnoreWildcardAlert := a.shouldBeIgnored(wildcardAlert)
+	return (alertExists && shouldIgnoreAlert) || (wildcardAlertExists && shouldIgnoreWildcardAlert)
+}
+
+func (a *Alerter) shouldBeIgnored(alert []Alert) bool {
+	for _, a := range alert {
+		if a.ShouldIgnoreResource {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/alerter/alerter.go
+++ b/pkg/alerter/alerter.go
@@ -41,7 +41,7 @@ func (a *Alerter) SetAlerts(alerts Alerts) {
 	a.alerts = alerts
 }
 
-func (a *Alerter) GetAlerts() Alerts {
+func (a *Alerter) Retrieve() Alerts {
 	close(a.alertsCh)
 	<-a.doneCh
 	return a.alerts

--- a/pkg/alerter/alerter_test.go
+++ b/pkg/alerter/alerter_test.go
@@ -1,0 +1,210 @@
+package alerter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cloudskiff/driftctl/pkg/resource"
+	resource2 "github.com/cloudskiff/driftctl/test/resource"
+)
+
+func TestAlerter_Alert(t *testing.T) {
+	cases := []struct {
+		name     string
+		alerts   Alerts
+		expected Alerts
+	}{
+		{
+			name:     "TestNoAlerts",
+			alerts:   nil,
+			expected: Alerts{},
+		},
+		{
+			name: "TestWithSingleAlert",
+			alerts: Alerts{
+				"fakeres.foobar": []Alert{
+					{
+						Message:              "This is an alert",
+						ShouldIgnoreResource: false,
+					},
+				},
+			},
+			expected: Alerts{
+				"fakeres.foobar": []Alert{
+					{
+						Message:              "This is an alert",
+						ShouldIgnoreResource: false,
+					},
+				},
+			},
+		},
+		{
+			name: "TestWithMultipleAlerts",
+			alerts: Alerts{
+				"fakeres.foobar": []Alert{
+					{
+						Message:              "This is an alert",
+						ShouldIgnoreResource: false,
+					},
+					{
+						Message:              "This is a second alert",
+						ShouldIgnoreResource: true,
+					},
+				},
+				"fakeres.barfoo": []Alert{
+					{
+						Message:              "This is a third alert",
+						ShouldIgnoreResource: true,
+					},
+				},
+			},
+			expected: Alerts{
+				"fakeres.foobar": []Alert{
+					{
+						Message:              "This is an alert",
+						ShouldIgnoreResource: false,
+					},
+					{
+						Message:              "This is a second alert",
+						ShouldIgnoreResource: true,
+					},
+				},
+				"fakeres.barfoo": []Alert{
+					{
+						Message:              "This is a third alert",
+						ShouldIgnoreResource: true,
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			alerter := NewAlerter()
+
+			for k, v := range c.alerts {
+				for _, a := range v {
+					alerter.SendAlert(k, a)
+				}
+			}
+
+			if eq := reflect.DeepEqual(alerter.GetAlerts(), c.expected); !eq {
+				t.Errorf("Got %+v, expected %+v", alerter.GetAlerts(), c.expected)
+			}
+		})
+	}
+}
+
+func TestAlerter_IgnoreResources(t *testing.T) {
+	cases := []struct {
+		name     string
+		alerts   Alerts
+		resource resource.Resource
+		expected bool
+	}{
+		{
+			name:   "TestNoAlerts",
+			alerts: Alerts{},
+			resource: &resource2.FakeResource{
+				Type: "fakeres",
+				Id:   "foobar",
+			},
+			expected: false,
+		},
+		{
+			name: "TestShouldNotBeIgnoredWithAlerts",
+			alerts: Alerts{
+				"fakeres": {
+					{
+						Message: "Should not be ignored",
+					},
+				},
+				"fakeres.foobar": {
+					{
+						Message: "Should not be ignored",
+					},
+				},
+				"fakeres.barfoo": {
+					{
+						Message: "Should not be ignored",
+					},
+				},
+				"other.resource": {
+					{
+						Message: "Should not be ignored",
+					},
+				},
+			},
+			resource: &resource2.FakeResource{
+				Type: "fakeres",
+				Id:   "foobar",
+			},
+			expected: false,
+		},
+		{
+			name: "TestShouldBeIgnoredWithAlertsOnWildcard",
+			alerts: Alerts{
+				"fakeres": {
+					{
+						Message:              "Should be ignored",
+						ShouldIgnoreResource: true,
+					},
+				},
+				"other.foobaz": {
+					{
+						Message:              "Should be ignored",
+						ShouldIgnoreResource: true,
+					},
+				},
+				"other.resource": {
+					{
+						Message: "Should not be ignored",
+					},
+				},
+			},
+			resource: &resource2.FakeResource{
+				Type: "fakeres",
+				Id:   "foobar",
+			},
+			expected: true,
+		},
+		{
+			name: "TestShouldBeIgnoredWithAlertsOnResource",
+			alerts: Alerts{
+				"fakeres": {
+					{
+						Message:              "Should be ignored",
+						ShouldIgnoreResource: true,
+					},
+				},
+				"other.foobaz": {
+					{
+						Message:              "Should be ignored",
+						ShouldIgnoreResource: true,
+					},
+				},
+				"other.resource": {
+					{
+						Message: "Should not be ignored",
+					},
+				},
+			},
+			resource: &resource2.FakeResource{
+				Type: "other",
+				Id:   "foobaz",
+			},
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			alerter := NewAlerter()
+			alerter.SetAlerts(c.alerts)
+			if got := alerter.IsResourceIgnored(c.resource); got != c.expected {
+				t.Errorf("Got %+v, expected %+v", got, c.expected)
+			}
+		})
+	}
+}

--- a/pkg/alerter/alerter_test.go
+++ b/pkg/alerter/alerter_test.go
@@ -89,8 +89,8 @@ func TestAlerter_Alert(t *testing.T) {
 				}
 			}
 
-			if eq := reflect.DeepEqual(alerter.GetAlerts(), c.expected); !eq {
-				t.Errorf("Got %+v, expected %+v", alerter.GetAlerts(), c.expected)
+			if eq := reflect.DeepEqual(alerter.Retrieve(), c.expected); !eq {
+				t.Errorf("Got %+v, expected %+v", alerter.Retrieve(), c.expected)
 			}
 		})
 	}

--- a/pkg/analyser/analysis.go
+++ b/pkg/analyser/analysis.go
@@ -8,9 +8,16 @@ import (
 	"github.com/r3labs/diff/v2"
 )
 
+type Change struct {
+	diff.Change
+	Computed bool `json:"computed"`
+}
+
+type Changelog []Change
+
 type Difference struct {
 	Res       resource.Resource
-	Changelog diff.Changelog
+	Changelog Changelog
 }
 
 type Summary struct {
@@ -32,7 +39,7 @@ type Analysis struct {
 
 type serializableDifference struct {
 	Res       resource.SerializableResource `json:"res"`
-	Changelog diff.Changelog                `json:"changelog"`
+	Changelog Changelog                     `json:"changelog"`
 }
 
 type serializableAnalysis struct {

--- a/pkg/analyser/analysis.go
+++ b/pkg/analyser/analysis.go
@@ -108,7 +108,7 @@ func (a *Analysis) UnmarshalJSON(bytes []byte) error {
 			Changelog: di.Changelog,
 		})
 	}
-	a.AddAlerts(bla.Alerts)
+	a.SetAlerts(bla.Alerts)
 	return nil
 }
 
@@ -139,7 +139,7 @@ func (a *Analysis) AddDifference(diffs ...Difference) {
 	a.summary.TotalDrifted += len(diffs)
 }
 
-func (a *Analysis) AddAlerts(alerts alerter.Alerts) {
+func (a *Analysis) SetAlerts(alerts alerter.Alerts) {
 	a.alerts = alerts
 }
 

--- a/pkg/analyser/analyzer.go
+++ b/pkg/analyser/analyzer.go
@@ -63,9 +63,7 @@ func (a Analyzer) Analyze(remoteResources, resourcesFromState []resource.Resourc
 					continue
 				}
 				c := Change{Change: change}
-				if a.isComputedField(stateRes, c) {
-					c.Computed = true
-				}
+				c.Computed = a.isComputedField(stateRes, c)
 				changelog = append(changelog, c)
 			}
 			if len(changelog) > 0 {
@@ -81,7 +79,7 @@ func (a Analyzer) Analyze(remoteResources, resourcesFromState []resource.Resourc
 	// Add remaining unmanaged resources
 	analysis.AddUnmanaged(filteredRemoteResource...)
 
-	analysis.AddAlerts(a.alerter.GetAlerts())
+	analysis.SetAlerts(a.alerter.Retrieve())
 
 	return analysis, nil
 }

--- a/pkg/analyser/analyzer_test.go
+++ b/pkg/analyser/analyzer_test.go
@@ -833,7 +833,7 @@ func TestAnalysis_MarshalJSON(t *testing.T) {
 			},
 		},
 	})
-	analysis.AddAlerts(alerter.Alerts{
+	analysis.SetAlerts(alerter.Alerts{
 		"aws_iam_access_key": {
 			{
 				Message: "This is an alert",

--- a/pkg/analyser/analyzer_test.go
+++ b/pkg/analyser/analyzer_test.go
@@ -221,39 +221,49 @@ func TestAnalyze(t *testing.T) {
 								Bar string
 							}{"baz", "bar"},
 						},
-						Changelog: diff.Changelog{
-							diff.Change{
-								Type: "update",
-								From: "foobar",
-								To:   "barfoo",
-								Path: []string{
-									"FooBar",
+						Changelog: Changelog{
+							{
+								Change: diff.Change{
+									Type: "update",
+									From: "foobar",
+									To:   "barfoo",
+									Path: []string{
+										"FooBar",
+									},
 								},
 							},
-							diff.Change{
-								Type: "update",
-								From: "barfoo",
-								To:   "foobar",
-								Path: []string{
-									"BarFoo",
+							{
+								Change: diff.Change{
+									Type: "update",
+									From: "barfoo",
+									To:   "foobar",
+									Path: []string{
+										"BarFoo",
+									},
 								},
+								Computed: true,
 							},
-							diff.Change{
-								Type: "update",
-								From: "baz",
-								To:   "bar",
-								Path: []string{
-									"Struct",
-									"Baz",
+							{
+								Change: diff.Change{
+									Type: "update",
+									From: "baz",
+									To:   "bar",
+									Path: []string{
+										"Struct",
+										"Baz",
+									},
 								},
+								Computed: true,
 							},
-							diff.Change{
-								Type: "update",
-								From: "bar",
-								To:   "baz",
-								Path: []string{
-									"Struct",
-									"Bar",
+							{
+								Change: diff.Change{
+									Type: "update",
+									From: "bar",
+									To:   "baz",
+									Path: []string{
+										"Struct",
+										"Bar",
+									},
 								},
 							},
 						},
@@ -326,14 +336,17 @@ func TestAnalyze(t *testing.T) {
 							FooBar: "foobar",
 							BarFoo: "barfoo",
 						},
-						Changelog: diff.Changelog{
-							diff.Change{
-								Type: "update",
-								From: "barfoo",
-								To:   "foobar",
-								Path: []string{
-									"BarFoo",
+						Changelog: Changelog{
+							{
+								Change: diff.Change{
+									Type: "update",
+									From: "barfoo",
+									To:   "foobar",
+									Path: []string{
+										"BarFoo",
+									},
 								},
+								Computed: true,
 							},
 						},
 					},
@@ -568,61 +581,77 @@ func TestAnalyze(t *testing.T) {
 								{"one", []string{"foo"}},
 							},
 						},
-						Changelog: diff.Changelog{
-							diff.Change{
-								Type: "update",
-								From: "foobar",
-								To:   "barfoo",
-								Path: []string{
-									"FooBar",
+						Changelog: Changelog{
+							{
+								Change: diff.Change{
+									Type: "update",
+									From: "foobar",
+									To:   "barfoo",
+									Path: []string{
+										"FooBar",
+									},
 								},
 							},
-							diff.Change{
-								Type: "update",
-								From: "barfoo",
-								To:   "foobar",
-								Path: []string{
-									"BarFoo",
+							{
+								Change: diff.Change{
+									Type: "update",
+									From: "barfoo",
+									To:   "foobar",
+									Path: []string{
+										"BarFoo",
+									},
+								},
+								Computed: true,
+							},
+							{
+								Change: diff.Change{
+									Type: "update",
+									From: "baz",
+									To:   "bar",
+									Path: []string{
+										"Struct",
+										"Baz",
+									},
+								},
+								Computed: true,
+							},
+							{
+								Change: diff.Change{
+									Type: "update",
+									From: "bar",
+									To:   "baz",
+									Path: []string{
+										"Struct",
+										"Bar",
+									},
 								},
 							},
-							diff.Change{
-								Type: "update",
-								From: "baz",
-								To:   "bar",
-								Path: []string{
-									"Struct",
-									"Baz",
+							{
+								Change: diff.Change{
+									Type: "update",
+									From: "foo",
+									To:   "oof",
+									Path: []string{
+										"StructSlice",
+										"0",
+										"Array",
+										"0",
+									},
 								},
+								Computed: true,
 							},
-							diff.Change{
-								Type: "update",
-								From: "bar",
-								To:   "baz",
-								Path: []string{
-									"Struct",
-									"Bar",
+							{
+								Change: diff.Change{
+									Type: "update",
+									From: "one",
+									To:   "two",
+									Path: []string{
+										"StructSlice",
+										"0",
+										"String",
+									},
 								},
-							},
-							diff.Change{
-								Type: "update",
-								From: "foo",
-								To:   "oof",
-								Path: []string{
-									"StructSlice",
-									"0",
-									"Array",
-									"0",
-								},
-							},
-							diff.Change{
-								Type: "update",
-								From: "one",
-								To:   "two",
-								Path: []string{
-									"StructSlice",
-									"0",
-									"String",
-								},
+								Computed: true,
 							},
 						},
 					},
@@ -654,7 +683,7 @@ func TestAnalyze(t *testing.T) {
 							Message: "StructSlice.0.String is a computed field",
 						},
 						{
-							Message: "StructSlice.0.Array.0 is a computed field",
+							Message: "StructSlice.0.Array is a computed field",
 						},
 					},
 				},
@@ -676,12 +705,12 @@ func TestAnalyze(t *testing.T) {
 			}
 			filter.On("IsFieldIgnored", mock.Anything, mock.Anything).Return(false)
 
-			alerter := alerter.NewAlerter()
+			al := alerter.NewAlerter()
 			if c.alerts != nil {
-				alerter.SetAlerts(c.alerts)
+				al.SetAlerts(c.alerts)
 			}
 
-			analyzer := NewAnalyzer(alerter)
+			analyzer := NewAnalyzer(al)
 			result, err := analyzer.Analyze(c.cloud, c.iac, filter)
 
 			if err != nil {
@@ -793,12 +822,14 @@ func TestAnalysis_MarshalJSON(t *testing.T) {
 			Id:   "AKIA5QYBVVD25KFXJHYJ",
 			Type: "aws_iam_access_key",
 		},
-		Changelog: []diff.Change{
+		Changelog: []Change{
 			{
-				Type: "update",
-				Path: []string{"Status"},
-				From: "Active",
-				To:   "Inactive",
+				Change: diff.Change{
+					Type: "update",
+					Path: []string{"Status"},
+					From: "Active",
+					To:   "Inactive",
+				},
 			},
 		},
 	})
@@ -872,12 +903,14 @@ func TestAnalysis_UnmarshalJSON(t *testing.T) {
 					Id:   "AKIA5QYBVVD25KFXJHYJ",
 					Type: "aws_iam_access_key",
 				},
-				Changelog: []diff.Change{
+				Changelog: []Change{
 					{
-						Type: "update",
-						Path: []string{"Status"},
-						From: "Active",
-						To:   "Inactive",
+						Change: diff.Change{
+							Type: "update",
+							Path: []string{"Status"},
+							From: "Active",
+							To:   "Inactive",
+						},
 					},
 				},
 			},

--- a/pkg/analyser/testdata/input.json
+++ b/pkg/analyser/testdata/input.json
@@ -49,7 +49,8 @@
             "Status"
           ],
           "from": "Active",
-          "to": "Inactive"
+          "to": "Inactive",
+          "computed": false
         }
       ]
     }

--- a/pkg/analyser/testdata/input.json
+++ b/pkg/analyser/testdata/input.json
@@ -54,5 +54,12 @@
       ]
     }
   ],
-  "coverage": 33
+  "coverage": 33,
+  "alerts": {
+    "aws_iam_access_key": [
+      {
+        "message": "This is an alert"
+      }
+    ]
+  }
 }

--- a/pkg/analyser/testdata/output.json
+++ b/pkg/analyser/testdata/output.json
@@ -49,7 +49,8 @@
 						"Status"
 					],
 					"from": "Active",
-					"to": "Inactive"
+					"to": "Inactive",
+					"computed": false
 				}
 			]
 		}

--- a/pkg/analyser/testdata/output.json
+++ b/pkg/analyser/testdata/output.json
@@ -54,5 +54,12 @@
 			]
 		}
 	],
-	"coverage": 33
+	"coverage": 33,
+	"alerts": {
+		"aws_iam_access_key": [
+			{
+				"message": "This is an alert"
+			}
+		]
+	}
 }

--- a/pkg/cmd/scan/output/console.go
+++ b/pkg/cmd/scan/output/console.go
@@ -88,15 +88,9 @@ func (c *Console) Write(analysis *analyser.Analysis) error {
 					}
 				}
 				fmt.Printf("    %s %s => %s", pref, prettify(change.From), prettify(change.To))
-				for key, val := range analysis.Alerts() {
-					if fmt.Sprintf("%s.%s", humanString, difference.Res.TerraformId()) == key {
-						for _, a := range val {
-							if fmt.Sprintf("%s is a computed field", path) == a.Message {
-								shouldWarnOnComputedFields = true
-								fmt.Printf(" %s", color.YellowString("(computed)"))
-							}
-						}
-					}
+				if change.Computed {
+					shouldWarnOnComputedFields = true
+					fmt.Printf(" %s", color.YellowString("(computed)"))
 				}
 				fmt.Printf("\n")
 			}

--- a/pkg/cmd/scan/output/console_test.go
+++ b/pkg/cmd/scan/output/console_test.go
@@ -49,6 +49,12 @@ func TestConsole_Write(t *testing.T) {
 			args:       args{analysis: fakeAnalysisWithStringerResources()},
 			wantErr:    false,
 		},
+		{
+			name:       "test console output with drift on computed fields",
+			goldenfile: "output_computed_fields.txt",
+			args:       args{analysis: fakeAnalysisWithComputedFields()},
+			wantErr:    false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/scan/output/json_test.go
+++ b/pkg/cmd/scan/output/json_test.go
@@ -30,6 +30,14 @@ func TestJSON_Write(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:       "test json output with drift on computed fields",
+			goldenfile: "output_computed_fields.json",
+			args: args{
+				analysis: fakeAnalysisWithComputedFields(),
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -228,7 +228,7 @@ func fakeAnalysisWithComputedFields() *analyser.Analysis {
 			Computed: true,
 		},
 	}})
-	a.AddAlerts(alerter.Alerts{
+	a.SetAlerts(alerter.Alerts{
 		"aws_diff_resource.diff-id-1": []alerter.Alert{
 			{
 				Message: "updated.field is a computed field",

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -43,24 +43,30 @@ func fakeAnalysis() *analyser.Analysis {
 	a.AddDifference(analyser.Difference{Res: &testresource.FakeResource{
 		Id:   "diff-id-1",
 		Type: "aws_diff_resource",
-	}, Changelog: []diff.Change{
+	}, Changelog: []analyser.Change{
 		{
-			Type: diff.UPDATE,
-			Path: []string{"updated", "field"},
-			From: "foobar",
-			To:   "barfoo",
+			Change: diff.Change{
+				Type: diff.UPDATE,
+				Path: []string{"updated", "field"},
+				From: "foobar",
+				To:   "barfoo",
+			},
 		},
 		{
-			Type: diff.CREATE,
-			Path: []string{"new", "field"},
-			From: nil,
-			To:   "newValue",
+			Change: diff.Change{
+				Type: diff.CREATE,
+				Path: []string{"new", "field"},
+				From: nil,
+				To:   "newValue",
+			},
 		},
 		{
-			Type: diff.DELETE,
-			Path: []string{"a"},
-			From: "oldValue",
-			To:   nil,
+			Change: diff.Change{
+				Type: diff.DELETE,
+				Path: []string{"a"},
+				From: "oldValue",
+				To:   nil,
+			},
 		},
 	}})
 	return &a
@@ -94,23 +100,27 @@ func fakeAnalysisWithJsonFields() *analyser.Analysis {
 	a.AddDifference(analyser.Difference{Res: &testresource.FakeResource{
 		Id:   "diff-id-1",
 		Type: "aws_diff_resource",
-	}, Changelog: []diff.Change{
+	}, Changelog: []analyser.Change{
 		{
-			Type: diff.UPDATE,
-			Path: []string{"Json"},
-			From: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Removed\":\"Added\",\"Changed\":[\"ec2:DescribeInstances\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}]}",
-			To:   "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Changed\":[\"ec2:*\"],\"NewField\":[\"foobar\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}]}",
+			Change: diff.Change{
+				Type: diff.UPDATE,
+				Path: []string{"Json"},
+				From: "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Removed\":\"Added\",\"Changed\":[\"ec2:DescribeInstances\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}]}",
+				To:   "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Changed\":[\"ec2:*\"],\"NewField\":[\"foobar\"],\"Effect\":\"Allow\",\"Resource\":\"*\"}]}",
+			},
 		},
 	}})
 	a.AddDifference(analyser.Difference{Res: &testresource.FakeResource{
 		Id:   "diff-id-2",
 		Type: "aws_diff_resource",
-	}, Changelog: []diff.Change{
+	}, Changelog: []analyser.Change{
 		{
-			Type: diff.UPDATE,
-			Path: []string{"Json"},
-			From: "{\"foo\":\"bar\"}",
-			To:   "{\"bar\":\"foo\"}",
+			Change: diff.Change{
+				Type: diff.UPDATE,
+				Path: []string{"Json"},
+				From: "{\"foo\":\"bar\"}",
+				To:   "{\"bar\":\"foo\"}",
+			},
 		},
 	}})
 	return &a
@@ -139,12 +149,14 @@ func fakeAnalysisWithStringerResources() *analyser.Analysis {
 	a.AddDifference(analyser.Difference{Res: &testresource.FakeResourceStringer{
 		Id:   "gdsfhgkbn",
 		Name: "resource with diff",
-	}, Changelog: []diff.Change{
+	}, Changelog: []analyser.Change{
 		{
-			Type: diff.UPDATE,
-			Path: []string{"Name"},
-			From: "",
-			To:   "resource with diff",
+			Change: diff.Change{
+				Type: diff.UPDATE,
+				Path: []string{"Name"},
+				From: "",
+				To:   "resource with diff",
+			},
 		},
 	}})
 	return &a
@@ -161,45 +173,59 @@ func fakeAnalysisWithComputedFields() *analyser.Analysis {
 	a.AddDifference(analyser.Difference{Res: testresource.FakeResource{
 		Id:   "diff-id-1",
 		Type: "aws_diff_resource",
-	}, Changelog: []diff.Change{
+	}, Changelog: []analyser.Change{
 		{
-			Type: diff.UPDATE,
-			Path: []string{"updated", "field"},
-			From: "foobar",
-			To:   "barfoo",
+			Change: diff.Change{
+				Type: diff.UPDATE,
+				Path: []string{"updated", "field"},
+				From: "foobar",
+				To:   "barfoo",
+			},
+			Computed: true,
 		},
 		{
-			Type: diff.CREATE,
-			Path: []string{"new", "field"},
-			From: nil,
-			To:   "newValue",
-		},
-		{
-			Type: diff.DELETE,
-			Path: []string{"a"},
-			From: "oldValue",
-			To:   nil,
-		},
-		{
-			Type: diff.UPDATE,
-			From: "foo",
-			To:   "oof",
-			Path: []string{
-				"struct",
-				"0",
-				"array",
-				"0",
+			Change: diff.Change{
+				Type: diff.CREATE,
+				Path: []string{"new", "field"},
+				From: nil,
+				To:   "newValue",
 			},
 		},
 		{
-			Type: diff.UPDATE,
-			From: "one",
-			To:   "two",
-			Path: []string{
-				"struct",
-				"0",
-				"string",
+			Change: diff.Change{
+				Type: diff.DELETE,
+				Path: []string{"a"},
+				From: "oldValue",
+				To:   nil,
 			},
+			Computed: true,
+		},
+		{
+			Change: diff.Change{
+				Type: diff.UPDATE,
+				From: "foo",
+				To:   "oof",
+				Path: []string{
+					"struct",
+					"0",
+					"array",
+					"0",
+				},
+			},
+			Computed: true,
+		},
+		{
+			Change: diff.Change{
+				Type: diff.UPDATE,
+				From: "one",
+				To:   "two",
+				Path: []string{
+					"struct",
+					"0",
+					"string",
+				},
+			},
+			Computed: true,
 		},
 	}})
 	a.AddAlerts(alerter.Alerts{
@@ -211,7 +237,7 @@ func fakeAnalysisWithComputedFields() *analyser.Analysis {
 				Message: "a is a computed field",
 			},
 			{
-				Message: "struct.0.array.0 is a computed field",
+				Message: "struct.0.array is a computed field",
 			},
 			{
 				Message: "struct.0.string is a computed field",

--- a/pkg/cmd/scan/output/testdata/output.json
+++ b/pkg/cmd/scan/output/testdata/output.json
@@ -72,5 +72,6 @@
 			]
 		}
 	],
-	"coverage": 33
+	"coverage": 33,
+	"alerts": null
 }

--- a/pkg/cmd/scan/output/testdata/output.json
+++ b/pkg/cmd/scan/output/testdata/output.json
@@ -50,7 +50,8 @@
 						"field"
 					],
 					"from": "foobar",
-					"to": "barfoo"
+					"to": "barfoo",
+					"computed": false
 				},
 				{
 					"type": "create",
@@ -59,7 +60,8 @@
 						"field"
 					],
 					"from": null,
-					"to": "newValue"
+					"to": "newValue",
+					"computed": false
 				},
 				{
 					"type": "delete",
@@ -67,7 +69,8 @@
 						"a"
 					],
 					"from": "oldValue",
-					"to": null
+					"to": null,
+					"computed": false
 				}
 			]
 		}

--- a/pkg/cmd/scan/output/testdata/output_computed_fields.json
+++ b/pkg/cmd/scan/output/testdata/output_computed_fields.json
@@ -28,7 +28,8 @@
 						"field"
 					],
 					"from": "foobar",
-					"to": "barfoo"
+					"to": "barfoo",
+					"computed": true
 				},
 				{
 					"type": "create",
@@ -37,7 +38,8 @@
 						"field"
 					],
 					"from": null,
-					"to": "newValue"
+					"to": "newValue",
+					"computed": false
 				},
 				{
 					"type": "delete",
@@ -45,7 +47,8 @@
 						"a"
 					],
 					"from": "oldValue",
-					"to": null
+					"to": null,
+					"computed": true
 				},
 				{
 					"type": "update",
@@ -56,7 +59,8 @@
 						"0"
 					],
 					"from": "foo",
-					"to": "oof"
+					"to": "oof",
+					"computed": true
 				},
 				{
 					"type": "update",
@@ -66,7 +70,8 @@
 						"string"
 					],
 					"from": "one",
-					"to": "two"
+					"to": "two",
+					"computed": true
 				}
 			]
 		}
@@ -81,7 +86,7 @@
 				"message": "a is a computed field"
 			},
 			{
-				"message": "struct.0.array.0 is a computed field"
+				"message": "struct.0.array is a computed field"
 			},
 			{
 				"message": "struct.0.string is a computed field"

--- a/pkg/cmd/scan/output/testdata/output_computed_fields.json
+++ b/pkg/cmd/scan/output/testdata/output_computed_fields.json
@@ -1,0 +1,91 @@
+{
+	"summary": {
+		"total_resources": 1,
+		"total_drifted": 1,
+		"total_unmanaged": 0,
+		"total_deleted": 0,
+		"total_managed": 1
+	},
+	"managed": [
+		{
+			"id": "diff-id-1",
+			"type": "aws_diff_resource"
+		}
+	],
+	"unmanaged": null,
+	"deleted": null,
+	"differences": [
+		{
+			"res": {
+				"id": "diff-id-1",
+				"type": "aws_diff_resource"
+			},
+			"changelog": [
+				{
+					"type": "update",
+					"path": [
+						"updated",
+						"field"
+					],
+					"from": "foobar",
+					"to": "barfoo"
+				},
+				{
+					"type": "create",
+					"path": [
+						"new",
+						"field"
+					],
+					"from": null,
+					"to": "newValue"
+				},
+				{
+					"type": "delete",
+					"path": [
+						"a"
+					],
+					"from": "oldValue",
+					"to": null
+				},
+				{
+					"type": "update",
+					"path": [
+						"struct",
+						"0",
+						"array",
+						"0"
+					],
+					"from": "foo",
+					"to": "oof"
+				},
+				{
+					"type": "update",
+					"path": [
+						"struct",
+						"0",
+						"string"
+					],
+					"from": "one",
+					"to": "two"
+				}
+			]
+		}
+	],
+	"coverage": 100,
+	"alerts": {
+		"aws_diff_resource.diff-id-1": [
+			{
+				"message": "updated.field is a computed field"
+			},
+			{
+				"message": "a is a computed field"
+			},
+			{
+				"message": "struct.0.array.0 is a computed field"
+			},
+			{
+				"message": "struct.0.string is a computed field"
+			}
+		]
+	}
+}

--- a/pkg/cmd/scan/output/testdata/output_computed_fields.txt
+++ b/pkg/cmd/scan/output/testdata/output_computed_fields.txt
@@ -1,0 +1,14 @@
+Found drifted resources:
+  - diff-id-1 (aws_diff_resource):
+    ~ updated.field: "foobar" => "barfoo" (computed)
+    + new.field: <nil> => "newValue"
+    - a: "oldValue" => <nil> (computed)
+    ~ struct.0.array.0: "foo" => "oof" (computed)
+    ~ struct.0.string: "one" => "two" (computed)
+Found 1 resource(s)
+ - 100% coverage
+ - 1 covered by IaC
+ - 0 not covered by IaC
+ - 0 deleted on cloud provider
+ - 1/1 drifted from IaC
+You have diffs on computed field, check the documentation for potential false positive drifts

--- a/pkg/driftctl.go
+++ b/pkg/driftctl.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"fmt"
 
+	"github.com/cloudskiff/driftctl/pkg/alerter"
 	"github.com/cloudskiff/driftctl/pkg/analyser"
 	"github.com/cloudskiff/driftctl/pkg/filter"
 	"github.com/cloudskiff/driftctl/pkg/middlewares"
@@ -18,8 +19,8 @@ type DriftCTL struct {
 	filter         *jmespath.JMESPath
 }
 
-func NewDriftCTL(remoteSupplier resource.Supplier, iacSupplier resource.Supplier, filter *jmespath.JMESPath) *DriftCTL {
-	return &DriftCTL{remoteSupplier, iacSupplier, analyser.NewAnalyzer(), filter}
+func NewDriftCTL(remoteSupplier resource.Supplier, iacSupplier resource.Supplier, filter *jmespath.JMESPath, alerter *alerter.Alerter) *DriftCTL {
+	return &DriftCTL{remoteSupplier, iacSupplier, analyser.NewAnalyzer(alerter), filter}
 }
 
 func (d DriftCTL) Run() *analyser.Analysis {
@@ -65,6 +66,7 @@ func (d DriftCTL) Run() *analyser.Analysis {
 	driftIgnore := filter.NewDriftIgnore()
 
 	analysis, err := d.analyzer.Analyze(remoteResources, resourcesFromState, driftIgnore)
+
 	if err != nil {
 		logrus.Errorf("Unable to analyse resources: %+v", err)
 		return nil

--- a/pkg/remote/aws/init.go
+++ b/pkg/remote/aws/init.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/cloudskiff/driftctl/pkg/alerter"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	"github.com/cloudskiff/driftctl/pkg/terraform"
 
@@ -17,7 +18,7 @@ const RemoteAWSTerraform = "aws+tf"
  * Initialize remote (configure credentials, launch tf providers and start gRPC clients)
  * Required to use Scanner
  */
-func Init() error {
+func Init(alerter *alerter.Alerter) error {
 	provider, err := NewTerraFormProvider()
 	if err != nil {
 		return err

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"fmt"
 
+	"github.com/cloudskiff/driftctl/pkg/alerter"
 	"github.com/cloudskiff/driftctl/pkg/remote/aws"
 )
 
@@ -19,10 +20,10 @@ func IsSupported(remote string) bool {
 	return false
 }
 
-func Activate(remote string) error {
+func Activate(remote string, alerter *alerter.Alerter) error {
 	switch remote {
 	case aws.RemoteAWSTerraform:
-		return aws.Init()
+		return aws.Init(alerter)
 	default:
 		return fmt.Errorf("unsupported remote '%s'", remote)
 	}

--- a/pkg/resource/aws/aws_instance_test.go
+++ b/pkg/resource/aws/aws_instance_test.go
@@ -3,6 +3,8 @@ package aws_test
 import (
 	"testing"
 
+	"github.com/cloudskiff/driftctl/pkg/analyser"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	awsresources "github.com/cloudskiff/driftctl/pkg/resource/aws"
@@ -68,11 +70,13 @@ func TestAcc_AwsInstance_WithBlockDevices(t *testing.T) {
 					result.AssertResourceHasDrift(
 						mutatedInstanceId,
 						awsresources.AwsInstanceResourceType,
-						diff.Change{
-							Type: diff.CREATE,
-							Path: []string{"Tags", "Env"},
-							From: nil,
-							To:   "Production",
+						analyser.Change{
+							Change: diff.Change{
+								Type: diff.CREATE,
+								Path: []string{"Tags", "Env"},
+								From: nil,
+								To:   "Production",
+							},
 						},
 					)
 				},

--- a/pkg/scanner.go
+++ b/pkg/scanner.go
@@ -6,18 +6,21 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/cloudskiff/driftctl/pkg/alerter"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 )
 
 type Scanner struct {
 	resourceSuppliers []resource.Supplier
 	runner            *ParallelRunner
+	alerter           *alerter.Alerter
 }
 
-func NewScanner(resourceSuppliers []resource.Supplier) *Scanner {
+func NewScanner(resourceSuppliers []resource.Supplier, alerter *alerter.Alerter) *Scanner {
 	return &Scanner{
 		resourceSuppliers: resourceSuppliers,
 		runner:            NewParallelRunner(context.TODO(), 10),
+		alerter:           alerter,
 	}
 }
 

--- a/test/acceptance/result.go
+++ b/test/acceptance/result.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cloudskiff/driftctl/pkg/analyser"
 
-	"github.com/r3labs/diff/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,7 +49,7 @@ func (r *ScanResult) AssertResourceDriftCount(id, ty string, count int) {
 	r.Failf("no differences found", "%s(%s)", id, ty)
 }
 
-func (r *ScanResult) AssertResourceHasDrift(id, ty string, change diff.Change) {
+func (r *ScanResult) AssertResourceHasDrift(id, ty string, change analyser.Change) {
 	found := false
 	for _, u := range r.Differences() {
 		if u.Res.TerraformType() == ty && u.Res.TerraformId() == id {

--- a/test/resource/resource.go
+++ b/test/resource/resource.go
@@ -5,7 +5,7 @@ import "fmt"
 type FakeResource struct {
 	Id        string
 	FooBar    string
-	BarFoo    string
+	BarFoo    string `computed:"true"`
 	Json      string `jsonstring:"true"`
 	Type      string
 	Tags      map[string]string
@@ -16,6 +16,10 @@ type FakeResource struct {
 	Struct struct {
 		Baz string `computed:"true"`
 		Bar string
+	}
+	StructSlice []struct {
+		String string   `computed:"true"`
+		Array  []string `computed:"true"`
 	}
 }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #7
| ❓ Documentation  | yes

## Description

Simple way to start a goroutine and to send alerts to it so as to display useful information to users.

An example could be if there are computed attributes of a resource that drifted but wasn't refreshed inside the tfstates, we should inform the user that he/she needs to refresh its states since it could be a false positive drift.

![image](https://user-images.githubusercontent.com/8110579/102387522-c5d8cf80-3fd0-11eb-95ef-7743f65362d0.png)
