### PR TITLE
Consistency across resources

### DIFF
--- a/pkg/analyser/analyzer_test.go
+++ b/pkg/analyser/analyzer_test.go
@@ -39,7 +39,7 @@ func TestAnalyze(t *testing.T) {
 		{
 			name: "TestIgnoreFromCoverageIacNotInCloud",
 			iac: []resource.Resource{
-				testresource.FakeResource{
+				&testresource.FakeResource{
 					Id: "foobar",
 				},
 			},
@@ -50,7 +50,7 @@ func TestAnalyze(t *testing.T) {
 					TotalDeleted:   1,
 				},
 				deleted: []resource.Resource{
-					testresource.FakeResource{
+					&testresource.FakeResource{
 						Id: "foobar",
 					},
 				},
@@ -60,18 +60,18 @@ func TestAnalyze(t *testing.T) {
 		{
 			name: "Test100PercentCoverage",
 			iac: []resource.Resource{
-				testresource.FakeResource{
+				&testresource.FakeResource{
 					Id: "foobar",
 				},
 			},
 			cloud: []resource.Resource{
-				testresource.FakeResource{
+				&testresource.FakeResource{
 					Id: "foobar",
 				},
 			},
 			expected: Analysis{
 				managed: []resource.Resource{
-					testresource.FakeResource{
+					&testresource.FakeResource{
 						Id: "foobar",
 					},
 				},
@@ -85,7 +85,7 @@ func TestAnalyze(t *testing.T) {
 			name: "TestUnmanagedResource",
 			iac:  []resource.Resource{},
 			cloud: []resource.Resource{
-				testresource.FakeResource{
+				&testresource.FakeResource{
 					Id: "foobar",
 				},
 			},
@@ -95,7 +95,7 @@ func TestAnalyze(t *testing.T) {
 					TotalUnmanaged: 1,
 				},
 				unmanaged: []resource.Resource{
-					testresource.FakeResource{
+					&testresource.FakeResource{
 						Id: "foobar",
 					},
 				},
@@ -105,14 +105,14 @@ func TestAnalyze(t *testing.T) {
 		{
 			name: "TestDiff",
 			iac: []resource.Resource{
-				testresource.FakeResource{
+				&testresource.FakeResource{
 					Id:     "foobar",
 					FooBar: "foobar",
 					BarFoo: "barfoo",
 				},
 			},
 			cloud: []resource.Resource{
-				testresource.FakeResource{
+				&testresource.FakeResource{
 					Id:     "foobar",
 					FooBar: "barfoo",
 					BarFoo: "foobar",
@@ -120,7 +120,7 @@ func TestAnalyze(t *testing.T) {
 			},
 			expected: Analysis{
 				managed: []resource.Resource{
-					testresource.FakeResource{
+					&testresource.FakeResource{
 						Id:     "foobar",
 						FooBar: "foobar",
 						BarFoo: "barfoo",
@@ -133,7 +133,7 @@ func TestAnalyze(t *testing.T) {
 				},
 				differences: []Difference{
 					{
-						Res: testresource.FakeResource{
+						Res: &testresource.FakeResource{
 							Id:     "foobar",
 							FooBar: "foobar",
 							BarFoo: "barfoo",
@@ -237,36 +237,36 @@ func TestAnalysis_MarshalJSON(t *testing.T) {
 	goldenFile := "./testdata/output.json"
 	analysis := Analysis{}
 	analysis.AddManaged(
-		testresource.FakeResource{
+		&testresource.FakeResource{
 			Id:   "AKIA5QYBVVD25KFXJHYJ",
 			Type: "aws_iam_access_key",
-		}, testresource.FakeResource{
+		}, &testresource.FakeResource{
 			Id:   "driftctl2",
 			Type: "aws_managed_resource",
 		},
 	)
 	analysis.AddUnmanaged(
-		testresource.FakeResource{
+		&testresource.FakeResource{
 			Id:   "driftctl",
 			Type: "aws_s3_bucket_policy",
-		}, testresource.FakeResource{
+		}, &testresource.FakeResource{
 			Id:   "driftctl",
 			Type: "aws_s3_bucket_notification",
 		},
 	)
 	analysis.AddDeleted(
-		testresource.FakeResource{
+		&testresource.FakeResource{
 			Id:     "test-driftctl2",
 			Type:   "aws_iam_user",
 			FooBar: "test",
 		},
-		testresource.FakeResource{
+		&testresource.FakeResource{
 			Id:   "AKIA5QYBVVD2Y6PBAAPY",
 			Type: "aws_iam_access_key",
 		},
 	)
 	analysis.AddDifference(Difference{
-		Res: testresource.FakeResource{
+		Res: &testresource.FakeResource{
 			Id:   "AKIA5QYBVVD25KFXJHYJ",
 			Type: "aws_iam_access_key",
 		},

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -11,35 +11,35 @@ import (
 func fakeAnalysis() *analyser.Analysis {
 	a := analyser.Analysis{}
 	a.AddUnmanaged(
-		testresource.FakeResource{
+		&testresource.FakeResource{
 			Id:   "unmanaged-id-1",
 			Type: "aws_unmanaged_resource",
 		},
-		testresource.FakeResource{
+		&testresource.FakeResource{
 			Id:   "unmanaged-id-2",
 			Type: "aws_unmanaged_resource",
 		},
 	)
 	a.AddDeleted(
-		testresource.FakeResource{
+		&testresource.FakeResource{
 			Id:   "deleted-id-1",
 			Type: "aws_deleted_resource",
-		}, testresource.FakeResource{
+		}, &testresource.FakeResource{
 			Id:   "deleted-id-2",
 			Type: "aws_deleted_resource",
 		},
 	)
 	a.AddManaged(
-		testresource.FakeResource{
+		&testresource.FakeResource{
 			Id:   "diff-id-1",
 			Type: "aws_diff_resource",
 		},
-		testresource.FakeResource{
+		&testresource.FakeResource{
 			Id:   "no-diff-id-1",
 			Type: "aws_no_diff_resource",
 		},
 	)
-	a.AddDifference(analyser.Difference{Res: testresource.FakeResource{
+	a.AddDifference(analyser.Difference{Res: &testresource.FakeResource{
 		Id:   "diff-id-1",
 		Type: "aws_diff_resource",
 	}, Changelog: []diff.Change{
@@ -68,7 +68,7 @@ func fakeAnalysis() *analyser.Analysis {
 func fakeAnalysisNoDrift() *analyser.Analysis {
 	a := analyser.Analysis{}
 	for i := 0; i < 5; i++ {
-		a.AddManaged(testresource.FakeResource{
+		a.AddManaged(&testresource.FakeResource{
 			Id:   "managed-id-" + fmt.Sprintf("%d", i),
 			Type: "aws_managed_resource",
 		})
@@ -79,18 +79,18 @@ func fakeAnalysisNoDrift() *analyser.Analysis {
 func fakeAnalysisWithJsonFields() *analyser.Analysis {
 	a := analyser.Analysis{}
 	a.AddManaged(
-		testresource.FakeResource{
+		&testresource.FakeResource{
 			Id:   "diff-id-1",
 			Type: "aws_diff_resource",
 		},
 	)
 	a.AddManaged(
-		testresource.FakeResource{
+		&testresource.FakeResource{
 			Id:   "diff-id-2",
 			Type: "aws_diff_resource",
 		},
 	)
-	a.AddDifference(analyser.Difference{Res: testresource.FakeResource{
+	a.AddDifference(analyser.Difference{Res: &testresource.FakeResource{
 		Id:   "diff-id-1",
 		Type: "aws_diff_resource",
 	}, Changelog: []diff.Change{

--- a/pkg/filter/driftignore_test.go
+++ b/pkg/filter/driftignore_test.go
@@ -20,13 +20,13 @@ func TestDriftIgnore_Run(t *testing.T) {
 		{
 			name: "drift_ignore_no_file",
 			resources: []resource.Resource{
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "type1",
 					Id:   "id1",
 				},
 			},
 			want: []resource.Resource{
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "type1",
 					Id:   "id1",
 				},
@@ -35,13 +35,13 @@ func TestDriftIgnore_Run(t *testing.T) {
 		{
 			name: "drift_ignore_empty",
 			resources: []resource.Resource{
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "type1",
 					Id:   "id1",
 				},
 			},
 			want: []resource.Resource{
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "type1",
 					Id:   "id1",
 				},
@@ -50,17 +50,17 @@ func TestDriftIgnore_Run(t *testing.T) {
 		{
 			name: "drift_ignore_invalid_lines",
 			resources: []resource.Resource{
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "type1",
 					Id:   "id1",
 				},
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "ignored_resource",
 					Id:   "id2",
 				},
 			},
 			want: []resource.Resource{
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "type1",
 					Id:   "id1",
 				},
@@ -69,33 +69,33 @@ func TestDriftIgnore_Run(t *testing.T) {
 		{
 			name: "drift_ignore_valid",
 			resources: []resource.Resource{
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "type1",
 					Id:   "id1",
 				},
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "wildcard_resource",
 					Id:   "id1",
 				},
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "wildcard_resource",
 					Id:   "id2",
 				},
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "wildcard_resource",
 					Id:   "id3",
 				},
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "ignored_resource",
 					Id:   "id2",
 				},
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "resource_type",
 					Id:   "id.with.dots",
 				},
 			},
 			want: []resource.Resource{
-				resource2.FakeResource{
+				&resource2.FakeResource{
 					Type: "type1",
 					Id:   "id1",
 				},


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #37 
| ❓ Documentation  | no

## Description
Change each resource that was added to `[]resource.Resource` as a pointer to `FakeResource` to be consistent with what we have in production.