### PR TITLE
add fmt check in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,17 @@ jobs:
       - image: golang:1.15
     steps:
       - checkout
+      - run:
+          name: Enforce Go Formatted Code
+          command: |
+            go fmt ./...
+            if [[ -z $(git status --porcelain) ]]; then
+              echo "Git directory is clean."
+            else
+              echo "Git directory is dirty. Run make fmt locally and commit any formatting fixes or generated code."
+              git status --porcelain
+              exit 1
+            fi
       - run: make install-tools
       - run: make test
       - run:

--- a/pkg/middlewares/aws_instance_eip.go
+++ b/pkg/middlewares/aws_instance_eip.go
@@ -47,7 +47,7 @@ func (a AwsInstanceEIP) hasEIP(instance *aws.AwsInstance, resources *[]resource.
 	return false
 }
 
-func (a AwsInstanceEIP) ignorePublicIpAndDns(instance *aws.AwsInstance, resourcesSet ...*[]resource.Resource)  {
+func (a AwsInstanceEIP) ignorePublicIpAndDns(instance *aws.AwsInstance, resourcesSet ...*[]resource.Resource) {
 	for _, resources := range resourcesSet {
 		for _, res := range *resources {
 			if res.TerraformType() == instance.TerraformType() &&

--- a/pkg/middlewares/aws_instance_eip_test.go
+++ b/pkg/middlewares/aws_instance_eip_test.go
@@ -15,29 +15,29 @@ func TestAwsInstanceEIP_Execute(t *testing.T) {
 		resourcesFromState *[]resource.Resource
 	}
 	tests := []struct {
-		name    string
-		args    args
+		name     string
+		args     args
 		expected args
 	}{
 		{
-			name:    "test that public ip and dns are nulled whith eip",
-			args:    args{
+			name: "test that public ip and dns are nulled whith eip",
+			args: args{
 				remoteResources: &[]resource.Resource{
 					&aws.AwsInstance{
-						Id: "instance1",
-						PublicIp: awssdk.String("1.2.3.4"),
+						Id:        "instance1",
+						PublicIp:  awssdk.String("1.2.3.4"),
 						PublicDns: awssdk.String("dns-of-eip.com"),
 					},
 					&aws.AwsInstance{
-						Id: "instance2",
-						PublicIp: awssdk.String("1.2.3.4"),
+						Id:        "instance2",
+						PublicIp:  awssdk.String("1.2.3.4"),
 						PublicDns: awssdk.String("dns-of-eip.com"),
 					},
 				},
 				resourcesFromState: &[]resource.Resource{
 					&aws.AwsInstance{
-						Id: "instance1",
-						PublicIp: awssdk.String("5.6.7.8"),
+						Id:        "instance1",
+						PublicIp:  awssdk.String("5.6.7.8"),
 						PublicDns: awssdk.String("example.com"),
 					},
 					&aws.AwsEip{
@@ -51,8 +51,8 @@ func TestAwsInstanceEIP_Execute(t *testing.T) {
 						Id: "instance1",
 					},
 					&aws.AwsInstance{
-						Id: "instance2",
-						PublicIp: awssdk.String("1.2.3.4"),
+						Id:        "instance2",
+						PublicIp:  awssdk.String("1.2.3.4"),
 						PublicDns: awssdk.String("dns-of-eip.com"),
 					},
 				},
@@ -67,24 +67,24 @@ func TestAwsInstanceEIP_Execute(t *testing.T) {
 			},
 		},
 		{
-			name:    "test that public ip and dns are nulled when eip association",
-			args:    args{
+			name: "test that public ip and dns are nulled when eip association",
+			args: args{
 				remoteResources: &[]resource.Resource{
 					&aws.AwsInstance{
-						Id: "instance1",
-						PublicIp: awssdk.String("1.2.3.4"),
+						Id:        "instance1",
+						PublicIp:  awssdk.String("1.2.3.4"),
 						PublicDns: awssdk.String("dns-of-eip.com"),
 					},
 					&aws.AwsInstance{
-						Id: "instance2",
-						PublicIp: awssdk.String("1.2.3.4"),
+						Id:        "instance2",
+						PublicIp:  awssdk.String("1.2.3.4"),
 						PublicDns: awssdk.String("dns-of-eip.com"),
 					},
 				},
 				resourcesFromState: &[]resource.Resource{
 					&aws.AwsInstance{
-						Id: "instance1",
-						PublicIp: awssdk.String("5.6.7.8"),
+						Id:        "instance1",
+						PublicIp:  awssdk.String("5.6.7.8"),
 						PublicDns: awssdk.String("example.com"),
 					},
 					&aws.AwsEipAssociation{
@@ -98,8 +98,8 @@ func TestAwsInstanceEIP_Execute(t *testing.T) {
 						Id: "instance1",
 					},
 					&aws.AwsInstance{
-						Id: "instance2",
-						PublicIp: awssdk.String("1.2.3.4"),
+						Id:        "instance2",
+						PublicIp:  awssdk.String("1.2.3.4"),
 						PublicDns: awssdk.String("dns-of-eip.com"),
 					},
 				},
@@ -120,7 +120,7 @@ func TestAwsInstanceEIP_Execute(t *testing.T) {
 			if err := a.Execute(tt.args.remoteResources, tt.args.resourcesFromState); err != nil {
 				t.Fatal(err)
 			}
-			if ! reflect.DeepEqual(tt.args, tt.expected) {
+			if !reflect.DeepEqual(tt.args, tt.expected) {
 				t.Fatalf("Expected results mismatch")
 			}
 		})


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues |
| ❓ Documentation  | no

## Description

We had badly formated (not passed to fmt) file in main. `make` will create diff that add noise to PR.
I added a check on ci during tests phase to prevent PR to be merge when fmt is not ok.