### PR TITLE
Several improvements on acceptance tests

### DIFF
--- a/pkg/resource/aws/aws_instance_test.go
+++ b/pkg/resource/aws/aws_instance_test.go
@@ -15,7 +15,7 @@ func TestAcc_AwsInstance_WithBlockDevices(t *testing.T) {
 	var mutatedInstanceId string
 	acceptance.Run(t, acceptance.AccTestCase{
 		Path: "./testdata/acc/aws_instance",
-		Args: []string{"scan"}, // TODO add filter to limit scan scope to aws_instances
+		Args: []string{"scan", "--filter", "Type=='aws_instance'"},
 		Checks: []acceptance.AccCheck{
 			{
 				Check: func(result *acceptance.ScanResult, stdout string, err error) {

--- a/pkg/resource/aws/testdata/acc/aws_instance/.terraform.lock.hcl
+++ b/pkg/resource/aws/testdata/acc/aws_instance/.terraform.lock.hcl
@@ -1,0 +1,37 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.19.0"
+  constraints = "~> 3.19.0"
+  hashes = [
+    "h1:+7Vi7p13+cnrxjXbfJiTimGSFR97xCaQwkkvWcreLns=",
+    "zh:185a5259153eb9ee4699d4be43b3d509386b473683392034319beee97d470c3b",
+    "zh:2d9a0a01f93e8d16539d835c02b8b6e1927b7685f4076e96cb07f7dd6944bc6c",
+    "zh:703f6da36b1b5f3497baa38fccaa7765fb8a2b6440344e4c97172516b49437dd",
+    "zh:770855565462abadbbddd98cb357d2f1a8f30f68a358cb37cbd5c072cb15b377",
+    "zh:8008db43149fe4345301f81e15e6d9ddb47aa5e7a31648f9b290af96ad86e92a",
+    "zh:8cdd27d375da6dcb7687f1fed126b7c04efce1671066802ee876dbbc9c66ec79",
+    "zh:be22ae185005690d1a017c1b909e0d80ab567e239b4f06ecacdba85080667c1c",
+    "zh:d2d02e72dbd80f607636cd6237a6c862897caabc635c7b50c0cb243d11246723",
+    "zh:d8f125b66a1eda2555c0f9bbdf12036a5f8d073499a22ca9e4812b68067fea31",
+    "zh:f5a98024c64d5d2973ff15b093725a074c0cb4afde07ef32c542e69f17ac90bc",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.0.0"
+  hashes = [
+    "h1:grDzxfnOdFXi90FRIIwP/ZrCzirJ/SfsGBe6cE0Shg4=",
+    "zh:0fcb00ff8b87dcac1b0ee10831e47e0203a6c46aafd76cb140ba2bab81f02c6b",
+    "zh:123c984c0e04bad910c421028d18aa2ca4af25a153264aef747521f4e7c36a17",
+    "zh:287443bc6fd7fa9a4341dec235589293cbcc6e467a042ae225fd5d161e4e68dc",
+    "zh:2c1be5596dd3cca4859466885eaedf0345c8e7628503872610629e275d71b0d2",
+    "zh:684a2ef6f415287944a3d966c4c8cee82c20e393e096e2f7cdcb4b2528407f6b",
+    "zh:7625ccbc6ff17c2d5360ff2af7f9261c3f213765642dcd84e84ae02a3768fd51",
+    "zh:9a60811ab9e6a5bfa6352fbb943bb530acb6198282a49373283a8fa3aa2b43fc",
+    "zh:c73e0eaeea6c65b1cf5098b101d51a2789b054201ce7986a6d206a9e2dacaefd",
+    "zh:e8f9ed41ac83dbe407de9f0206ef1148204a0d51ba240318af801ffb3ee5f578",
+    "zh:fbdd0684e62563d3ac33425b0ac9439d543a3942465f4b26582bcfabcb149515",
+  ]
+}

--- a/pkg/resource/aws/testdata/acc/aws_route53_record/.terraform.lock.hcl
+++ b/pkg/resource/aws/testdata/acc/aws_route53_record/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.19.0"
+  constraints = "~> 3.19.0"
+  hashes = [
+    "h1:+7Vi7p13+cnrxjXbfJiTimGSFR97xCaQwkkvWcreLns=",
+    "zh:185a5259153eb9ee4699d4be43b3d509386b473683392034319beee97d470c3b",
+    "zh:2d9a0a01f93e8d16539d835c02b8b6e1927b7685f4076e96cb07f7dd6944bc6c",
+    "zh:703f6da36b1b5f3497baa38fccaa7765fb8a2b6440344e4c97172516b49437dd",
+    "zh:770855565462abadbbddd98cb357d2f1a8f30f68a358cb37cbd5c072cb15b377",
+    "zh:8008db43149fe4345301f81e15e6d9ddb47aa5e7a31648f9b290af96ad86e92a",
+    "zh:8cdd27d375da6dcb7687f1fed126b7c04efce1671066802ee876dbbc9c66ec79",
+    "zh:be22ae185005690d1a017c1b909e0d80ab567e239b4f06ecacdba85080667c1c",
+    "zh:d2d02e72dbd80f607636cd6237a6c862897caabc635c7b50c0cb243d11246723",
+    "zh:d8f125b66a1eda2555c0f9bbdf12036a5f8d073499a22ca9e4812b68067fea31",
+    "zh:f5a98024c64d5d2973ff15b093725a074c0cb4afde07ef32c542e69f17ac90bc",
+  ]
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no

## Description

- Add filter on aws_instance test
- Add terraform locks
- Do not run terraform init if already done previously
- Do not use chdir in tests (it could cause race if we want to switch to parallel tests, uses --from arg instead)
- Handle terraform destroy errors