### PR TITLE
Fix crash for buckets in us-east-1

### DIFF
--- a/pkg/remote/aws/s3_bucket_supplier.go
+++ b/pkg/remote/aws/s3_bucket_supplier.go
@@ -68,6 +68,13 @@ func readBucketRegion(client *s3iface.S3API, name string) (string, error) {
 		}
 		return "", err
 	}
+
+	// Buckets in Region us-east-1 have a LocationConstraint of null.
+	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html#API_GetBucketLocation_ResponseSyntax
+	if bucketLocationResponse.LocationConstraint == nil {
+		return "us-east-1", err
+	}
+
 	return *bucketLocationResponse.LocationConstraint, nil
 }
 

--- a/pkg/resource/aws/aws_s3_bucket_test.go
+++ b/pkg/resource/aws/aws_s3_bucket_test.go
@@ -1,0 +1,26 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/cloudskiff/driftctl/test/acceptance"
+)
+
+func TestAcc_AwsS3Bucket_BucketInUsEast1(t *testing.T) {
+	acceptance.Run(t, acceptance.AccTestCase{
+		Path: "./testdata/acc/aws_s3_bucket",
+		Args: []string{"scan", "--filter", "Type=='aws_s3_bucket'"},
+		Checks: []acceptance.AccCheck{
+			{
+				Check: func(result *acceptance.ScanResult, stdout string, err error) {
+					if err != nil {
+						t.Fatal(err)
+					}
+					result.Equal(1, result.Summary().TotalManaged)
+					result.Equal("aws_s3_bucket", result.Analysis.Managed()[0].TerraformType())
+					result.Equal("foobar.driftctl-test.com", result.Analysis.Managed()[0].TerraformId())
+				},
+			},
+		},
+	})
+}

--- a/pkg/resource/aws/testdata/acc/aws_s3_bucket/.terraform.lock.hcl
+++ b/pkg/resource/aws/testdata/acc/aws_s3_bucket/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.19.0"
+  constraints = "~> 3.19.0"
+  hashes = [
+    "h1:+7Vi7p13+cnrxjXbfJiTimGSFR97xCaQwkkvWcreLns=",
+    "zh:185a5259153eb9ee4699d4be43b3d509386b473683392034319beee97d470c3b",
+    "zh:2d9a0a01f93e8d16539d835c02b8b6e1927b7685f4076e96cb07f7dd6944bc6c",
+    "zh:703f6da36b1b5f3497baa38fccaa7765fb8a2b6440344e4c97172516b49437dd",
+    "zh:770855565462abadbbddd98cb357d2f1a8f30f68a358cb37cbd5c072cb15b377",
+    "zh:8008db43149fe4345301f81e15e6d9ddb47aa5e7a31648f9b290af96ad86e92a",
+    "zh:8cdd27d375da6dcb7687f1fed126b7c04efce1671066802ee876dbbc9c66ec79",
+    "zh:be22ae185005690d1a017c1b909e0d80ab567e239b4f06ecacdba85080667c1c",
+    "zh:d2d02e72dbd80f607636cd6237a6c862897caabc635c7b50c0cb243d11246723",
+    "zh:d8f125b66a1eda2555c0f9bbdf12036a5f8d073499a22ca9e4812b68067fea31",
+    "zh:f5a98024c64d5d2973ff15b093725a074c0cb4afde07ef32c542e69f17ac90bc",
+  ]
+}

--- a/pkg/resource/aws/testdata/acc/aws_s3_bucket/providers.tf
+++ b/pkg/resource/aws/testdata/acc/aws_s3_bucket/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region  = "us-east-1"
+}
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 3.19.0"
+    }
+  }
+}

--- a/pkg/resource/aws/testdata/acc/aws_s3_bucket/s3.tf
+++ b/pkg/resource/aws/testdata/acc/aws_s3_bucket/s3.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "foobar" {
+  bucket = "foobar.driftctl-test.com"
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #73 
| ❓ Documentation  | no

## Description

According to AWS SDK documentation, buckets in `us-east-1` region return `nil` in `GetBucketLocation`