### PR TITLE
Start by reading IaC before enumerate cloud resources

### DIFF
--- a/pkg/driftctl.go
+++ b/pkg/driftctl.go
@@ -89,14 +89,14 @@ func (d DriftCTL) Stop() {
 }
 
 func (d DriftCTL) scan() (remoteResources []resource.Resource, resourcesFromState []resource.Resource, err error) {
-	logrus.Info("Start scanning cloud provider")
-	remoteResources, err = d.remoteSupplier.Resources()
+	logrus.Info("Start reading terraform state")
+	resourcesFromState, err = d.iacSupplier.Resources()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	logrus.Info("Start reading terraform state")
-	resourcesFromState, err = d.iacSupplier.Resources()
+	logrus.Info("Start scanning cloud provider")
+	remoteResources, err = d.remoteSupplier.Resources()
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #86 
| ❓ Documentation  | no

## Description

Ensure IaC source are valid prevent us to fail after a potentially long
running cloud resources scan.