### PR TITLE
rename "remotes" to "IaaS Providers"

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -18,6 +18,6 @@ Details of reported data can be found [here](./cmd/flags/error-reporting.md)
   - Scan
     - [Output format](cmd/scan/output.md)
     - [Filtering resources](cmd/scan/filter.md)
-    - [Supported remotes](cmd/scan/supported_resources/README.md)
+    - [Supported resources](cmd/scan/supported_resources/README.md)
     - [Iac sources](cmd/scan/iac_source.md)
 

--- a/doc/cmd/scan/supported_resources/README.md
+++ b/doc/cmd/scan/supported_resources/README.md
@@ -1,3 +1,3 @@
-# Supported remotes
+# Supported IaaS Providers
 
 - [AWS](aws.md)


### PR DESCRIPTION
_"Supported remotes"_ makes me think it's about the terraform state remote storage or something, and not about all the supported resources in this IaaS.

| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | yes 

## Description

Rename for clarity