### PR TITLE
Remove singleton to fix issues when chain multiples cmd run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ coverage: test
 
 .PHONY: acc
 acc:
-	DRIFTCTL_ACC=true $(GOTEST) --format testname --junitfile unit-tests-acc.xml -- -coverprofile=cover-acc.out -coverpkg=./pkg/... -run=TestAcc_ ./pkg/resource/...
+	DRIFTCTL_ACC=true $(GOTEST) --format testname --junitfile unit-tests-acc.xml -- -coverprofile=cover-acc.out -test.timeout 1h -coverpkg=./pkg/... -run=TestAcc_ ./pkg/resource/...
 
 .PHONY: mocks
 mocks: deps

--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -126,8 +126,10 @@ func scanRun(opts *ScanOptions) error {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 
 	alerter := alerter.NewAlerter()
+	providerLibrary := terraform.NewProviderLibrary()
+	supplierLibrary := resource.NewSupplierLibrary()
 
-	err := remote.Activate(opts.To, alerter)
+	err := remote.Activate(opts.To, alerter, providerLibrary, supplierLibrary)
 	if err != nil {
 		return err
 	}
@@ -135,13 +137,13 @@ func scanRun(opts *ScanOptions) error {
 	// Teardown
 	defer func() {
 		logrus.Trace("Exiting scan cmd")
-		terraform.Cleanup()
+		providerLibrary.Cleanup()
 		logrus.Trace("Exited")
 	}()
 
-	scanner := pkg.NewScanner(resource.Suppliers(), alerter)
+	scanner := pkg.NewScanner(supplierLibrary.Suppliers(), alerter)
 
-	iacSupplier, err := supplier.GetIACSupplier(opts.From)
+	iacSupplier, err := supplier.GetIACSupplier(opts.From, providerLibrary)
 	if err != nil {
 		return err
 	}

--- a/pkg/iac/supplier/supplier.go
+++ b/pkg/iac/supplier/supplier.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/cloudskiff/driftctl/pkg/iac/terraform/state/backend"
+	"github.com/cloudskiff/driftctl/pkg/terraform"
 	"github.com/sirupsen/logrus"
 
 	"github.com/cloudskiff/driftctl/pkg/iac/config"
@@ -26,7 +27,7 @@ func IsSupplierSupported(supplierKey string) bool {
 	return false
 }
 
-func GetIACSupplier(configs []config.SupplierConfig) (resource.Supplier, error) {
+func GetIACSupplier(configs []config.SupplierConfig, library *terraform.ProviderLibrary) (resource.Supplier, error) {
 	chainSupplier := resource.NewChainSupplier()
 	for _, config := range configs {
 		if !IsSupplierSupported(config.Key) {
@@ -37,7 +38,7 @@ func GetIACSupplier(configs []config.SupplierConfig) (resource.Supplier, error) 
 		var err error
 		switch config.Key {
 		case state.TerraformStateReaderSupplier:
-			supplier, err = state.NewReader(config)
+			supplier, err = state.NewReader(config, library)
 		default:
 			return nil, fmt.Errorf("Unsupported supplier '%s'", config.Key)
 		}

--- a/pkg/iac/supplier/supplier_test.go
+++ b/pkg/iac/supplier/supplier_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cloudskiff/driftctl/pkg/iac/config"
+	"github.com/cloudskiff/driftctl/pkg/terraform"
 )
 
 func TestGetIACSupplier(t *testing.T) {
@@ -76,7 +77,7 @@ func TestGetIACSupplier(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := GetIACSupplier(tt.args.config)
+			_, err := GetIACSupplier(tt.args.config, terraform.NewProviderLibrary())
 			if tt.wantErr != nil && err.Error() != tt.wantErr.Error() {
 				t.Errorf("GetIACSupplier() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/iac/terraform/state/terraform_state_reader.go
+++ b/pkg/iac/terraform/state/terraform_state_reader.go
@@ -21,6 +21,7 @@ import (
 const TerraformStateReaderSupplier = "tfstate"
 
 type TerraformStateReader struct {
+	library       *terraform.ProviderLibrary
 	config        config.SupplierConfig
 	backend       backend.Backend
 	deserializers []deserializer.CTYDeserializer
@@ -35,8 +36,8 @@ func (r *TerraformStateReader) initReader() error {
 	return nil
 }
 
-func NewReader(config config.SupplierConfig) (*TerraformStateReader, error) {
-	reader := TerraformStateReader{config: config, deserializers: iac.Deserializers()}
+func NewReader(config config.SupplierConfig, library *terraform.ProviderLibrary) (*TerraformStateReader, error) {
+	reader := TerraformStateReader{library: library, config: config, deserializers: iac.Deserializers()}
 	err := reader.initReader()
 	if err != nil {
 		return nil, err
@@ -70,7 +71,7 @@ func (r *TerraformStateReader) retrieve() (map[string][]cty.Value, error) {
 				continue
 			}
 			providerType := stateRes.ProviderConfig.Provider.Type
-			provider := terraform.Provider(providerType)
+			provider := r.library.Provider(providerType)
 			if provider == nil {
 				logrus.WithFields(logrus.Fields{
 					"providerKey": providerType,

--- a/pkg/iac/terraform/state/terraform_state_reader_test.go
+++ b/pkg/iac/terraform/state/terraform_state_reader_test.go
@@ -90,12 +90,13 @@ func TestTerraformStateReader_Resources(t *testing.T) {
 			}
 
 			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, realProvider, shouldUpdate)
-
-			terraform.AddProvider(terraform.AWS, provider)
+			library := terraform.NewProviderLibrary()
+			library.AddProvider(terraform.AWS, provider)
 
 			b, _ := backend.NewFileReader(path.Join(goldenfile.GoldenFilePath, tt.dirName, "terraform.tfstate"))
 			r := &TerraformStateReader{
 				backend:       b,
+				library:       library,
 				deserializers: iac.Deserializers(),
 			}
 

--- a/pkg/remote/aws/db_instance_supplier.go
+++ b/pkg/remote/aws/db_instance_supplier.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 	"github.com/cloudskiff/driftctl/pkg/resource"
@@ -22,12 +21,12 @@ type DBInstanceSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewDBInstanceSupplier(runner *parallel.ParallelRunner, client rdsiface.RDSAPI) *DBInstanceSupplier {
+func NewDBInstanceSupplier(provider *TerraformProvider) *DBInstanceSupplier {
 	return &DBInstanceSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewDBInstanceDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		rds.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/db_instance_supplier_test.go
+++ b/pkg/remote/aws/db_instance_supplier_test.go
@@ -113,18 +113,21 @@ func TestDBInstanceSupplier_Resources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewDBInstanceSupplier(provider.Runner(), rds.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewDBInstanceSupplier(provider))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewDBInstanceDeserializer()
 
 			client := mocks.NewMockAWSRDSClient(tt.instancesPages)

--- a/pkg/remote/aws/db_subnet_group_supplier.go
+++ b/pkg/remote/aws/db_subnet_group_supplier.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 	"github.com/cloudskiff/driftctl/pkg/resource/aws"
@@ -25,12 +24,12 @@ type DBSubnetGroupSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewDBSubnetGroupSupplier(runner *parallel.ParallelRunner, client rdsiface.RDSAPI) *DBSubnetGroupSupplier {
+func NewDBSubnetGroupSupplier(provider *TerraformProvider) *DBSubnetGroupSupplier {
 	return &DBSubnetGroupSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewDBSubnetGroupDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		rds.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/db_subnet_group_supplier_test.go
+++ b/pkg/remote/aws/db_subnet_group_supplier_test.go
@@ -83,18 +83,22 @@ func TestDBSubnetGroupSupplier_Resources(t *testing.T) {
 	for _, tt := range tests {
 
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewDBInstanceSupplier(provider.Runner(), rds.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewDBInstanceSupplier(provider))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewDBSubnetGroupDeserializer()
 			client := mocks.NewMockAWSRDSSubnetGroupClient(tt.subnets)
 			if tt.subnetsListError != nil {

--- a/pkg/remote/aws/ec2_ami_supplier.go
+++ b/pkg/remote/aws/ec2_ami_supplier.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -24,12 +23,12 @@ type EC2AmiSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2AmiSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *EC2AmiSupplier {
+func NewEC2AmiSupplier(provider *TerraformProvider) *EC2AmiSupplier {
 	return &EC2AmiSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewEC2AmiDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/ec2_ebs_snapshot_supplier.go
+++ b/pkg/remote/aws/ec2_ebs_snapshot_supplier.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -24,12 +23,12 @@ type EC2EbsSnapshotSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2EbsSnapshotSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *EC2EbsSnapshotSupplier {
+func NewEC2EbsSnapshotSupplier(provider *TerraformProvider) *EC2EbsSnapshotSupplier {
 	return &EC2EbsSnapshotSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewEC2EbsSnapshotDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/ec2_ebs_snapshot_supplier_test.go
+++ b/pkg/remote/aws/ec2_ebs_snapshot_supplier_test.go
@@ -81,18 +81,22 @@ func TestEC2EbsSnapshotSupplier_Resources(t *testing.T) {
 	for _, tt := range tests {
 
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewEC2EbsSnapshotSupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewEC2EbsSnapshotSupplier(provider))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewEC2EbsSnapshotDeserializer()
 			client := mocks.NewMockAWSEC2EbsSnapshotClient(tt.snapshotsPages)
 			if tt.snapshotsPagesError != nil {

--- a/pkg/remote/aws/ec2_ebs_volume_supplier.go
+++ b/pkg/remote/aws/ec2_ebs_volume_supplier.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -24,12 +23,12 @@ type EC2EbsVolumeSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2EbsVolumeSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *EC2EbsVolumeSupplier {
+func NewEC2EbsVolumeSupplier(provider *TerraformProvider) *EC2EbsVolumeSupplier {
 	return &EC2EbsVolumeSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewEC2EbsVolumeDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/ec2_ebs_volume_supplier_test.go
+++ b/pkg/remote/aws/ec2_ebs_volume_supplier_test.go
@@ -81,18 +81,22 @@ func TestEC2EbsVolumeSupplier_Resources(t *testing.T) {
 	for _, tt := range tests {
 
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewEC2EbsVolumeSupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewEC2EbsVolumeSupplier(provider))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewEC2EbsVolumeDeserializer()
 			client := mocks.NewMockAWSEC2EbsVolumeClient(tt.volumesPages)
 			if tt.volumesPagesError != nil {

--- a/pkg/remote/aws/ec2_eip_association_supplier.go
+++ b/pkg/remote/aws/ec2_eip_association_supplier.go
@@ -1,9 +1,9 @@
 package aws
 
 import (
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	resourceaws "github.com/cloudskiff/driftctl/pkg/resource/aws"
@@ -23,13 +23,12 @@ type EC2EipAssociationSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2EipAssociationSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *EC2EipAssociationSupplier {
+func NewEC2EipAssociationSupplier(provider *TerraformProvider) *EC2EipAssociationSupplier {
 	return &EC2EipAssociationSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewEC2EipAssociationDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
-	}
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner())}
 }
 
 func (s EC2EipAssociationSupplier) Resources() ([]resource.Resource, error) {

--- a/pkg/remote/aws/ec2_eip_association_supplier_test.go
+++ b/pkg/remote/aws/ec2_eip_association_supplier_test.go
@@ -59,18 +59,22 @@ func TestEC2EipAssociationSupplier_Resources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewEC2EipAssociationSupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewEC2EipAssociationSupplier(provider))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewEC2EipAssociationDeserializer()
 			client := mocks.NewMockAWSEC2EipClient(tt.addresses)
 			if tt.listError != nil {

--- a/pkg/remote/aws/ec2_eip_supplier.go
+++ b/pkg/remote/aws/ec2_eip_supplier.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -24,12 +23,12 @@ type EC2EipSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2EipSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *EC2EipSupplier {
+func NewEC2EipSupplier(provider *TerraformProvider) *EC2EipSupplier {
 	return &EC2EipSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewEC2EipDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/ec2_eip_supplier_test.go
+++ b/pkg/remote/aws/ec2_eip_supplier_test.go
@@ -62,18 +62,22 @@ func TestEC2EipSupplier_Resources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewEC2EipSupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewEC2EipSupplier(provider))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewEC2EipDeserializer()
 			client := mocks.NewMockAWSEC2EipClient(tt.addresses)
 			if tt.listError != nil {

--- a/pkg/remote/aws/ec2_instance_supplier.go
+++ b/pkg/remote/aws/ec2_instance_supplier.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -24,12 +23,12 @@ type EC2InstanceSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2InstanceSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *EC2InstanceSupplier {
+func NewEC2InstanceSupplier(provider *TerraformProvider) *EC2InstanceSupplier {
 	return &EC2InstanceSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewEC2InstanceDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/ec2_instance_supplier_test.go
+++ b/pkg/remote/aws/ec2_instance_supplier_test.go
@@ -113,18 +113,22 @@ func TestEC2InstanceSupplier_Resources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewEC2InstanceSupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewEC2InstanceSupplier(provider))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewEC2InstanceDeserializer()
 			client := mocks.NewMockAWSEC2InstanceClient(tt.instancesPages)
 			if tt.listError != nil {

--- a/pkg/remote/aws/ec2_key_pair_supplier.go
+++ b/pkg/remote/aws/ec2_key_pair_supplier.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -24,12 +23,12 @@ type EC2KeyPairSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2KeyPairSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *EC2KeyPairSupplier {
+func NewEC2KeyPairSupplier(provider *TerraformProvider) *EC2KeyPairSupplier {
 	return &EC2KeyPairSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewEC2KeyPairDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/iam_access_key_supplier.go
+++ b/pkg/remote/aws/iam_access_key_supplier.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -23,12 +22,12 @@ type IamAccessKeySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamAccessKeySupplier(runner *parallel.ParallelRunner, client iamiface.IAMAPI) *IamAccessKeySupplier {
+func NewIamAccessKeySupplier(provider *TerraformProvider) *IamAccessKeySupplier {
 	return &IamAccessKeySupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewIamAccessKeyDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		iam.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/iam_access_key_supplier_test.go
+++ b/pkg/remote/aws/iam_access_key_supplier_test.go
@@ -149,21 +149,25 @@ func TestIamAccessKeySupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewIamAccessKeySupplier(provider.Runner(), iam.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewIamAccessKeySupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeIam := mocks.FakeIAM{}
 			c.mocks(&fakeIam)
 
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewIamAccessKeyDeserializer()
 			s := &IamAccessKeySupplier{
 				provider,

--- a/pkg/remote/aws/iam_policy_supplier.go
+++ b/pkg/remote/aws/iam_policy_supplier.go
@@ -4,7 +4,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -24,12 +23,12 @@ type IamPolicySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamPolicySupplier(runner *parallel.ParallelRunner, client iamiface.IAMAPI) *IamPolicySupplier {
+func NewIamPolicySupplier(provider *TerraformProvider) *IamPolicySupplier {
 	return &IamPolicySupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewIamPolicyDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		iam.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/iam_policy_supplier_test.go
+++ b/pkg/remote/aws/iam_policy_supplier_test.go
@@ -89,21 +89,25 @@ func TestIamPolicySupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewIamPolicySupplier(provider.Runner(), iam.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewIamPolicySupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeIam := mocks.FakeIAM{}
 			c.mocks(&fakeIam)
 
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewIamPolicyDeserializer()
 			s := &IamPolicySupplier{
 				provider,

--- a/pkg/remote/aws/iam_role_policy_attachment_supplier.go
+++ b/pkg/remote/aws/iam_role_policy_attachment_supplier.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -23,12 +22,12 @@ type IamRolePolicyAttachmentSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamRolePolicyAttachmentSupplier(runner *parallel.ParallelRunner, client iamiface.IAMAPI) *IamRolePolicyAttachmentSupplier {
+func NewIamRolePolicyAttachmentSupplier(provider *TerraformProvider) *IamRolePolicyAttachmentSupplier {
 	return &IamRolePolicyAttachmentSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewIamRolePolicyAttachmentDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		iam.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/iam_role_policy_attachment_supplier_test.go
+++ b/pkg/remote/aws/iam_role_policy_attachment_supplier_test.go
@@ -181,21 +181,25 @@ func TestIamRolePolicyAttachmentSupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewIamRolePolicyAttachmentSupplier(provider.Runner(), iam.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewIamRolePolicyAttachmentSupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeIam := mocks.FakeIAM{}
 			c.mocks(&fakeIam)
 
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewIamRolePolicyAttachmentDeserializer()
 			s := &IamRolePolicyAttachmentSupplier{
 				provider,

--- a/pkg/remote/aws/iam_role_policy_supplier.go
+++ b/pkg/remote/aws/iam_role_policy_supplier.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
-
-	"github.com/cloudskiff/driftctl/pkg/parallel"
-
 	awsdeserializer "github.com/cloudskiff/driftctl/pkg/resource/aws/deserializer"
 
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -27,12 +24,12 @@ type IamRolePolicySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamRolePolicySupplier(runner *parallel.ParallelRunner, client iamiface.IAMAPI) *IamRolePolicySupplier {
+func NewIamRolePolicySupplier(provider *TerraformProvider) *IamRolePolicySupplier {
 	return &IamRolePolicySupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewIamRolePolicyDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		iam.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/iam_role_policy_supplier_test.go
+++ b/pkg/remote/aws/iam_role_policy_supplier_test.go
@@ -146,21 +146,25 @@ func TestIamRolePolicySupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewIamRolePolicySupplier(provider.Runner(), iam.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewIamRolePolicySupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeIam := mocks.FakeIAM{}
 			c.mocks(&fakeIam)
 
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewIamRolePolicyDeserializer()
 			s := &IamRolePolicySupplier{
 				provider,

--- a/pkg/remote/aws/iam_role_supplier.go
+++ b/pkg/remote/aws/iam_role_supplier.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -32,12 +31,12 @@ type IamRoleSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamRoleSupplier(runner *parallel.ParallelRunner, client iamiface.IAMAPI) *IamRoleSupplier {
+func NewIamRoleSupplier(provider *TerraformProvider) *IamRoleSupplier {
 	return &IamRoleSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewIamRoleDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		iam.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/iam_role_supplier_test.go
+++ b/pkg/remote/aws/iam_role_supplier_test.go
@@ -104,21 +104,25 @@ func TestIamRoleSupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewIamRoleSupplier(provider.Runner(), iam.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewIamRoleSupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeIam := mocks.FakeIAM{}
 			c.mocks(&fakeIam)
 
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewIamRoleDeserializer()
 			s := &IamRoleSupplier{
 				provider,

--- a/pkg/remote/aws/iam_user_policy_attachment_supplier.go
+++ b/pkg/remote/aws/iam_user_policy_attachment_supplier.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -23,12 +22,12 @@ type IamUserPolicyAttachmentSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamUserPolicyAttachmentSupplier(runner *parallel.ParallelRunner, client iamiface.IAMAPI) *IamUserPolicyAttachmentSupplier {
+func NewIamUserPolicyAttachmentSupplier(provider *TerraformProvider) *IamUserPolicyAttachmentSupplier {
 	return &IamUserPolicyAttachmentSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewIamUserPolicyAttachmentDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		iam.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/iam_user_policy_attachment_supplier_test.go
+++ b/pkg/remote/aws/iam_user_policy_attachment_supplier_test.go
@@ -199,21 +199,25 @@ func TestIamUserPolicyAttachmentSupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewIamUserPolicyAttachmentSupplier(provider.Runner(), iam.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewIamUserPolicyAttachmentSupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeIam := mocks.FakeIAM{}
 			c.mocks(&fakeIam)
 
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewIamUserPolicyAttachmentDeserializer()
 			s := &IamUserPolicyAttachmentSupplier{
 				provider,

--- a/pkg/remote/aws/iam_user_policy_supplier.go
+++ b/pkg/remote/aws/iam_user_policy_supplier.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
-
-	"github.com/cloudskiff/driftctl/pkg/parallel"
-
 	awsdeserializer "github.com/cloudskiff/driftctl/pkg/resource/aws/deserializer"
 
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -27,12 +24,12 @@ type IamUserPolicySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamUserPolicySupplier(runner *parallel.ParallelRunner, client iamiface.IAMAPI) *IamUserPolicySupplier {
+func NewIamUserPolicySupplier(provider *TerraformProvider) *IamUserPolicySupplier {
 	return &IamUserPolicySupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewIamUserPolicyDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		iam.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/iam_user_policy_supplier_test.go
+++ b/pkg/remote/aws/iam_user_policy_supplier_test.go
@@ -170,21 +170,25 @@ func TestIamUserPolicySupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewIamUserPolicySupplier(provider.Runner(), iam.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewIamUserPolicySupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeIam := mocks.FakeIAM{}
 			c.mocks(&fakeIam)
 
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewIamUserPolicyDeserializer()
 			s := &IamUserPolicySupplier{
 				provider,

--- a/pkg/remote/aws/iam_user_supplier.go
+++ b/pkg/remote/aws/iam_user_supplier.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -23,12 +22,12 @@ type IamUserSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamUserSupplier(runner *parallel.ParallelRunner, client iamiface.IAMAPI) *IamUserSupplier {
+func NewIamUserSupplier(provider *TerraformProvider) *IamUserSupplier {
 	return &IamUserSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewIamUserDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		iam.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/iam_user_supplier_test.go
+++ b/pkg/remote/aws/iam_user_supplier_test.go
@@ -83,21 +83,25 @@ func TestIamUserSupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewIamUserSupplier(provider.Runner(), iam.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewIamUserSupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeIam := mocks.FakeIAM{}
 			c.mocks(&fakeIam)
 
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewIamUserDeserializer()
 			s := &IamUserSupplier{
 				provider,

--- a/pkg/remote/aws/init.go
+++ b/pkg/remote/aws/init.go
@@ -1,15 +1,9 @@
 package aws
 
 import (
-	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/cloudskiff/driftctl/pkg/alerter"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	"github.com/cloudskiff/driftctl/pkg/terraform"
-
-	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/lambda"
-	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/aws/aws-sdk-go/service/route53"
 )
 
 const RemoteAWSTerraform = "aws+tf"
@@ -18,7 +12,7 @@ const RemoteAWSTerraform = "aws+tf"
  * Initialize remote (configure credentials, launch tf providers and start gRPC clients)
  * Required to use Scanner
  */
-func Init(alerter *alerter.Alerter) error {
+func Init(alerter *alerter.Alerter, providerLibrary *terraform.ProviderLibrary, supplierLibrary *resource.SupplierLibrary) error {
 	provider, err := NewTerraFormProvider()
 	if err != nil {
 		return err
@@ -26,42 +20,43 @@ func Init(alerter *alerter.Alerter) error {
 
 	factory := AwsClientFactory{config: provider.session}
 
-	terraform.AddProvider(terraform.AWS, provider)
-	resource.AddSupplier(NewS3BucketSupplier(provider.Runner().SubRunner(), factory))
-	resource.AddSupplier(NewS3BucketAnalyticSupplier(provider.Runner().SubRunner(), factory))
-	resource.AddSupplier(NewS3BucketInventorySupplier(provider.Runner().SubRunner(), factory))
-	resource.AddSupplier(NewS3BucketMetricSupplier(provider.Runner().SubRunner(), factory))
-	resource.AddSupplier(NewS3BucketNotificationSupplier(provider.Runner().SubRunner(), factory))
-	resource.AddSupplier(NewS3BucketPolicySupplier(provider.Runner().SubRunner(), factory))
-	resource.AddSupplier(NewEC2EipSupplier(provider.Runner().SubRunner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewEC2EipAssociationSupplier(provider.Runner().SubRunner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewEC2EbsVolumeSupplier(provider.Runner().SubRunner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewEC2EbsSnapshotSupplier(provider.Runner().SubRunner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewRoute53ZoneSupplier(provider.Runner().SubRunner(), route53.New(provider.session)))
-	resource.AddSupplier(NewRoute53RecordSupplier(provider.Runner().SubRunner(), route53.New(provider.session)))
-	resource.AddSupplier(NewEC2InstanceSupplier(provider.Runner().SubRunner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewEC2AmiSupplier(provider.Runner().SubRunner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewEC2KeyPairSupplier(provider.Runner().SubRunner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewLambdaFunctionSupplier(provider.Runner().SubRunner(), lambda.New(provider.session)))
-	resource.AddSupplier(NewDBSubnetGroupSupplier(provider.Runner().SubRunner(), rds.New(provider.session)))
-	resource.AddSupplier(NewDBInstanceSupplier(provider.Runner().SubRunner(), rds.New(provider.session)))
-	resource.AddSupplier(NewVPCSecurityGroupSupplier(provider.Runner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewIamUserSupplier(provider.Runner().SubRunner(), iam.New(provider.session)))
-	resource.AddSupplier(NewIamUserPolicySupplier(provider.Runner().SubRunner(), iam.New(provider.session)))
-	resource.AddSupplier(NewIamUserPolicyAttachmentSupplier(provider.Runner().SubRunner(), iam.New(provider.session)))
-	resource.AddSupplier(NewIamAccessKeySupplier(provider.Runner().SubRunner(), iam.New(provider.session)))
-	resource.AddSupplier(NewIamRoleSupplier(provider.Runner().SubRunner(), iam.New(provider.session)))
-	resource.AddSupplier(NewIamPolicySupplier(provider.Runner().SubRunner(), iam.New(provider.session)))
-	resource.AddSupplier(NewIamRolePolicySupplier(provider.Runner().SubRunner(), iam.New(provider.session)))
-	resource.AddSupplier(NewIamRolePolicyAttachmentSupplier(provider.Runner().SubRunner(), iam.New(provider.session)))
-	resource.AddSupplier(NewVPCSecurityGroupRuleSupplier(provider.Runner().SubRunner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewVPCSupplier(provider.Runner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewSubnetSupplier(provider.Runner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewRouteTableSupplier(provider.Runner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewRouteSupplier(provider.Runner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewRouteTableAssociationSupplier(provider.Runner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewNatGatewaySupplier(provider.Runner(), ec2.New(provider.session)))
-	resource.AddSupplier(NewInternetGatewaySupplier(provider.Runner().SubRunner(), ec2.New(provider.session)))
+	providerLibrary.AddProvider(terraform.AWS, provider)
+
+	supplierLibrary.AddSupplier(NewS3BucketSupplier(provider, factory))
+	supplierLibrary.AddSupplier(NewS3BucketAnalyticSupplier(provider, factory))
+	supplierLibrary.AddSupplier(NewS3BucketInventorySupplier(provider, factory))
+	supplierLibrary.AddSupplier(NewS3BucketMetricSupplier(provider, factory))
+	supplierLibrary.AddSupplier(NewS3BucketNotificationSupplier(provider, factory))
+	supplierLibrary.AddSupplier(NewS3BucketPolicySupplier(provider, factory))
+	supplierLibrary.AddSupplier(NewEC2EipSupplier(provider))
+	supplierLibrary.AddSupplier(NewEC2EipAssociationSupplier(provider))
+	supplierLibrary.AddSupplier(NewEC2EbsVolumeSupplier(provider))
+	supplierLibrary.AddSupplier(NewEC2EbsSnapshotSupplier(provider))
+	supplierLibrary.AddSupplier(NewRoute53ZoneSupplier(provider))
+	supplierLibrary.AddSupplier(NewRoute53RecordSupplier(provider))
+	supplierLibrary.AddSupplier(NewEC2InstanceSupplier(provider))
+	supplierLibrary.AddSupplier(NewEC2AmiSupplier(provider))
+	supplierLibrary.AddSupplier(NewEC2KeyPairSupplier(provider))
+	supplierLibrary.AddSupplier(NewLambdaFunctionSupplier(provider))
+	supplierLibrary.AddSupplier(NewDBSubnetGroupSupplier(provider))
+	supplierLibrary.AddSupplier(NewDBInstanceSupplier(provider))
+	supplierLibrary.AddSupplier(NewVPCSecurityGroupSupplier(provider))
+	supplierLibrary.AddSupplier(NewIamUserSupplier(provider))
+	supplierLibrary.AddSupplier(NewIamUserPolicySupplier(provider))
+	supplierLibrary.AddSupplier(NewIamUserPolicyAttachmentSupplier(provider))
+	supplierLibrary.AddSupplier(NewIamAccessKeySupplier(provider))
+	supplierLibrary.AddSupplier(NewIamRoleSupplier(provider))
+	supplierLibrary.AddSupplier(NewIamPolicySupplier(provider))
+	supplierLibrary.AddSupplier(NewIamRolePolicySupplier(provider))
+	supplierLibrary.AddSupplier(NewIamRolePolicyAttachmentSupplier(provider))
+	supplierLibrary.AddSupplier(NewVPCSecurityGroupRuleSupplier(provider))
+	supplierLibrary.AddSupplier(NewVPCSupplier(provider))
+	supplierLibrary.AddSupplier(NewSubnetSupplier(provider))
+	supplierLibrary.AddSupplier(NewRouteTableSupplier(provider))
+	supplierLibrary.AddSupplier(NewRouteSupplier(provider))
+	supplierLibrary.AddSupplier(NewRouteTableAssociationSupplier(provider))
+	supplierLibrary.AddSupplier(NewNatGatewaySupplier(provider))
+	supplierLibrary.AddSupplier(NewInternetGatewaySupplier(provider))
 
 	return nil
 }

--- a/pkg/remote/aws/internet_gateway_supplier.go
+++ b/pkg/remote/aws/internet_gateway_supplier.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 	"github.com/cloudskiff/driftctl/pkg/resource"
@@ -21,12 +20,12 @@ type InternetGatewaySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewInternetGatewaySupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *InternetGatewaySupplier {
+func NewInternetGatewaySupplier(provider *TerraformProvider) *InternetGatewaySupplier {
 	return &InternetGatewaySupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewInternetGatewayDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/internet_gateway_supplier_test.go
+++ b/pkg/remote/aws/internet_gateway_supplier_test.go
@@ -83,20 +83,24 @@ func TestInternetGatewaySupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewInternetGatewaySupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewInternetGatewaySupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeEC2 := mocks.FakeEC2{}
 			c.mocks(&fakeEC2)
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			internetGatewayDeserializer := awsdeserializer.NewInternetGatewayDeserializer()
 			s := &InternetGatewaySupplier{
 				provider,

--- a/pkg/remote/aws/lambda_function_supplier.go
+++ b/pkg/remote/aws/lambda_function_supplier.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -23,12 +22,12 @@ type LambdaFunctionSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewLambdaFunctionSupplier(runner *parallel.ParallelRunner, client lambdaiface.LambdaAPI) *LambdaFunctionSupplier {
+func NewLambdaFunctionSupplier(provider *TerraformProvider) *LambdaFunctionSupplier {
 	return &LambdaFunctionSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewLambdaFunctionDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		lambda.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/lambda_function_supplier_test.go
+++ b/pkg/remote/aws/lambda_function_supplier_test.go
@@ -98,18 +98,22 @@ func TestLambdaFunctionSupplier_Resources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewLambdaFunctionSupplier(provider.Runner(), lambda.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewLambdaFunctionSupplier(provider))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewLambdaFunctionDeserializer()
 			client := mocks.NewMockAWSLambdaClient(tt.functionsPages)
 			if tt.listError != nil {

--- a/pkg/remote/aws/nat_gateway_supplier.go
+++ b/pkg/remote/aws/nat_gateway_supplier.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 	"github.com/cloudskiff/driftctl/pkg/resource"
@@ -21,12 +20,12 @@ type NatGatewaySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewNatGatewaySupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *NatGatewaySupplier {
+func NewNatGatewaySupplier(provider *TerraformProvider) *NatGatewaySupplier {
 	return &NatGatewaySupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewNatGatewayDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner.SubRunner()),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/nat_gateway_supplier_test.go
+++ b/pkg/remote/aws/nat_gateway_supplier_test.go
@@ -78,20 +78,24 @@ func TestNatGatewaySupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewNatGatewaySupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewNatGatewaySupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeEC2 := mocks.FakeEC2{}
 			c.mocks(&fakeEC2)
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			natGatewaydeserializer := awsdeserializer.NewNatGatewayDeserializer()
 			s := &NatGatewaySupplier{
 				provider,

--- a/pkg/remote/aws/route53_record_supplier.go
+++ b/pkg/remote/aws/route53_record_supplier.go
@@ -4,9 +4,6 @@ import (
 	"strings"
 
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
-
-	"github.com/cloudskiff/driftctl/pkg/parallel"
-
 	awsdeserializer "github.com/cloudskiff/driftctl/pkg/resource/aws/deserializer"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -28,13 +25,12 @@ type Route53RecordSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewRoute53RecordSupplier(runner *parallel.ParallelRunner, client route53iface.Route53API) *Route53RecordSupplier {
+func NewRoute53RecordSupplier(provider *TerraformProvider) *Route53RecordSupplier {
 	return &Route53RecordSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewRoute53RecordDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
-	}
+		route53.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner())}
 }
 
 func (s Route53RecordSupplier) Resources() ([]resource.Resource, error) {

--- a/pkg/remote/aws/route53_record_supplier_test.go
+++ b/pkg/remote/aws/route53_record_supplier_test.go
@@ -248,17 +248,21 @@ func TestRoute53RecordSupplier_Resources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.test, func(t *testing.T) {
 			shouldUpdate := tt.dirName == *goldenfile.Update
+
+			providerLibrary := terraform.NewProviderLibrary()
+			supplierLibrary := resource.NewSupplierLibrary()
+
 			if shouldUpdate {
 				provider, err := NewTerraFormProvider()
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				terraform.AddProvider(terraform.AWS, provider)
-				resource.AddSupplier(NewRoute53RecordSupplier(provider.Runner(), route53.New(provider.session)))
+				providerLibrary.AddProvider(terraform.AWS, provider)
+				supplierLibrary.AddSupplier(NewRoute53RecordSupplier(provider))
 			}
 
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewRoute53RecordDeserializer()
 			client := mocks.NewMockAWSRoute53RecordClient(tt.zonesPages, tt.recordsPages, tt.listError)
 			s := &Route53RecordSupplier{

--- a/pkg/remote/aws/route53_zone_supplier.go
+++ b/pkg/remote/aws/route53_zone_supplier.go
@@ -5,8 +5,6 @@ import (
 
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
-	"github.com/cloudskiff/driftctl/pkg/parallel"
-
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	resourceaws "github.com/cloudskiff/driftctl/pkg/resource/aws"
@@ -26,12 +24,12 @@ type Route53ZoneSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewRoute53ZoneSupplier(runner *parallel.ParallelRunner, client route53iface.Route53API) *Route53ZoneSupplier {
+func NewRoute53ZoneSupplier(provider *TerraformProvider) *Route53ZoneSupplier {
 	return &Route53ZoneSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewRoute53ZoneDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		route53.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/route53_zone_supplier_test.go
+++ b/pkg/remote/aws/route53_zone_supplier_test.go
@@ -105,19 +105,23 @@ func TestRoute53ZoneSupplier_Resources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewRoute53ZoneSupplier(provider.Runner(), route53.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewRoute53ZoneSupplier(provider))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
 			deserializer := awsdeserializer.NewRoute53ZoneDeserializer()
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			client := mocks.NewMockAWSRoute53ZoneClient(tt.zonesPages, tt.listError)
 			s := &Route53ZoneSupplier{
 				provider,

--- a/pkg/remote/aws/route_supplier.go
+++ b/pkg/remote/aws/route_supplier.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	"github.com/cloudskiff/driftctl/pkg/resource/aws"
@@ -21,12 +20,12 @@ type RouteSupplier struct {
 	routeRunner       *terraform.ParallelResourceReader
 }
 
-func NewRouteSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *RouteSupplier {
+func NewRouteSupplier(provider *TerraformProvider) *RouteSupplier {
 	return &RouteSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewRouteDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner.SubRunner()),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/route_supplier_test.go
+++ b/pkg/remote/aws/route_supplier_test.go
@@ -148,20 +148,24 @@ func TestRouteSupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewRouteSupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewRouteSupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeEC2 := mocks.FakeEC2{}
 			c.mocks(&fakeEC2)
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			routeDeserializer := awsdeserializer.NewRouteDeserializer()
 			s := &RouteSupplier{
 				provider,

--- a/pkg/remote/aws/route_table_association_supplier.go
+++ b/pkg/remote/aws/route_table_association_supplier.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	"github.com/cloudskiff/driftctl/pkg/resource/aws"
@@ -21,12 +20,12 @@ type RouteTableAssociationSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewRouteTableAssociationSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *RouteTableAssociationSupplier {
+func NewRouteTableAssociationSupplier(provider *TerraformProvider) *RouteTableAssociationSupplier {
 	return &RouteTableAssociationSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewRouteTableAssociationDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/route_table_association_supplier_test.go
+++ b/pkg/remote/aws/route_table_association_supplier_test.go
@@ -151,20 +151,24 @@ func TestRouteTableAssociationSupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewRouteTableAssociationSupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewRouteTableAssociationSupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeEC2 := mocks.FakeEC2{}
 			c.mocks(&fakeEC2)
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			routeTableAssociationDeserializer := awsdeserializer.NewRouteTableAssociationDeserializer()
 			s := &RouteTableAssociationSupplier{
 				provider,

--- a/pkg/remote/aws/route_table_supplier.go
+++ b/pkg/remote/aws/route_table_supplier.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	"github.com/cloudskiff/driftctl/pkg/resource/aws"
@@ -27,14 +26,14 @@ type RouteTableSupplier struct {
 	routeTableRunner              *terraform.ParallelResourceReader
 }
 
-func NewRouteTableSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *RouteTableSupplier {
+func NewRouteTableSupplier(provider *TerraformProvider) *RouteTableSupplier {
 	return &RouteTableSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewDefaultRouteTableDeserializer(),
 		awsdeserializer.NewRouteTableDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner.SubRunner()),
-		terraform.NewParallelResourceReader(runner.SubRunner()),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/route_table_supplier_test.go
+++ b/pkg/remote/aws/route_table_supplier_test.go
@@ -100,20 +100,24 @@ func TestRouteTableSupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewRouteTableSupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewRouteTableSupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeEC2 := mocks.FakeEC2{}
 			c.mocks(&fakeEC2)
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			routeTableDeserializer := awsdeserializer.NewRouteTableDeserializer()
 			defaultRouteTableDeserializer := awsdeserializer.NewDefaultRouteTableDeserializer()
 			s := &RouteTableSupplier{

--- a/pkg/remote/aws/s3_bucket_analytic_supplier.go
+++ b/pkg/remote/aws/s3_bucket_analytic_supplier.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
-
-	"github.com/cloudskiff/driftctl/pkg/parallel"
-
 	awsdeserializer "github.com/cloudskiff/driftctl/pkg/resource/aws/deserializer"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
@@ -27,12 +24,12 @@ type S3BucketAnalyticSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewS3BucketAnalyticSupplier(runner *parallel.ParallelRunner, factory AwsClientFactoryInterface) *S3BucketAnalyticSupplier {
+func NewS3BucketAnalyticSupplier(provider *TerraformProvider, factory AwsClientFactoryInterface) *S3BucketAnalyticSupplier {
 	return &S3BucketAnalyticSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewS3BucketAnalyticDeserializer(),
 		factory,
-		terraform.NewParallelResourceReader(runner),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/s3_bucket_analytic_supplier_test.go
+++ b/pkg/remote/aws/s3_bucket_analytic_supplier_test.go
@@ -105,6 +105,10 @@ func TestS3BucketAnalyticSupplier_Resources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
@@ -112,15 +116,15 @@ func TestS3BucketAnalyticSupplier_Resources(t *testing.T) {
 			}
 
 			factory := AwsClientFactory{config: provider.session}
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewS3BucketAnalyticSupplier(provider.Runner().SubRunner(), factory))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewS3BucketAnalyticSupplier(provider, factory))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
 
 			mock := mocks.NewMockAWSS3Client(tt.bucketsIDs, tt.analyticsIDs, nil, nil, tt.bucketLocation, tt.listError)
 
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			factory := mocks.NewMockAwsClientFactory(mock)
 
 			deserializer := awsdeserializer.NewS3BucketAnalyticDeserializer()

--- a/pkg/remote/aws/s3_bucket_inventory_supplier.go
+++ b/pkg/remote/aws/s3_bucket_inventory_supplier.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
-
-	"github.com/cloudskiff/driftctl/pkg/parallel"
-
 	awsdeserializer "github.com/cloudskiff/driftctl/pkg/resource/aws/deserializer"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
@@ -27,12 +24,12 @@ type S3BucketInventorySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewS3BucketInventorySupplier(runner *parallel.ParallelRunner, factory AwsClientFactoryInterface) *S3BucketInventorySupplier {
+func NewS3BucketInventorySupplier(provider *TerraformProvider, factory AwsClientFactoryInterface) *S3BucketInventorySupplier {
 	return &S3BucketInventorySupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewS3BucketInventoryDeserializer(),
 		factory,
-		terraform.NewParallelResourceReader(runner),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/s3_bucket_inventory_supplier_test.go
+++ b/pkg/remote/aws/s3_bucket_inventory_supplier_test.go
@@ -104,6 +104,10 @@ func TestS3BucketInventorySupplier_Resources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
@@ -112,8 +116,8 @@ func TestS3BucketInventorySupplier_Resources(t *testing.T) {
 
 			factory := AwsClientFactory{config: provider.session}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewS3BucketInventorySupplier(provider.Runner().SubRunner(), factory))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewS3BucketInventorySupplier(provider, factory))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
@@ -121,7 +125,7 @@ func TestS3BucketInventorySupplier_Resources(t *testing.T) {
 			mock := mocks.NewMockAWSS3Client(tt.bucketsIDs, nil, tt.inventoriesIDs, nil, tt.bucketLocation, tt.listError)
 			factory := mocks.NewMockAwsClientFactory(mock)
 
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewS3BucketInventoryDeserializer()
 			s := &S3BucketInventorySupplier{
 				provider,

--- a/pkg/remote/aws/s3_bucket_metric_supplier_test.go
+++ b/pkg/remote/aws/s3_bucket_metric_supplier_test.go
@@ -104,6 +104,10 @@ func TestS3BucketMetricSupplier_Resources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
@@ -112,8 +116,8 @@ func TestS3BucketMetricSupplier_Resources(t *testing.T) {
 
 			factory := AwsClientFactory{config: provider.session}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewS3BucketMetricSupplier(provider.Runner().SubRunner(), factory))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewS3BucketMetricSupplier(provider, factory))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
@@ -121,7 +125,7 @@ func TestS3BucketMetricSupplier_Resources(t *testing.T) {
 			mock := mocks.NewMockAWSS3Client(tt.bucketsIDs, nil, nil, tt.metricsIDs, tt.bucketLocation, tt.listError)
 			factory := mocks.NewMockAwsClientFactory(mock)
 
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewS3BucketMetricDeserializer()
 			s := &S3BucketMetricSupplier{
 				provider,

--- a/pkg/remote/aws/s3_bucket_metrics_supplier.go
+++ b/pkg/remote/aws/s3_bucket_metrics_supplier.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
-
-	"github.com/cloudskiff/driftctl/pkg/parallel"
-
 	awsdeserializer "github.com/cloudskiff/driftctl/pkg/resource/aws/deserializer"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
@@ -27,12 +24,12 @@ type S3BucketMetricSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewS3BucketMetricSupplier(runner *parallel.ParallelRunner, factory AwsClientFactoryInterface) *S3BucketMetricSupplier {
+func NewS3BucketMetricSupplier(provider *TerraformProvider, factory AwsClientFactoryInterface) *S3BucketMetricSupplier {
 	return &S3BucketMetricSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewS3BucketMetricDeserializer(),
 		factory,
-		terraform.NewParallelResourceReader(runner),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/s3_bucket_notification_supplier.go
+++ b/pkg/remote/aws/s3_bucket_notification_supplier.go
@@ -4,7 +4,6 @@ import (
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	"github.com/cloudskiff/driftctl/pkg/resource/aws"
@@ -20,12 +19,11 @@ type S3BucketNotificationSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewS3BucketNotificationSupplier(runner *parallel.ParallelRunner, factory AwsClientFactoryInterface) *S3BucketNotificationSupplier {
+func NewS3BucketNotificationSupplier(provider *TerraformProvider, factory AwsClientFactoryInterface) *S3BucketNotificationSupplier {
 	return &S3BucketNotificationSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewS3BucketNotificationDeserializer(),
-		factory,
-		terraform.NewParallelResourceReader(runner),
+		factory, terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/s3_bucket_notification_supplier_test.go
+++ b/pkg/remote/aws/s3_bucket_notification_supplier_test.go
@@ -69,6 +69,10 @@ func TestS3BucketNotificationSupplier_Resources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
@@ -77,8 +81,8 @@ func TestS3BucketNotificationSupplier_Resources(t *testing.T) {
 
 			factory := AwsClientFactory{config: provider.session}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewS3BucketNotificationSupplier(provider.Runner().SubRunner(), factory))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewS3BucketNotificationSupplier(provider, factory))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
@@ -86,7 +90,7 @@ func TestS3BucketNotificationSupplier_Resources(t *testing.T) {
 			mock := mocks.NewMockAWSS3Client(tt.bucketsIDs, nil, nil, nil, tt.bucketLocation, tt.listError)
 			factory := mocks.NewMockAwsClientFactory(mock)
 
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewS3BucketNotificationDeserializer()
 			s := &S3BucketNotificationSupplier{
 				provider,

--- a/pkg/remote/aws/s3_bucket_policy_supplier.go
+++ b/pkg/remote/aws/s3_bucket_policy_supplier.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -20,12 +19,12 @@ type S3BucketPolicySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewS3BucketPolicySupplier(runner *parallel.ParallelRunner, factory AwsClientFactoryInterface) *S3BucketPolicySupplier {
+func NewS3BucketPolicySupplier(provider *TerraformProvider, factory AwsClientFactoryInterface) *S3BucketPolicySupplier {
 	return &S3BucketPolicySupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewS3BucketPolicyDeserializer(),
 		factory,
-		terraform.NewParallelResourceReader(runner),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/s3_bucket_policy_supplier_test.go
+++ b/pkg/remote/aws/s3_bucket_policy_supplier_test.go
@@ -70,6 +70,10 @@ func TestS3BucketPolicySupplier_Resources(t *testing.T) {
 	for _, tt := range tests {
 
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
@@ -78,8 +82,8 @@ func TestS3BucketPolicySupplier_Resources(t *testing.T) {
 
 			factory := AwsClientFactory{config: provider.session}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewS3BucketPolicySupplier(provider.Runner().SubRunner(), factory))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewS3BucketPolicySupplier(provider, factory))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
@@ -87,7 +91,7 @@ func TestS3BucketPolicySupplier_Resources(t *testing.T) {
 			mock := mocks.NewMockAWSS3Client(tt.bucketsIDs, nil, nil, nil, tt.bucketLocation, tt.listError)
 			factory := mocks.NewMockAwsClientFactory(mock)
 
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewS3BucketPolicyDeserializer()
 			s := &S3BucketPolicySupplier{
 				provider,

--- a/pkg/remote/aws/s3_bucket_supplier.go
+++ b/pkg/remote/aws/s3_bucket_supplier.go
@@ -4,7 +4,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -24,12 +23,12 @@ type S3BucketSupplier struct {
 	runner           *terraform.ParallelResourceReader
 }
 
-func NewS3BucketSupplier(runner *parallel.ParallelRunner, factory AwsClientFactoryInterface) *S3BucketSupplier {
+func NewS3BucketSupplier(provider *TerraformProvider, factory AwsClientFactoryInterface) *S3BucketSupplier {
 	return &S3BucketSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewS3BucketDeserializer(),
 		factory,
-		terraform.NewParallelResourceReader(runner),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/s3_bucket_supplier_test.go
+++ b/pkg/remote/aws/s3_bucket_supplier_test.go
@@ -59,6 +59,10 @@ func TestS3BucketSupplier_Resources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
@@ -67,15 +71,15 @@ func TestS3BucketSupplier_Resources(t *testing.T) {
 
 			factory := AwsClientFactory{config: provider.session}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewS3BucketSupplier(provider.Runner().SubRunner(), factory))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewS3BucketSupplier(provider, factory))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
 
 			factory := mocks.NewMockAwsClientFactory(mocks.NewMockAWSS3Client(tt.bucketsIDs, nil, nil, nil, tt.bucketLocation, tt.listError))
 
-			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewS3BucketDeserializer()
 			s := &S3BucketSupplier{
 				provider,

--- a/pkg/remote/aws/subnet_supplier.go
+++ b/pkg/remote/aws/subnet_supplier.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -26,14 +25,14 @@ type SubnetSupplier struct {
 	subnetRunner              *terraform.ParallelResourceReader
 }
 
-func NewSubnetSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *SubnetSupplier {
+func NewSubnetSupplier(provider *TerraformProvider) *SubnetSupplier {
 	return &SubnetSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewDefaultSubnetDeserializer(),
 		awsdeserializer.NewSubnetDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner.SubRunner()),
-		terraform.NewParallelResourceReader(runner.SubRunner()),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/subnet_supplier_test.go
+++ b/pkg/remote/aws/subnet_supplier_test.go
@@ -110,20 +110,24 @@ func TestSubnetSupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewSubnetSupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewSubnetSupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeEC2 := mocks.FakeEC2{}
 			c.mocks(&fakeEC2)
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			SubnetDeserializer := awsdeserializer.NewSubnetDeserializer()
 			defaultSubnetDeserializer := awsdeserializer.NewDefaultSubnetDeserializer()
 			s := &SubnetSupplier{

--- a/pkg/remote/aws/terraform_provider.go
+++ b/pkg/remote/aws/terraform_provider.go
@@ -83,7 +83,7 @@ func NewTerraFormProvider() (*TerraformProvider, error) {
 		select {
 		case <-c:
 			logrus.Warn("Detected interrupt during terraform provider configuration, cleanup ...")
-			tf.Cleanup()
+			p.Cleanup()
 			os.Exit(1)
 		case <-stopCh:
 			return
@@ -234,4 +234,13 @@ func (p *TerraformProvider) ReadResource(args tf.ReadResourceArgs) (*cty.Value, 
 		return nil, err
 	}
 	return &newState, nil
+}
+
+func (p *TerraformProvider) Cleanup() {
+	for region, client := range p.grpcProviders {
+		logrus.WithFields(logrus.Fields{
+			"region": region,
+		}).Debug("Closing gRPC client")
+		client.Close()
+	}
 }

--- a/pkg/remote/aws/vpc_security_group_rule_supplier.go
+++ b/pkg/remote/aws/vpc_security_group_rule_supplier.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -30,12 +29,12 @@ type VPCSecurityGroupRuleSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewVPCSecurityGroupRuleSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *VPCSecurityGroupRuleSupplier {
+func NewVPCSecurityGroupRuleSupplier(provider *TerraformProvider) *VPCSecurityGroupRuleSupplier {
 	return &VPCSecurityGroupRuleSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewVPCSecurityGroupRuleDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/vpc_security_group_rule_supplier_test.go
+++ b/pkg/remote/aws/vpc_security_group_rule_supplier_test.go
@@ -235,20 +235,24 @@ func TestVPCSecurityGroupRuleSupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewVPCSecurityGroupRuleSupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewVPCSecurityGroupRuleSupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeEC2 := mocks.FakeEC2{}
 			c.mocks(&fakeEC2)
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			deserializer := awsdeserializer.NewVPCSecurityGroupRuleDeserializer()
 			s := &VPCSecurityGroupRuleSupplier{
 				provider,

--- a/pkg/remote/aws/vpc_security_group_supplier.go
+++ b/pkg/remote/aws/vpc_security_group_supplier.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -26,14 +25,14 @@ type VPCSecurityGroupSupplier struct {
 	securityGroupRunner              *terraform.ParallelResourceReader
 }
 
-func NewVPCSecurityGroupSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *VPCSecurityGroupSupplier {
+func NewVPCSecurityGroupSupplier(provider *TerraformProvider) *VPCSecurityGroupSupplier {
 	return &VPCSecurityGroupSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewDefaultSecurityGroupDeserializer(),
 		awsdeserializer.NewVPCSecurityGroupDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner.SubRunner()),
-		terraform.NewParallelResourceReader(runner.SubRunner()),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/vpc_security_group_supplier_test.go
+++ b/pkg/remote/aws/vpc_security_group_supplier_test.go
@@ -86,20 +86,24 @@ func TestVPCSecurityGroupSupplier_Resources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		shouldUpdate := tt.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewVPCSecurityGroupSupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewVPCSecurityGroupSupplier(provider))
 		}
 
 		t.Run(tt.test, func(t *testing.T) {
 			fakeEC2 := mocks.FakeEC2{}
 			tt.mocks(&fakeEC2)
-			provider := mocks2.NewMockedGoldenTFProvider(tt.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(tt.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			securityGroupDeserializer := awsdeserializer.NewVPCSecurityGroupDeserializer()
 			defaultSecurityGroupDeserializer := awsdeserializer.NewDefaultSecurityGroupDeserializer()
 			s := &VPCSecurityGroupSupplier{

--- a/pkg/remote/aws/vpc_supplier.go
+++ b/pkg/remote/aws/vpc_supplier.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/cloudskiff/driftctl/pkg/parallel"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
@@ -26,14 +25,14 @@ type VPCSupplier struct {
 	vpcRunner              *terraform.ParallelResourceReader
 }
 
-func NewVPCSupplier(runner *parallel.ParallelRunner, client ec2iface.EC2API) *VPCSupplier {
+func NewVPCSupplier(provider *TerraformProvider) *VPCSupplier {
 	return &VPCSupplier{
-		terraform.Provider(terraform.AWS),
+		provider,
 		awsdeserializer.NewDefaultVPCDeserializer(),
 		awsdeserializer.NewVPCDeserializer(),
-		client,
-		terraform.NewParallelResourceReader(runner.SubRunner()),
-		terraform.NewParallelResourceReader(runner.SubRunner()),
+		ec2.New(provider.session),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
+		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 

--- a/pkg/remote/aws/vpc_supplier_test.go
+++ b/pkg/remote/aws/vpc_supplier_test.go
@@ -100,20 +100,24 @@ func TestVPCSupplier_Resources(t *testing.T) {
 	}
 	for _, c := range cases {
 		shouldUpdate := c.dirName == *goldenfile.Update
+
+		providerLibrary := terraform.NewProviderLibrary()
+		supplierLibrary := resource.NewSupplierLibrary()
+
 		if shouldUpdate {
 			provider, err := NewTerraFormProvider()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			terraform.AddProvider(terraform.AWS, provider)
-			resource.AddSupplier(NewVPCSupplier(provider.Runner(), ec2.New(provider.session)))
+			providerLibrary.AddProvider(terraform.AWS, provider)
+			supplierLibrary.AddSupplier(NewVPCSupplier(provider))
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
 			fakeEC2 := mocks.FakeEC2{}
 			c.mocks(&fakeEC2)
-			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, terraform.Provider(terraform.AWS), shouldUpdate)
+			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			VPCDeserializer := awsdeserializer.NewVPCDeserializer()
 			defaultVPCDeserializer := awsdeserializer.NewDefaultVPCDeserializer()
 			s := &VPCSupplier{

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/cloudskiff/driftctl/pkg/alerter"
 	"github.com/cloudskiff/driftctl/pkg/remote/aws"
+	"github.com/cloudskiff/driftctl/pkg/resource"
+	"github.com/cloudskiff/driftctl/pkg/terraform"
 )
 
 var supportedRemotes = []string{
@@ -20,10 +22,10 @@ func IsSupported(remote string) bool {
 	return false
 }
 
-func Activate(remote string, alerter *alerter.Alerter) error {
+func Activate(remote string, alerter *alerter.Alerter, providerLibrary *terraform.ProviderLibrary, supplierLibrary *resource.SupplierLibrary) error {
 	switch remote {
 	case aws.RemoteAWSTerraform:
-		return aws.Init(alerter)
+		return aws.Init(alerter, providerLibrary, supplierLibrary)
 	default:
 		return fmt.Errorf("unsupported remote '%s'", remote)
 	}

--- a/pkg/resource/resource_suppliers.go
+++ b/pkg/resource/resource_suppliers.go
@@ -1,11 +1,19 @@
 package resource
 
-var resourceSupplier = make([]Supplier, 0)
-
-func AddSupplier(supplier Supplier) {
-	resourceSupplier = append(resourceSupplier, supplier)
+type SupplierLibrary struct {
+	resourceSupplier []Supplier
 }
 
-func Suppliers() []Supplier {
-	return resourceSupplier
+func NewSupplierLibrary() *SupplierLibrary {
+	return &SupplierLibrary{
+		make([]Supplier, 0),
+	}
+}
+
+func (r *SupplierLibrary) AddSupplier(supplier Supplier) {
+	r.resourceSupplier = append(r.resourceSupplier, supplier)
+}
+
+func (r *SupplierLibrary) Suppliers() []Supplier {
+	return r.resourceSupplier
 }

--- a/pkg/terraform/terraform_provider.go
+++ b/pkg/terraform/terraform_provider.go
@@ -4,4 +4,5 @@ package terraform
 type TerraformProvider interface {
 	SchemaSupplier
 	ResourceReader
+	Cleanup()
 }

--- a/test/acceptance/result.go
+++ b/test/acceptance/result.go
@@ -86,5 +86,15 @@ func (r *ScanResult) AssertDriftCountTotal(count int) {
 }
 
 func (r ScanResult) AssertInfrastructureIsInSync() {
-	r.Equal(true, r.Analysis.IsSync(), fmt.Sprintf("Infrastructure is not in sync: %+v", r.Analysis.Summary()))
+	r.Equal(
+		true,
+		r.Analysis.IsSync(),
+		fmt.Sprintf(
+			"Infrastructure is not in sync: %+v\nUnmanaged:\n%+v\nDeleted:\n%+v\nDifferences:\n%+v\n",
+			r.Analysis.Summary(),
+			r.Analysis.Unmanaged(),
+			r.Analysis.Deleted(),
+			r.Analysis.Differences(),
+		),
+	)
 }

--- a/test/mocks/MockGoldenTerraformProvider.go
+++ b/test/mocks/MockGoldenTerraformProvider.go
@@ -165,3 +165,5 @@ func getFileNameSuffix(args terraform.ReadResourceArgs) string {
 	}
 	return suffix
 }
+
+func (p MockedGoldenTFProvider) Cleanup() {}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #68 
| ❓ Documentation  | no

## Description

We have some issue when running acceptance test, more generally
when we use to execute scan cmd multiples times.
We were using global singletons for provider and resources suppliers
managment which lead us to improper state in the second scan run.
We should avoid this in the future and make proper initialization of our
dependencies maybe using a dependency injection container.