### PR TITLE
Allow to override env vars for terraform operations in acc tests

### DIFF
--- a/doc/contributing/tests.md
+++ b/doc/contributing/tests.md
@@ -124,6 +124,34 @@ Each acceptance test should be prefixed by `TestAcc_` and should be run using en
 DRIFTCTL_ACC=true go test -run=TestAcc_ ./pkg/resource/aws/aws_instance_test.go
 ```
 
+### Credentials
+
+Acceptance tests need credentials to perform real world action on cloud providers:
+- Read/write access are required to perform terraform action
+- Read only access is required for driftctl execution
+
+Recommended way to run acc tests is to use two distinct credentials:
+one for terraform related actions, and one for driftctl scan.
+
+You can override environment variables passed to terraform operations by adding `ACC_` prefix on env variables.
+
+#### AWS
+
+You can use `ACC_AWS_PROFILE` to override AWS named profile used for terraform operations.
+
+```shell script
+ACC_AWS_PROFILE=read-write-profile AWS_PROFILE=read-only-profile DRIFTCTL_ACC=true go test -run=TestAcc_ ./pkg/resource/aws/aws_instance_test.go
+```
+
+In the example below, the `driftctl` AWS profile must have read/write permissions and will be used
+for both terraform operations and driftctl run.
+
+This is **not** the recommended way to run tests as it may hide permissions issues.
+
+```shell script
+AWS_PROFILE=driftctl DRIFTCTL_ACC=true go test -run=TestAcc_ ./pkg/resource/aws/aws_instance_test.go
+```
+
 ### Workflow
 
 - **`OnStart`** You may run some code before everything

--- a/test/acceptance/testing_test.go
+++ b/test/acceptance/testing_test.go
@@ -1,0 +1,28 @@
+package acceptance
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestAccTestCase_resolveTerraformEnv(t *testing.T) {
+
+	os.Clearenv()
+	os.Setenv("ACC_TEST_VAR", "foobar")
+	os.Setenv("TEST_VAR", "barfoo")
+	os.Setenv("TEST_VAR_2", "barfoo")
+	os.Setenv("ACC_TEST_VAR_3", "")
+	os.Setenv("TEST_VAR_3", "barfoo")
+	os.Setenv("TEST_VAR_4", "barfoo")
+	os.Setenv("ACC_TEST_VAR_4", "")
+
+	testCase := AccTestCase{}
+	env := testCase.resolveTerraformEnv()
+	expected := []string{"TEST_VAR=foobar", "TEST_VAR_2=barfoo", "TEST_VAR_3=", "TEST_VAR_4="}
+
+	if !reflect.DeepEqual(expected, env) {
+		t.Fatalf("Variable env override not working, got: %+v, expected %+v", env, expected)
+	}
+
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #83 
| ❓ Documentation  | yes