### PR TITLE
bash completion doc fix

### DIFF
--- a/doc/cmd/completion/script.md
+++ b/doc/cmd/completion/script.md
@@ -17,7 +17,7 @@ By default, this command will print on the standard output the content of the co
 ### Bash
 ```shell
 # Linux:
-$ driftctl completion bash > /etc/bash_completion.d/driftctl
+$ driftctl completion bash | sudo tee /etc/bash_completion.d/driftctl
 
 # MacOS:
 $ driftctl completion bash > /usr/local/etc/bash_completion.d/driftctl


### PR DESCRIPTION
current doc can't work as is
proposed fixed with sudo and tee

| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | yes <!-- does this require documentation update ? -->

## Description

fixes a misleading bash documentation for linux