### PR TITLE
Fix brew

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,8 @@ jobs:
       - run:
           name: "Bump driftctl formula"
           command: |
-            brew bump-formula-pr driftctl --url https://github.com/cloudskiff/driftctl/archive/$CIRCLE_TAG.tar.gz
+            brew install-bundler-gems -d -v
+            brew bump-formula-pr driftctl --url https://github.com/cloudskiff/driftctl/archive/$CIRCLE_TAG.tar.gz -d -v
 workflows:
   pullrequest:
     jobs:


### PR DESCRIPTION
On the v0.3.1 release, the brew command for bumping the formula was stuck during the install of the ruby gems.

Let's install the gems before we use this command.

PS: I added the d (debug) and v (verbose) flags on both commands.