### PR TITLE
Embed the environment variables before PreExec in ACC test

### DIFF
--- a/test/acceptance/testing.go
+++ b/test/acceptance/testing.go
@@ -271,15 +271,15 @@ func Run(t *testing.T, c AccTestCase) {
 		if check.Check == nil {
 			t.Fatal("Check attribute must be defined")
 		}
-		if check.PreExec != nil {
-			c.useTerraformEnv()
-			check.PreExec()
-			c.restoreEnv()
-		}
 		if len(check.Env) > 0 {
 			for key, value := range check.Env {
 				os.Setenv(key, value)
 			}
+		}
+		if check.PreExec != nil {
+			c.useTerraformEnv()
+			check.PreExec()
+			c.restoreEnv()
 		}
 		_, out, cmdErr := runDriftCtlCmd(driftctlCmd)
 		if len(check.Env) > 0 {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #175
| ❓ Documentation  | no

## Description
I fixed #175.
Please review my commit!