### PR TITLE
Fix lint sometimes fail in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ clean:
 .PHONY: lint
 lint:
 	@which golangci-lint > /dev/null 2>&1 || (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $(GOBINPATH) v1.31.0)
-	golangci-lint run
+	golangci-lint run --timeout=2m
 
 .PHONY: deps
 deps:


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no

## Description

As we use minimal enviroment in our CircleCI build, sometimes the linter fail with a timeout like there : https://app.circleci.com/pipelines/github/cloudskiff/driftctl/369/workflows/2d4f9c86-d119-48af-abe4-7a1e734e673f/jobs/448

This pull request increase the linter timeout to 2 minutes 