### PR TITLE
Fix unexpected deleted resources in acceptance tests

### DIFF
--- a/pkg/resource/aws/aws_instance_test.go
+++ b/pkg/resource/aws/aws_instance_test.go
@@ -76,6 +76,7 @@ func TestAcc_AwsInstance_WithBlockDevices(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
+					result.Equal(0, result.Summary().TotalDeleted)
 					result.AssertResourceHasDrift(
 						mutatedInstanceId,
 						awsresources.AwsInstanceResourceType,

--- a/test/acceptance/testing.go
+++ b/test/acceptance/testing.go
@@ -252,8 +252,6 @@ func Run(t *testing.T, c AccTestCase) {
 
 	logger.Init(logger.GetConfig())
 
-	driftctlCmd := cmd.NewDriftctlCmd(test.Build{})
-
 	err = c.createResultFile(t)
 	if err != nil {
 		t.Fatal(err)
@@ -268,6 +266,7 @@ func Run(t *testing.T, c AccTestCase) {
 	os.Args = c.Args
 
 	for _, check := range c.Checks {
+		driftctlCmd := cmd.NewDriftctlCmd(test.Build{})
 		if check.Check == nil {
 			t.Fatal("Check attribute must be defined")
 		}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no

## Description

Cobra cmd seems to return flag twice when executed multiples times.
I moved cmd creation in the loop to start with a fresh cobra cmd each time.

First check

![image](https://user-images.githubusercontent.com/6154987/106791389-242b4180-6655-11eb-9555-4111461d5f68.png)

Second check

![image](https://user-images.githubusercontent.com/6154987/106791580-65bbec80-6655-11eb-9653-a551492db7b8.png)
