### PR TITLE
Add retry mechanism for polling and use it to poll sqs queues during acc tests

### DIFF
--- a/pkg/resource/aws/aws_sqs_queue_policy_test.go
+++ b/pkg/resource/aws/aws_sqs_queue_policy_test.go
@@ -2,6 +2,11 @@ package aws_test
 
 import (
 	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/cloudskiff/driftctl/test/acceptance/awsutils"
+	"github.com/sirupsen/logrus"
 
 	"github.com/cloudskiff/driftctl/test/acceptance"
 )
@@ -14,6 +19,22 @@ func TestAcc_AwsSqsQueuePolicy(t *testing.T) {
 			{
 				Env: map[string]string{
 					"AWS_REGION": "us-east-1",
+				},
+				PreExec: func() {
+					err := acceptance.RetryFor(60*time.Second, func(doneCh chan struct{}) error {
+						return sqs.New(awsutils.Session()).ListQueuesPages(&sqs.ListQueuesInput{},
+							func(resp *sqs.ListQueuesOutput, lastPage bool) bool {
+								logrus.Debugf("Retrieved %d SQS queues", len(resp.QueueUrls))
+								if len(resp.QueueUrls) == 3 {
+									doneCh <- struct{}{}
+								}
+								return !lastPage
+							},
+						)
+					})
+					if err != nil {
+						t.Fatal("Timeout while fetching SQS queues")
+					}
 				},
 				Check: func(result *acceptance.ScanResult, stdout string, err error) {
 					if err != nil {

--- a/test/acceptance/testing_test.go
+++ b/test/acceptance/testing_test.go
@@ -1,10 +1,15 @@
 package acceptance
 
 import (
+	"context"
+	"errors"
 	"os"
 	"reflect"
 	"sort"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccTestCase_resolveTerraformEnv(t *testing.T) {
@@ -28,4 +33,47 @@ func TestAccTestCase_resolveTerraformEnv(t *testing.T) {
 		t.Fatalf("Variable env override not working, got: %+v, expected %+v", env, expected)
 	}
 
+}
+
+func TestRetryFor(t *testing.T) {
+	randomError := errors.New("random error")
+
+	cases := []struct {
+		name    string
+		timeout time.Duration
+		f       func(c chan struct{}) error
+		err     error
+	}{
+		{
+			name:    "success on first try",
+			timeout: 1 * time.Millisecond,
+			f: func(c chan struct{}) error {
+				c <- struct{}{}
+				return nil
+			},
+		},
+		{
+			name:    "timeout exceeded",
+			timeout: 1 * time.Millisecond,
+			f: func(c chan struct{}) error {
+				return nil
+			},
+			err: context.DeadlineExceeded,
+		},
+		{
+			name:    "error before timeout exceeded",
+			timeout: 1 * time.Millisecond,
+			f: func(c chan struct{}) error {
+				return randomError
+			},
+			err: randomError,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(tt *testing.T) {
+			err := RetryFor(c.timeout, c.f)
+			assert.Equal(tt, c.err, err)
+		})
+	}
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Found error in CI while running acceptance tests. The problem in short is that SQS queues has a weird behaviour where creation/deletion takes time to propagate. TLDR, we need to poll to list sqs queues in a pre check.