### PR TITLE
fix policies in topic subscription not beeing tag as jsonstring

### DIFF
--- a/pkg/resource/aws/aws_sns_topic_subscription.go
+++ b/pkg/resource/aws/aws_sns_topic_subscription.go
@@ -6,10 +6,10 @@ const AwsSnsTopicSubscriptionResourceType = "aws_sns_topic_subscription"
 type AwsSnsTopicSubscription struct {
 	Arn                          *string `cty:"arn" computed:"true"`
 	ConfirmationTimeoutInMinutes *int    `cty:"confirmation_timeout_in_minutes"`
-	DeliveryPolicy               *string `cty:"delivery_policy"`
+	DeliveryPolicy               *string `cty:"delivery_policy" jsonstring:"true"`
 	Endpoint                     *string `cty:"endpoint"`
 	EndpointAutoConfirms         *bool   `cty:"endpoint_auto_confirms"`
-	FilterPolicy                 *string `cty:"filter_policy"`
+	FilterPolicy                 *string `cty:"filter_policy" jsonstring:"true"`
 	Id                           string  `cty:"id" computed:"true"`
 	Protocol                     *string `cty:"protocol"`
 	RawMessageDelivery           *bool   `cty:"raw_message_delivery"`


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | 
| ❓ Documentation  | no

## Description

fix policies in topic subscription not beeing tag as jsonstring. So drift will be displayed correctly