### PR TITLE
docs: add more examples to filter.md for prefix/suffix

### DIFF
--- a/doc/cmd/scan/filter.md
+++ b/doc/cmd/scan/filter.md
@@ -69,4 +69,11 @@ driftctl scan --filter $'!(Type==\'aws_s3_bucket\' && Attr.Tags.terraform==\'fal
 
 # Ignore buckets that don't have tag terraform
 driftctl scan --filter $'!(Type==\'aws_s3_bucket\' && Attr.Tags != null && !contains(keys(Attr.Tags), \'terraform\'))'
+
+# Ignore buckets with an ID prefix of 'terraform-'
+driftctl scan --filter $'!(Type==\'aws_s3_bucket\' && starts_with(Id, \'terraform-\'))'
+
+# Ignore buckets with an ID suffix of '-test'
+driftctl scan --filter $'!(Type==\'aws_s3_bucket\' && ends_with(Id, \'-test\'))'
+
 ```


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | [232](https://github.com/cloudskiff/driftctl/issues/232)
| ❓ Documentation  | yes 

## Description

I reached out on Discord asking about how to use wildcards in `.driftignore` and was pointed towards trying to use JMES filters first. This PR adds two new examples to `filter.md` which show use of `starts_with` and `ends_with` for filtering resources based on prefixes and suffixes respectively.

Use of the [wildcard operator](https://jmespath.org/specification.html#wildcard-expressions) appears to be limited to iteration over a list as opposed to string matching on a property, so these functions might be the limit. I'd love if someone can prove me wrong though!

Attempted JMES:

`!(Type=='aws_iam_role' && Id=='AWS*'` - does not exclude `aws_iam_role.AWSServiceRoleForX`.