### PR TITLE
Make terraform provider generic

### DIFF
--- a/pkg/iac/terraform/state/terraform_state_reader_test.go
+++ b/pkg/iac/terraform/state/terraform_state_reader_test.go
@@ -85,11 +85,15 @@ func TestTerraformStateReader_Resources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			shouldUpdate := tt.dirName == *goldenfile.Update
 
-			var realProvider terraform.TerraformProvider
+			var realProvider *aws.AWSTerraformProvider
 
 			if shouldUpdate {
 				var err error
-				realProvider, err = aws.NewTerraFormProvider()
+				realProvider, err = aws.NewAWSTerraformProvider()
+				if err != nil {
+					t.Fatal(err)
+				}
+				err = realProvider.Init()
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/remote/aws/db_instance_supplier.go
+++ b/pkg/remote/aws/db_instance_supplier.go
@@ -21,7 +21,7 @@ type DBInstanceSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewDBInstanceSupplier(provider *TerraformProvider) *DBInstanceSupplier {
+func NewDBInstanceSupplier(provider *AWSTerraformProvider) *DBInstanceSupplier {
 	return &DBInstanceSupplier{
 		provider,
 		awsdeserializer.NewDBInstanceDeserializer(),

--- a/pkg/remote/aws/db_instance_supplier_test.go
+++ b/pkg/remote/aws/db_instance_supplier_test.go
@@ -118,11 +118,10 @@ func TestDBInstanceSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewDBInstanceSupplier(provider))
 		}
 

--- a/pkg/remote/aws/db_subnet_group_supplier.go
+++ b/pkg/remote/aws/db_subnet_group_supplier.go
@@ -24,7 +24,7 @@ type DBSubnetGroupSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewDBSubnetGroupSupplier(provider *TerraformProvider) *DBSubnetGroupSupplier {
+func NewDBSubnetGroupSupplier(provider *AWSTerraformProvider) *DBSubnetGroupSupplier {
 	return &DBSubnetGroupSupplier{
 		provider,
 		awsdeserializer.NewDBSubnetGroupDeserializer(),

--- a/pkg/remote/aws/db_subnet_group_supplier_test.go
+++ b/pkg/remote/aws/db_subnet_group_supplier_test.go
@@ -88,12 +88,10 @@ func TestDBSubnetGroupSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewDBInstanceSupplier(provider))
 		}
 

--- a/pkg/remote/aws/dynamodb_table_supplier.go
+++ b/pkg/remote/aws/dynamodb_table_supplier.go
@@ -20,7 +20,7 @@ type DynamoDBTableSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewDynamoDBTableSupplier(provider *TerraformProvider) *DynamoDBTableSupplier {
+func NewDynamoDBTableSupplier(provider *AWSTerraformProvider) *DynamoDBTableSupplier {
 	return &DynamoDBTableSupplier{
 		provider,
 		awsdeserializer.NewDynamoDBTableDeserializer(),

--- a/pkg/remote/aws/dynamodb_table_supplier_test.go
+++ b/pkg/remote/aws/dynamodb_table_supplier_test.go
@@ -71,7 +71,7 @@ func TestDynamoDBTableSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/remote/aws/ec2_ami_supplier.go
+++ b/pkg/remote/aws/ec2_ami_supplier.go
@@ -23,7 +23,7 @@ type EC2AmiSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2AmiSupplier(provider *TerraformProvider) *EC2AmiSupplier {
+func NewEC2AmiSupplier(provider *AWSTerraformProvider) *EC2AmiSupplier {
 	return &EC2AmiSupplier{
 		provider,
 		awsdeserializer.NewEC2AmiDeserializer(),

--- a/pkg/remote/aws/ec2_ami_supplier_test.go
+++ b/pkg/remote/aws/ec2_ami_supplier_test.go
@@ -55,12 +55,10 @@ func TestEC2AmiSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewEC2AmiSupplier(provider))
 		}
 

--- a/pkg/remote/aws/ec2_ebs_snapshot_supplier.go
+++ b/pkg/remote/aws/ec2_ebs_snapshot_supplier.go
@@ -23,7 +23,7 @@ type EC2EbsSnapshotSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2EbsSnapshotSupplier(provider *TerraformProvider) *EC2EbsSnapshotSupplier {
+func NewEC2EbsSnapshotSupplier(provider *AWSTerraformProvider) *EC2EbsSnapshotSupplier {
 	return &EC2EbsSnapshotSupplier{
 		provider,
 		awsdeserializer.NewEC2EbsSnapshotDeserializer(),

--- a/pkg/remote/aws/ec2_ebs_snapshot_supplier_test.go
+++ b/pkg/remote/aws/ec2_ebs_snapshot_supplier_test.go
@@ -86,12 +86,10 @@ func TestEC2EbsSnapshotSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewEC2EbsSnapshotSupplier(provider))
 		}
 

--- a/pkg/remote/aws/ec2_ebs_volume_supplier.go
+++ b/pkg/remote/aws/ec2_ebs_volume_supplier.go
@@ -23,7 +23,7 @@ type EC2EbsVolumeSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2EbsVolumeSupplier(provider *TerraformProvider) *EC2EbsVolumeSupplier {
+func NewEC2EbsVolumeSupplier(provider *AWSTerraformProvider) *EC2EbsVolumeSupplier {
 	return &EC2EbsVolumeSupplier{
 		provider,
 		awsdeserializer.NewEC2EbsVolumeDeserializer(),

--- a/pkg/remote/aws/ec2_ebs_volume_supplier_test.go
+++ b/pkg/remote/aws/ec2_ebs_volume_supplier_test.go
@@ -86,12 +86,10 @@ func TestEC2EbsVolumeSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewEC2EbsVolumeSupplier(provider))
 		}
 

--- a/pkg/remote/aws/ec2_eip_association_supplier.go
+++ b/pkg/remote/aws/ec2_eip_association_supplier.go
@@ -23,7 +23,7 @@ type EC2EipAssociationSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2EipAssociationSupplier(provider *TerraformProvider) *EC2EipAssociationSupplier {
+func NewEC2EipAssociationSupplier(provider *AWSTerraformProvider) *EC2EipAssociationSupplier {
 	return &EC2EipAssociationSupplier{
 		provider,
 		awsdeserializer.NewEC2EipAssociationDeserializer(),

--- a/pkg/remote/aws/ec2_eip_association_supplier_test.go
+++ b/pkg/remote/aws/ec2_eip_association_supplier_test.go
@@ -64,12 +64,10 @@ func TestEC2EipAssociationSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewEC2EipAssociationSupplier(provider))
 		}
 

--- a/pkg/remote/aws/ec2_eip_supplier.go
+++ b/pkg/remote/aws/ec2_eip_supplier.go
@@ -23,7 +23,7 @@ type EC2EipSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2EipSupplier(provider *TerraformProvider) *EC2EipSupplier {
+func NewEC2EipSupplier(provider *AWSTerraformProvider) *EC2EipSupplier {
 	return &EC2EipSupplier{
 		provider,
 		awsdeserializer.NewEC2EipDeserializer(),

--- a/pkg/remote/aws/ec2_eip_supplier_test.go
+++ b/pkg/remote/aws/ec2_eip_supplier_test.go
@@ -67,12 +67,10 @@ func TestEC2EipSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewEC2EipSupplier(provider))
 		}
 

--- a/pkg/remote/aws/ec2_instance_supplier.go
+++ b/pkg/remote/aws/ec2_instance_supplier.go
@@ -23,7 +23,7 @@ type EC2InstanceSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2InstanceSupplier(provider *TerraformProvider) *EC2InstanceSupplier {
+func NewEC2InstanceSupplier(provider *AWSTerraformProvider) *EC2InstanceSupplier {
 	return &EC2InstanceSupplier{
 		provider,
 		awsdeserializer.NewEC2InstanceDeserializer(),

--- a/pkg/remote/aws/ec2_instance_supplier_test.go
+++ b/pkg/remote/aws/ec2_instance_supplier_test.go
@@ -118,12 +118,10 @@ func TestEC2InstanceSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewEC2InstanceSupplier(provider))
 		}
 

--- a/pkg/remote/aws/ec2_key_pair_supplier.go
+++ b/pkg/remote/aws/ec2_key_pair_supplier.go
@@ -23,7 +23,7 @@ type EC2KeyPairSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewEC2KeyPairSupplier(provider *TerraformProvider) *EC2KeyPairSupplier {
+func NewEC2KeyPairSupplier(provider *AWSTerraformProvider) *EC2KeyPairSupplier {
 	return &EC2KeyPairSupplier{
 		provider,
 		awsdeserializer.NewEC2KeyPairDeserializer(),

--- a/pkg/remote/aws/ec2_key_pair_supplier_test.go
+++ b/pkg/remote/aws/ec2_key_pair_supplier_test.go
@@ -61,12 +61,10 @@ func TestEC2KeyPairSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewEC2KeyPairSupplier(provider))
 		}
 

--- a/pkg/remote/aws/iam_access_key_supplier.go
+++ b/pkg/remote/aws/iam_access_key_supplier.go
@@ -22,7 +22,7 @@ type IamAccessKeySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamAccessKeySupplier(provider *TerraformProvider) *IamAccessKeySupplier {
+func NewIamAccessKeySupplier(provider *AWSTerraformProvider) *IamAccessKeySupplier {
 	return &IamAccessKeySupplier{
 		provider,
 		awsdeserializer.NewIamAccessKeyDeserializer(),

--- a/pkg/remote/aws/iam_access_key_supplier_test.go
+++ b/pkg/remote/aws/iam_access_key_supplier_test.go
@@ -154,12 +154,10 @@ func TestIamAccessKeySupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewIamAccessKeySupplier(provider))
 		}
 

--- a/pkg/remote/aws/iam_policy_supplier.go
+++ b/pkg/remote/aws/iam_policy_supplier.go
@@ -23,7 +23,7 @@ type IamPolicySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamPolicySupplier(provider *TerraformProvider) *IamPolicySupplier {
+func NewIamPolicySupplier(provider *AWSTerraformProvider) *IamPolicySupplier {
 	return &IamPolicySupplier{
 		provider,
 		awsdeserializer.NewIamPolicyDeserializer(),

--- a/pkg/remote/aws/iam_policy_supplier_test.go
+++ b/pkg/remote/aws/iam_policy_supplier_test.go
@@ -94,12 +94,10 @@ func TestIamPolicySupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewIamPolicySupplier(provider))
 		}
 

--- a/pkg/remote/aws/iam_role_policy_attachment_supplier.go
+++ b/pkg/remote/aws/iam_role_policy_attachment_supplier.go
@@ -22,7 +22,7 @@ type IamRolePolicyAttachmentSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamRolePolicyAttachmentSupplier(provider *TerraformProvider) *IamRolePolicyAttachmentSupplier {
+func NewIamRolePolicyAttachmentSupplier(provider *AWSTerraformProvider) *IamRolePolicyAttachmentSupplier {
 	return &IamRolePolicyAttachmentSupplier{
 		provider,
 		awsdeserializer.NewIamRolePolicyAttachmentDeserializer(),

--- a/pkg/remote/aws/iam_role_policy_attachment_supplier_test.go
+++ b/pkg/remote/aws/iam_role_policy_attachment_supplier_test.go
@@ -186,12 +186,10 @@ func TestIamRolePolicyAttachmentSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewIamRolePolicyAttachmentSupplier(provider))
 		}
 

--- a/pkg/remote/aws/iam_role_policy_supplier.go
+++ b/pkg/remote/aws/iam_role_policy_supplier.go
@@ -24,7 +24,7 @@ type IamRolePolicySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamRolePolicySupplier(provider *TerraformProvider) *IamRolePolicySupplier {
+func NewIamRolePolicySupplier(provider *AWSTerraformProvider) *IamRolePolicySupplier {
 	return &IamRolePolicySupplier{
 		provider,
 		awsdeserializer.NewIamRolePolicyDeserializer(),

--- a/pkg/remote/aws/iam_role_policy_supplier_test.go
+++ b/pkg/remote/aws/iam_role_policy_supplier_test.go
@@ -151,12 +151,10 @@ func TestIamRolePolicySupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewIamRolePolicySupplier(provider))
 		}
 

--- a/pkg/remote/aws/iam_role_supplier.go
+++ b/pkg/remote/aws/iam_role_supplier.go
@@ -31,7 +31,7 @@ type IamRoleSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamRoleSupplier(provider *TerraformProvider) *IamRoleSupplier {
+func NewIamRoleSupplier(provider *AWSTerraformProvider) *IamRoleSupplier {
 	return &IamRoleSupplier{
 		provider,
 		awsdeserializer.NewIamRoleDeserializer(),

--- a/pkg/remote/aws/iam_role_supplier_test.go
+++ b/pkg/remote/aws/iam_role_supplier_test.go
@@ -109,12 +109,10 @@ func TestIamRoleSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewIamRoleSupplier(provider))
 		}
 

--- a/pkg/remote/aws/iam_user_policy_attachment_supplier.go
+++ b/pkg/remote/aws/iam_user_policy_attachment_supplier.go
@@ -22,7 +22,7 @@ type IamUserPolicyAttachmentSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamUserPolicyAttachmentSupplier(provider *TerraformProvider) *IamUserPolicyAttachmentSupplier {
+func NewIamUserPolicyAttachmentSupplier(provider *AWSTerraformProvider) *IamUserPolicyAttachmentSupplier {
 	return &IamUserPolicyAttachmentSupplier{
 		provider,
 		awsdeserializer.NewIamUserPolicyAttachmentDeserializer(),

--- a/pkg/remote/aws/iam_user_policy_attachment_supplier_test.go
+++ b/pkg/remote/aws/iam_user_policy_attachment_supplier_test.go
@@ -204,12 +204,10 @@ func TestIamUserPolicyAttachmentSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewIamUserPolicyAttachmentSupplier(provider))
 		}
 

--- a/pkg/remote/aws/iam_user_policy_supplier.go
+++ b/pkg/remote/aws/iam_user_policy_supplier.go
@@ -24,7 +24,7 @@ type IamUserPolicySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamUserPolicySupplier(provider *TerraformProvider) *IamUserPolicySupplier {
+func NewIamUserPolicySupplier(provider *AWSTerraformProvider) *IamUserPolicySupplier {
 	return &IamUserPolicySupplier{
 		provider,
 		awsdeserializer.NewIamUserPolicyDeserializer(),

--- a/pkg/remote/aws/iam_user_policy_supplier_test.go
+++ b/pkg/remote/aws/iam_user_policy_supplier_test.go
@@ -175,12 +175,10 @@ func TestIamUserPolicySupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewIamUserPolicySupplier(provider))
 		}
 

--- a/pkg/remote/aws/iam_user_supplier.go
+++ b/pkg/remote/aws/iam_user_supplier.go
@@ -22,7 +22,7 @@ type IamUserSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewIamUserSupplier(provider *TerraformProvider) *IamUserSupplier {
+func NewIamUserSupplier(provider *AWSTerraformProvider) *IamUserSupplier {
 	return &IamUserSupplier{
 		provider,
 		awsdeserializer.NewIamUserDeserializer(),

--- a/pkg/remote/aws/iam_user_supplier_test.go
+++ b/pkg/remote/aws/iam_user_supplier_test.go
@@ -88,12 +88,10 @@ func TestIamUserSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewIamUserSupplier(provider))
 		}
 

--- a/pkg/remote/aws/init.go
+++ b/pkg/remote/aws/init.go
@@ -13,7 +13,11 @@ const RemoteAWSTerraform = "aws+tf"
  * Required to use Scanner
  */
 func Init(alerter *alerter.Alerter, providerLibrary *terraform.ProviderLibrary, supplierLibrary *resource.SupplierLibrary) error {
-	provider, err := NewTerraFormProvider()
+	provider, err := NewAWSTerraformProvider()
+	if err != nil {
+		return err
+	}
+	err = provider.Init()
 	if err != nil {
 		return err
 	}

--- a/pkg/remote/aws/init_test.go
+++ b/pkg/remote/aws/init_test.go
@@ -1,0 +1,16 @@
+package aws
+
+import "github.com/cloudskiff/driftctl/pkg/terraform"
+
+func InitTestAwsProvider(providerLibrary *terraform.ProviderLibrary) (*AWSTerraformProvider, error) {
+	provider, err := NewAWSTerraformProvider()
+	if err != nil {
+		return nil, err
+	}
+	err = provider.Init()
+	if err != nil {
+		return nil, err
+	}
+	providerLibrary.AddProvider(terraform.AWS, provider)
+	return provider, nil
+}

--- a/pkg/remote/aws/internet_gateway_supplier.go
+++ b/pkg/remote/aws/internet_gateway_supplier.go
@@ -20,7 +20,7 @@ type InternetGatewaySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewInternetGatewaySupplier(provider *TerraformProvider) *InternetGatewaySupplier {
+func NewInternetGatewaySupplier(provider *AWSTerraformProvider) *InternetGatewaySupplier {
 	return &InternetGatewaySupplier{
 		provider,
 		awsdeserializer.NewInternetGatewayDeserializer(),

--- a/pkg/remote/aws/internet_gateway_supplier_test.go
+++ b/pkg/remote/aws/internet_gateway_supplier_test.go
@@ -88,12 +88,10 @@ func TestInternetGatewaySupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewInternetGatewaySupplier(provider))
 		}
 

--- a/pkg/remote/aws/lambda_function_supplier.go
+++ b/pkg/remote/aws/lambda_function_supplier.go
@@ -22,7 +22,7 @@ type LambdaFunctionSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewLambdaFunctionSupplier(provider *TerraformProvider) *LambdaFunctionSupplier {
+func NewLambdaFunctionSupplier(provider *AWSTerraformProvider) *LambdaFunctionSupplier {
 	return &LambdaFunctionSupplier{
 		provider,
 		awsdeserializer.NewLambdaFunctionDeserializer(),

--- a/pkg/remote/aws/lambda_function_supplier_test.go
+++ b/pkg/remote/aws/lambda_function_supplier_test.go
@@ -103,12 +103,10 @@ func TestLambdaFunctionSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewLambdaFunctionSupplier(provider))
 		}
 

--- a/pkg/remote/aws/nat_gateway_supplier.go
+++ b/pkg/remote/aws/nat_gateway_supplier.go
@@ -20,7 +20,7 @@ type NatGatewaySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewNatGatewaySupplier(provider *TerraformProvider) *NatGatewaySupplier {
+func NewNatGatewaySupplier(provider *AWSTerraformProvider) *NatGatewaySupplier {
 	return &NatGatewaySupplier{
 		provider,
 		awsdeserializer.NewNatGatewayDeserializer(),

--- a/pkg/remote/aws/nat_gateway_supplier_test.go
+++ b/pkg/remote/aws/nat_gateway_supplier_test.go
@@ -83,12 +83,10 @@ func TestNatGatewaySupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewNatGatewaySupplier(provider))
 		}
 

--- a/pkg/remote/aws/provider.go
+++ b/pkg/remote/aws/provider.go
@@ -1,0 +1,70 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/cloudskiff/driftctl/pkg/remote/terraform"
+	tf "github.com/cloudskiff/driftctl/pkg/terraform"
+)
+
+type awsConfig struct {
+	AccessKey     string
+	SecretKey     string
+	CredsFilename string
+	Profile       string
+	Token         string
+	Region        string `cty:"region"`
+	MaxRetries    int
+
+	AssumeRoleARN         string
+	AssumeRoleExternalID  string
+	AssumeRoleSessionName string
+	AssumeRolePolicy      string
+
+	AllowedAccountIds   []string
+	ForbiddenAccountIds []string
+
+	Endpoints        map[string]string
+	IgnoreTagsConfig map[string]string
+	Insecure         bool
+
+	SkipCredsValidation     bool
+	SkipGetEC2Platforms     bool
+	SkipRegionValidation    bool
+	SkipRequestingAccountId bool
+	SkipMetadataApiCheck    bool
+	S3ForcePathStyle        bool
+}
+
+type AWSTerraformProvider struct {
+	*terraform.TerraformProvider
+	session *session.Session
+}
+
+func NewAWSTerraformProvider() (*AWSTerraformProvider, error) {
+	p := &AWSTerraformProvider{}
+	installer, err := tf.NewProviderInstaller(tf.ProviderConfig{
+		Key:     "aws",
+		Version: "3.19.0",
+		Postfix: "x5",
+	})
+	if err != nil {
+		return nil, err
+	}
+	p.session = session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+	tfProvider, err := terraform.NewTerraformProvider(installer, terraform.TerraformProviderConfig{
+		DefaultAlias: *p.session.Config.Region,
+		GetProviderConfig: func(alias string) interface{} {
+			return awsConfig{
+				Region:     alias,
+				MaxRetries: 10, // TODO make this configurable
+			}
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	p.TerraformProvider = tfProvider
+	return p, err
+}

--- a/pkg/remote/aws/route53_record_supplier.go
+++ b/pkg/remote/aws/route53_record_supplier.go
@@ -25,7 +25,7 @@ type Route53RecordSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewRoute53RecordSupplier(provider *TerraformProvider) *Route53RecordSupplier {
+func NewRoute53RecordSupplier(provider *AWSTerraformProvider) *Route53RecordSupplier {
 	return &Route53RecordSupplier{
 		provider,
 		awsdeserializer.NewRoute53RecordDeserializer(),

--- a/pkg/remote/aws/route53_record_supplier_test.go
+++ b/pkg/remote/aws/route53_record_supplier_test.go
@@ -253,12 +253,10 @@ func TestRoute53RecordSupplier_Resources(t *testing.T) {
 			supplierLibrary := resource.NewSupplierLibrary()
 
 			if shouldUpdate {
-				provider, err := NewTerraFormProvider()
+				provider, err := InitTestAwsProvider(providerLibrary)
 				if err != nil {
 					t.Fatal(err)
 				}
-
-				providerLibrary.AddProvider(terraform.AWS, provider)
 				supplierLibrary.AddSupplier(NewRoute53RecordSupplier(provider))
 			}
 

--- a/pkg/remote/aws/route53_zone_supplier.go
+++ b/pkg/remote/aws/route53_zone_supplier.go
@@ -24,7 +24,7 @@ type Route53ZoneSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewRoute53ZoneSupplier(provider *TerraformProvider) *Route53ZoneSupplier {
+func NewRoute53ZoneSupplier(provider *AWSTerraformProvider) *Route53ZoneSupplier {
 	return &Route53ZoneSupplier{
 		provider,
 		awsdeserializer.NewRoute53ZoneDeserializer(),

--- a/pkg/remote/aws/route53_zone_supplier_test.go
+++ b/pkg/remote/aws/route53_zone_supplier_test.go
@@ -110,12 +110,10 @@ func TestRoute53ZoneSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewRoute53ZoneSupplier(provider))
 		}
 

--- a/pkg/remote/aws/route_supplier.go
+++ b/pkg/remote/aws/route_supplier.go
@@ -20,7 +20,7 @@ type RouteSupplier struct {
 	routeRunner       *terraform.ParallelResourceReader
 }
 
-func NewRouteSupplier(provider *TerraformProvider) *RouteSupplier {
+func NewRouteSupplier(provider *AWSTerraformProvider) *RouteSupplier {
 	return &RouteSupplier{
 		provider,
 		awsdeserializer.NewRouteDeserializer(),

--- a/pkg/remote/aws/route_supplier_test.go
+++ b/pkg/remote/aws/route_supplier_test.go
@@ -153,12 +153,10 @@ func TestRouteSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewRouteSupplier(provider))
 		}
 

--- a/pkg/remote/aws/route_table_association_supplier.go
+++ b/pkg/remote/aws/route_table_association_supplier.go
@@ -20,7 +20,7 @@ type RouteTableAssociationSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewRouteTableAssociationSupplier(provider *TerraformProvider) *RouteTableAssociationSupplier {
+func NewRouteTableAssociationSupplier(provider *AWSTerraformProvider) *RouteTableAssociationSupplier {
 	return &RouteTableAssociationSupplier{
 		provider,
 		awsdeserializer.NewRouteTableAssociationDeserializer(),

--- a/pkg/remote/aws/route_table_association_supplier_test.go
+++ b/pkg/remote/aws/route_table_association_supplier_test.go
@@ -156,12 +156,10 @@ func TestRouteTableAssociationSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewRouteTableAssociationSupplier(provider))
 		}
 

--- a/pkg/remote/aws/route_table_supplier.go
+++ b/pkg/remote/aws/route_table_supplier.go
@@ -26,7 +26,7 @@ type RouteTableSupplier struct {
 	routeTableRunner              *terraform.ParallelResourceReader
 }
 
-func NewRouteTableSupplier(provider *TerraformProvider) *RouteTableSupplier {
+func NewRouteTableSupplier(provider *AWSTerraformProvider) *RouteTableSupplier {
 	return &RouteTableSupplier{
 		provider,
 		awsdeserializer.NewDefaultRouteTableDeserializer(),

--- a/pkg/remote/aws/route_table_supplier_test.go
+++ b/pkg/remote/aws/route_table_supplier_test.go
@@ -105,12 +105,10 @@ func TestRouteTableSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewRouteTableSupplier(provider))
 		}
 

--- a/pkg/remote/aws/s3_bucket_analytic_supplier.go
+++ b/pkg/remote/aws/s3_bucket_analytic_supplier.go
@@ -94,7 +94,7 @@ func (s *S3BucketAnalyticSupplier) listBucketAnalyticConfiguration(name, region 
 					Ty: aws.AwsS3BucketAnalyticsConfigurationResourceType,
 					ID: id,
 					Attributes: map[string]string{
-						"aws_region": region,
+						"alias": region,
 					},
 				},
 			)

--- a/pkg/remote/aws/s3_bucket_analytic_supplier.go
+++ b/pkg/remote/aws/s3_bucket_analytic_supplier.go
@@ -24,7 +24,7 @@ type S3BucketAnalyticSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewS3BucketAnalyticSupplier(provider *TerraformProvider, factory AwsClientFactoryInterface) *S3BucketAnalyticSupplier {
+func NewS3BucketAnalyticSupplier(provider *AWSTerraformProvider, factory AwsClientFactoryInterface) *S3BucketAnalyticSupplier {
 	return &S3BucketAnalyticSupplier{
 		provider,
 		awsdeserializer.NewS3BucketAnalyticDeserializer(),

--- a/pkg/remote/aws/s3_bucket_analytic_supplier_test.go
+++ b/pkg/remote/aws/s3_bucket_analytic_supplier_test.go
@@ -110,13 +110,11 @@ func TestS3BucketAnalyticSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
 			factory := AwsClientFactory{config: provider.session}
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewS3BucketAnalyticSupplier(provider, factory))
 		}
 

--- a/pkg/remote/aws/s3_bucket_inventory_supplier.go
+++ b/pkg/remote/aws/s3_bucket_inventory_supplier.go
@@ -94,7 +94,7 @@ func (s *S3BucketInventorySupplier) listBucketInventoryConfiguration(name, regio
 					Ty: aws.AwsS3BucketInventoryResourceType,
 					ID: id,
 					Attributes: map[string]string{
-						"aws_region": region,
+						"alias": region,
 					},
 				},
 			)

--- a/pkg/remote/aws/s3_bucket_inventory_supplier.go
+++ b/pkg/remote/aws/s3_bucket_inventory_supplier.go
@@ -24,7 +24,7 @@ type S3BucketInventorySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewS3BucketInventorySupplier(provider *TerraformProvider, factory AwsClientFactoryInterface) *S3BucketInventorySupplier {
+func NewS3BucketInventorySupplier(provider *AWSTerraformProvider, factory AwsClientFactoryInterface) *S3BucketInventorySupplier {
 	return &S3BucketInventorySupplier{
 		provider,
 		awsdeserializer.NewS3BucketInventoryDeserializer(),

--- a/pkg/remote/aws/s3_bucket_inventory_supplier_test.go
+++ b/pkg/remote/aws/s3_bucket_inventory_supplier_test.go
@@ -109,14 +109,12 @@ func TestS3BucketInventorySupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			factory := AwsClientFactory{config: provider.session}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewS3BucketInventorySupplier(provider, factory))
 		}
 

--- a/pkg/remote/aws/s3_bucket_metric_supplier_test.go
+++ b/pkg/remote/aws/s3_bucket_metric_supplier_test.go
@@ -109,14 +109,11 @@ func TestS3BucketMetricSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
 			factory := AwsClientFactory{config: provider.session}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewS3BucketMetricSupplier(provider, factory))
 		}
 

--- a/pkg/remote/aws/s3_bucket_metrics_supplier.go
+++ b/pkg/remote/aws/s3_bucket_metrics_supplier.go
@@ -94,7 +94,7 @@ func (s *S3BucketMetricSupplier) listBucketMetricConfiguration(name, region stri
 					Ty: aws.AwsS3BucketMetricResourceType,
 					ID: id,
 					Attributes: map[string]string{
-						"aws_region": region,
+						"alias": region,
 					},
 				},
 			)

--- a/pkg/remote/aws/s3_bucket_metrics_supplier.go
+++ b/pkg/remote/aws/s3_bucket_metrics_supplier.go
@@ -24,7 +24,7 @@ type S3BucketMetricSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewS3BucketMetricSupplier(provider *TerraformProvider, factory AwsClientFactoryInterface) *S3BucketMetricSupplier {
+func NewS3BucketMetricSupplier(provider *AWSTerraformProvider, factory AwsClientFactoryInterface) *S3BucketMetricSupplier {
 	return &S3BucketMetricSupplier{
 		provider,
 		awsdeserializer.NewS3BucketMetricDeserializer(),

--- a/pkg/remote/aws/s3_bucket_notification_supplier.go
+++ b/pkg/remote/aws/s3_bucket_notification_supplier.go
@@ -19,7 +19,7 @@ type S3BucketNotificationSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewS3BucketNotificationSupplier(provider *TerraformProvider, factory AwsClientFactoryInterface) *S3BucketNotificationSupplier {
+func NewS3BucketNotificationSupplier(provider *AWSTerraformProvider, factory AwsClientFactoryInterface) *S3BucketNotificationSupplier {
 	return &S3BucketNotificationSupplier{
 		provider,
 		awsdeserializer.NewS3BucketNotificationDeserializer(),

--- a/pkg/remote/aws/s3_bucket_notification_supplier.go
+++ b/pkg/remote/aws/s3_bucket_notification_supplier.go
@@ -75,7 +75,7 @@ func (s *S3BucketNotificationSupplier) listBucketNotificationConfiguration(name,
 			Ty: aws.AwsS3BucketNotificationResourceType,
 			ID: name,
 			Attributes: map[string]string{
-				"aws_region": region,
+				"alias": region,
 			},
 		})
 		if err != nil {

--- a/pkg/remote/aws/s3_bucket_notification_supplier_test.go
+++ b/pkg/remote/aws/s3_bucket_notification_supplier_test.go
@@ -74,14 +74,11 @@ func TestS3BucketNotificationSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
 			factory := AwsClientFactory{config: provider.session}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewS3BucketNotificationSupplier(provider, factory))
 		}
 

--- a/pkg/remote/aws/s3_bucket_policy_supplier.go
+++ b/pkg/remote/aws/s3_bucket_policy_supplier.go
@@ -76,7 +76,7 @@ func (s *S3BucketPolicySupplier) listBucketPolicyConfiguration(name, region stri
 				Ty: aws.AwsS3BucketPolicyResourceType,
 				ID: name,
 				Attributes: map[string]string{
-					"aws_region": region,
+					"alias": region,
 				},
 			},
 		)

--- a/pkg/remote/aws/s3_bucket_policy_supplier.go
+++ b/pkg/remote/aws/s3_bucket_policy_supplier.go
@@ -19,7 +19,7 @@ type S3BucketPolicySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewS3BucketPolicySupplier(provider *TerraformProvider, factory AwsClientFactoryInterface) *S3BucketPolicySupplier {
+func NewS3BucketPolicySupplier(provider *AWSTerraformProvider, factory AwsClientFactoryInterface) *S3BucketPolicySupplier {
 	return &S3BucketPolicySupplier{
 		provider,
 		awsdeserializer.NewS3BucketPolicyDeserializer(),

--- a/pkg/remote/aws/s3_bucket_policy_supplier_test.go
+++ b/pkg/remote/aws/s3_bucket_policy_supplier_test.go
@@ -75,14 +75,11 @@ func TestS3BucketPolicySupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
 			factory := AwsClientFactory{config: provider.session}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewS3BucketPolicySupplier(provider, factory))
 		}
 

--- a/pkg/remote/aws/s3_bucket_supplier.go
+++ b/pkg/remote/aws/s3_bucket_supplier.go
@@ -99,7 +99,7 @@ func (s *S3BucketSupplier) readBucket(bucket s3.Bucket, client *s3iface.S3API) (
 		Ty: aws.AwsS3BucketResourceType,
 		ID: name,
 		Attributes: map[string]string{
-			"aws_region": region,
+			"alias": region,
 		},
 	})
 	if err != nil {

--- a/pkg/remote/aws/s3_bucket_supplier.go
+++ b/pkg/remote/aws/s3_bucket_supplier.go
@@ -23,7 +23,7 @@ type S3BucketSupplier struct {
 	runner           *terraform.ParallelResourceReader
 }
 
-func NewS3BucketSupplier(provider *TerraformProvider, factory AwsClientFactoryInterface) *S3BucketSupplier {
+func NewS3BucketSupplier(provider *AWSTerraformProvider, factory AwsClientFactoryInterface) *S3BucketSupplier {
 	return &S3BucketSupplier{
 		provider,
 		awsdeserializer.NewS3BucketDeserializer(),

--- a/pkg/remote/aws/s3_bucket_supplier_test.go
+++ b/pkg/remote/aws/s3_bucket_supplier_test.go
@@ -64,14 +64,11 @@ func TestS3BucketSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
 			factory := AwsClientFactory{config: provider.session}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewS3BucketSupplier(provider, factory))
 		}
 

--- a/pkg/remote/aws/sns_topic_policy_supplier.go
+++ b/pkg/remote/aws/sns_topic_policy_supplier.go
@@ -21,7 +21,7 @@ type SNSTopicPolicySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewSNSTopicPolicySupplier(provider *TerraformProvider) *SNSTopicPolicySupplier {
+func NewSNSTopicPolicySupplier(provider *AWSTerraformProvider) *SNSTopicPolicySupplier {
 	return &SNSTopicPolicySupplier{
 		provider,
 		awsdeserializer.NewSNSTopicPolicyDeserializer(),

--- a/pkg/remote/aws/sns_topic_policy_supplier_test.go
+++ b/pkg/remote/aws/sns_topic_policy_supplier_test.go
@@ -72,12 +72,10 @@ func TestSNSTopicPolicySupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewSNSTopicSupplier(provider))
 		}
 

--- a/pkg/remote/aws/sns_topic_subscription_supplier.go
+++ b/pkg/remote/aws/sns_topic_subscription_supplier.go
@@ -21,7 +21,7 @@ type SNSTopicSubscriptionSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewSNSTopicSubscriptionSupplier(provider *TerraformProvider) *SNSTopicSubscriptionSupplier {
+func NewSNSTopicSubscriptionSupplier(provider *AWSTerraformProvider) *SNSTopicSubscriptionSupplier {
 	return &SNSTopicSubscriptionSupplier{
 		provider,
 		awsdeserializer.NewSNSTopicSubscriptionDeserializer(),

--- a/pkg/remote/aws/sns_topic_subscription_supplier_test.go
+++ b/pkg/remote/aws/sns_topic_subscription_supplier_test.go
@@ -72,12 +72,10 @@ func TestSNSTopicSubscriptionSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewSNSTopicSubscriptionSupplier(provider))
 		}
 

--- a/pkg/remote/aws/sns_topic_supplier.go
+++ b/pkg/remote/aws/sns_topic_supplier.go
@@ -21,7 +21,7 @@ type SNSTopicSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewSNSTopicSupplier(provider *TerraformProvider) *SNSTopicSupplier {
+func NewSNSTopicSupplier(provider *AWSTerraformProvider) *SNSTopicSupplier {
 	return &SNSTopicSupplier{
 		provider,
 		awsdeserializer.NewSNSTopicDeserializer(),

--- a/pkg/remote/aws/sns_topic_supplier_test.go
+++ b/pkg/remote/aws/sns_topic_supplier_test.go
@@ -73,12 +73,10 @@ func TestSNSTopicSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewSNSTopicSupplier(provider))
 		}
 

--- a/pkg/remote/aws/sqs_queue_policy_supplier.go
+++ b/pkg/remote/aws/sqs_queue_policy_supplier.go
@@ -19,7 +19,7 @@ type SqsQueuePolicySupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewSqsQueuePolicySupplier(provider *TerraformProvider) *SqsQueuePolicySupplier {
+func NewSqsQueuePolicySupplier(provider *AWSTerraformProvider) *SqsQueuePolicySupplier {
 	return &SqsQueuePolicySupplier{
 		provider,
 		awsdeserializer.NewSqsQueuePolicyDeserializer(),

--- a/pkg/remote/aws/sqs_queue_policy_supplier_test.go
+++ b/pkg/remote/aws/sqs_queue_policy_supplier_test.go
@@ -67,12 +67,10 @@ func TestSqsQueuePolicySupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewSqsQueuePolicySupplier(provider))
 		}
 

--- a/pkg/remote/aws/sqs_queue_supplier.go
+++ b/pkg/remote/aws/sqs_queue_supplier.go
@@ -19,7 +19,7 @@ type SqsQueueSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewSqsQueueSupplier(provider *TerraformProvider) *SqsQueueSupplier {
+func NewSqsQueueSupplier(provider *AWSTerraformProvider) *SqsQueueSupplier {
 	return &SqsQueueSupplier{
 		provider,
 		awsdeserializer.NewSqsQueueDeserializer(),

--- a/pkg/remote/aws/sqs_queue_supplier_test.go
+++ b/pkg/remote/aws/sqs_queue_supplier_test.go
@@ -64,12 +64,10 @@ func TestSqsQueueSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewSqsQueueSupplier(provider))
 		}
 

--- a/pkg/remote/aws/subnet_supplier.go
+++ b/pkg/remote/aws/subnet_supplier.go
@@ -25,7 +25,7 @@ type SubnetSupplier struct {
 	subnetRunner              *terraform.ParallelResourceReader
 }
 
-func NewSubnetSupplier(provider *TerraformProvider) *SubnetSupplier {
+func NewSubnetSupplier(provider *AWSTerraformProvider) *SubnetSupplier {
 	return &SubnetSupplier{
 		provider,
 		awsdeserializer.NewDefaultSubnetDeserializer(),

--- a/pkg/remote/aws/subnet_supplier_test.go
+++ b/pkg/remote/aws/subnet_supplier_test.go
@@ -115,12 +115,10 @@ func TestSubnetSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewSubnetSupplier(provider))
 		}
 

--- a/pkg/remote/aws/vpc_security_group_rule_supplier.go
+++ b/pkg/remote/aws/vpc_security_group_rule_supplier.go
@@ -29,7 +29,7 @@ type VPCSecurityGroupRuleSupplier struct {
 	runner       *terraform.ParallelResourceReader
 }
 
-func NewVPCSecurityGroupRuleSupplier(provider *TerraformProvider) *VPCSecurityGroupRuleSupplier {
+func NewVPCSecurityGroupRuleSupplier(provider *AWSTerraformProvider) *VPCSecurityGroupRuleSupplier {
 	return &VPCSecurityGroupRuleSupplier{
 		provider,
 		awsdeserializer.NewVPCSecurityGroupRuleDeserializer(),

--- a/pkg/remote/aws/vpc_security_group_rule_supplier_test.go
+++ b/pkg/remote/aws/vpc_security_group_rule_supplier_test.go
@@ -240,12 +240,10 @@ func TestVPCSecurityGroupRuleSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewVPCSecurityGroupRuleSupplier(provider))
 		}
 

--- a/pkg/remote/aws/vpc_security_group_supplier.go
+++ b/pkg/remote/aws/vpc_security_group_supplier.go
@@ -25,7 +25,7 @@ type VPCSecurityGroupSupplier struct {
 	securityGroupRunner              *terraform.ParallelResourceReader
 }
 
-func NewVPCSecurityGroupSupplier(provider *TerraformProvider) *VPCSecurityGroupSupplier {
+func NewVPCSecurityGroupSupplier(provider *AWSTerraformProvider) *VPCSecurityGroupSupplier {
 	return &VPCSecurityGroupSupplier{
 		provider,
 		awsdeserializer.NewDefaultSecurityGroupDeserializer(),

--- a/pkg/remote/aws/vpc_security_group_supplier_test.go
+++ b/pkg/remote/aws/vpc_security_group_supplier_test.go
@@ -91,12 +91,10 @@ func TestVPCSecurityGroupSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewVPCSecurityGroupSupplier(provider))
 		}
 

--- a/pkg/remote/aws/vpc_supplier.go
+++ b/pkg/remote/aws/vpc_supplier.go
@@ -25,7 +25,7 @@ type VPCSupplier struct {
 	vpcRunner              *terraform.ParallelResourceReader
 }
 
-func NewVPCSupplier(provider *TerraformProvider) *VPCSupplier {
+func NewVPCSupplier(provider *AWSTerraformProvider) *VPCSupplier {
 	return &VPCSupplier{
 		provider,
 		awsdeserializer.NewDefaultVPCDeserializer(),

--- a/pkg/remote/aws/vpc_supplier_test.go
+++ b/pkg/remote/aws/vpc_supplier_test.go
@@ -105,12 +105,10 @@ func TestVPCSupplier_Resources(t *testing.T) {
 		supplierLibrary := resource.NewSupplierLibrary()
 
 		if shouldUpdate {
-			provider, err := NewTerraFormProvider()
+			provider, err := InitTestAwsProvider(providerLibrary)
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			providerLibrary.AddProvider(terraform.AWS, provider)
 			supplierLibrary.AddSupplier(NewVPCSupplier(provider))
 		}
 

--- a/pkg/terraform/provider_factory.go
+++ b/pkg/terraform/provider_factory.go
@@ -5,7 +5,7 @@ import (
 	"github.com/hashicorp/terraform/plugin/discovery"
 )
 
-func NewTerraformProvider(meta discovery.PluginMeta) (*plugin.GRPCProvider, error) {
+func NewGRPCProvider(meta discovery.PluginMeta) (*plugin.GRPCProvider, error) {
 	client := Client(meta)
 	// Request the RPC terraformProvider so we can get the provider
 	// so we can build the actual RPC-implemented provider.


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #213 
| ❓ Documentation  | no

## Description

Remove all related aws stuff from `TerraformProvider` and create an `AWSTerraformProvider`

⚠️ Architecture review please @moadibfr @wbeuil. I splitted commits in small reviewable parts.