### PR TITLE
Warn on unmanaged security group rules

### DIFF
--- a/doc/LIMITATIONS.md
+++ b/doc/LIMITATIONS.md
@@ -11,3 +11,10 @@
 - Terraform version >= 0.12 is supported
 - Terraform AWS provider version >= 3.x is supported
 
+## Terraform Resources
+
+### AWS
+
+- aws_security_group and aws_security_group_rule:
+
+For security group that has in-line egress or ingress rules, driftctl will output an alert message at the end of the scan to warn you that those rules are falsely unmanaged. The explanation is that we can't distinct, based only on the Terraform state, rules created in the console and rules created in-line in either egress or ingress blocks.

--- a/pkg/analyser/analyzer_test.go
+++ b/pkg/analyser/analyzer_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cloudskiff/driftctl/pkg/alerter"
 	"github.com/cloudskiff/driftctl/pkg/resource"
+	"github.com/cloudskiff/driftctl/pkg/resource/aws"
 
 	"github.com/r3labs/diff/v2"
 
@@ -876,6 +877,47 @@ func TestAnalyze(t *testing.T) {
 					"": {
 						{
 							Message: "You have diffs on computed fields, check the documentation for potential false positive drifts",
+						},
+					},
+				},
+			},
+			hasDrifted: true,
+		},
+		{
+			name: "Test alert on unmanaged security group rules",
+			iac: []resource.Resource{
+				&aws.AwsSecurityGroup{
+					Id: "managed security group",
+				},
+			},
+			cloud: []resource.Resource{
+				&aws.AwsSecurityGroup{
+					Id: "managed security group",
+				},
+				&aws.AwsSecurityGroupRule{
+					Id: "unmanaged rule",
+				},
+			},
+			expected: Analysis{
+				managed: []resource.Resource{
+					&aws.AwsSecurityGroup{
+						Id: "managed security group",
+					},
+				},
+				unmanaged: []resource.Resource{
+					&aws.AwsSecurityGroupRule{
+						Id: "unmanaged rule",
+					},
+				},
+				summary: Summary{
+					TotalResources: 2,
+					TotalManaged:   1,
+					TotalUnmanaged: 1,
+				},
+				alerts: alerter.Alerts{
+					"": {
+						{
+							Message: "You have unmanaged security group rules that could be false positives, find out more at https://github.com/cloudskiff/driftctl/blob/main/doc/LIMITATIONS.md#terraform-resources",
 						},
 					},
 				},


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #8
| ❓ Documentation  | yes

## Description

Unmanaged security group rules can be falsely displayed as unmanaged in driftctl scan output. Simply because it's impossible, by only reading the state, to be sure that those rules were created by terraform. Indeed terraform re-writes on apply/refresh the state with all the rules a security group has in AWS if you don't use the egress/ingress in-line blocks. We decided to warn our users if we found rules that were not created with the aws_security_group_rule resource.

![image](https://user-images.githubusercontent.com/8110579/107961436-33d84d80-6fa6-11eb-86fa-3b0c47c4f92b.png)
