### PR TITLE
Add homebrew bump formula github action on release event

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,15 +132,6 @@ jobs:
           name: "Update Lambda version"
           command: |
             aws lambda update-function-configuration --function-name $FUNCTION_NAME --environment "{\"Variables\":{\"LATEST_VERSION\":\"$CIRCLE_TAG\"}}"
-  bump-homebrew-core:
-    macos:
-      xcode: 12.3.0
-    steps:
-      - run:
-          name: "Bump driftctl formula"
-          command: |
-            brew install-bundler-gems -d -v
-            brew bump-formula-pr driftctl --url https://github.com/cloudskiff/driftctl/archive/$CIRCLE_TAG.tar.gz -d -v
 workflows:
   nightly:
     jobs:
@@ -214,15 +205,6 @@ workflows:
               ignore: /.*/
       - update-lambda:
           context: driftctl-version-lambda
-          requires:
-            - release
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-      - bump-homebrew-core:
-          context: driftctl-homebrew
           requires:
             - release
           filters:

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,12 @@
+name: Homebrew Bump Formula
+on:
+  release:
+    types: [published]
+jobs:
+  homebrew:
+    runs-on: macos-latest
+    steps:
+      - uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          formula: driftctl


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Change the automation of the homebrew bump formula pipeline from CircleCI to GitHub Actions.