### PR TITLE
Point to the policy for driftctl when an access denied is encountered

### DIFF
--- a/pkg/alerter/alert.go
+++ b/pkg/alerter/alert.go
@@ -1,8 +1,53 @@
 package alerter
 
+import "encoding/json"
+
 type Alerts map[string][]Alert
 
-type Alert struct {
-	Message              string `json:"message"`
-	ShouldIgnoreResource bool   `json:"-"`
+type Alert interface {
+	Message() string
+	ShouldIgnoreResource() bool
+}
+
+type FakeAlert struct {
+	Msg            string
+	IgnoreResource bool
+}
+
+func (f *FakeAlert) Message() string {
+	return f.Msg
+}
+
+func (f *FakeAlert) ShouldIgnoreResource() bool {
+	return f.IgnoreResource
+}
+
+type SerializableAlert struct {
+	Alert
+}
+
+type SerializedAlert struct {
+	Msg string `json:"message"`
+}
+
+func (u *SerializedAlert) Message() string {
+	return u.Msg
+}
+
+func (u *SerializedAlert) ShouldIgnoreResource() bool {
+	return false
+}
+
+func (s *SerializableAlert) UnmarshalJSON(bytes []byte) error {
+	var res SerializedAlert
+
+	if err := json.Unmarshal(bytes, &res); err != nil {
+		return err
+	}
+	s.Alert = &res
+	return nil
+}
+
+func (s *SerializableAlert) MarshalJSON() ([]byte, error) {
+	return json.Marshal(SerializedAlert{Msg: s.Message()})
 }

--- a/pkg/alerter/alerter.go
+++ b/pkg/alerter/alerter.go
@@ -67,7 +67,7 @@ func (a *Alerter) IsResourceIgnored(res resource.Resource) bool {
 
 func (a *Alerter) shouldBeIgnored(alert []Alert) bool {
 	for _, a := range alert {
-		if a.ShouldIgnoreResource {
+		if a.ShouldIgnoreResource() {
 			return true
 		}
 	}

--- a/pkg/alerter/alerter_test.go
+++ b/pkg/alerter/alerter_test.go
@@ -23,18 +23,12 @@ func TestAlerter_Alert(t *testing.T) {
 			name: "TestWithSingleAlert",
 			alerts: Alerts{
 				"fakeres.foobar": []Alert{
-					{
-						Message:              "This is an alert",
-						ShouldIgnoreResource: false,
-					},
+					&FakeAlert{"This is an alert", false},
 				},
 			},
 			expected: Alerts{
 				"fakeres.foobar": []Alert{
-					{
-						Message:              "This is an alert",
-						ShouldIgnoreResource: false,
-					},
+					&FakeAlert{"This is an alert", false},
 				},
 			},
 		},
@@ -42,38 +36,20 @@ func TestAlerter_Alert(t *testing.T) {
 			name: "TestWithMultipleAlerts",
 			alerts: Alerts{
 				"fakeres.foobar": []Alert{
-					{
-						Message:              "This is an alert",
-						ShouldIgnoreResource: false,
-					},
-					{
-						Message:              "This is a second alert",
-						ShouldIgnoreResource: true,
-					},
+					&FakeAlert{"This is an alert", false},
+					&FakeAlert{"This is a second alert", true},
 				},
 				"fakeres.barfoo": []Alert{
-					{
-						Message:              "This is a third alert",
-						ShouldIgnoreResource: true,
-					},
+					&FakeAlert{"This is a third alert", true},
 				},
 			},
 			expected: Alerts{
 				"fakeres.foobar": []Alert{
-					{
-						Message:              "This is an alert",
-						ShouldIgnoreResource: false,
-					},
-					{
-						Message:              "This is a second alert",
-						ShouldIgnoreResource: true,
-					},
+					&FakeAlert{"This is an alert", false},
+					&FakeAlert{"This is a second alert", true},
 				},
 				"fakeres.barfoo": []Alert{
-					{
-						Message:              "This is a third alert",
-						ShouldIgnoreResource: true,
-					},
+					&FakeAlert{"This is a third alert", true},
 				},
 			},
 		},
@@ -116,24 +92,16 @@ func TestAlerter_IgnoreResources(t *testing.T) {
 			name: "TestShouldNotBeIgnoredWithAlerts",
 			alerts: Alerts{
 				"fakeres": {
-					{
-						Message: "Should not be ignored",
-					},
+					&FakeAlert{"Should not be ignored", false},
 				},
 				"fakeres.foobar": {
-					{
-						Message: "Should not be ignored",
-					},
+					&FakeAlert{"Should not be ignored", false},
 				},
 				"fakeres.barfoo": {
-					{
-						Message: "Should not be ignored",
-					},
+					&FakeAlert{"Should not be ignored", false},
 				},
 				"other.resource": {
-					{
-						Message: "Should not be ignored",
-					},
+					&FakeAlert{"Should not be ignored", false},
 				},
 			},
 			resource: &resource2.FakeResource{
@@ -146,21 +114,13 @@ func TestAlerter_IgnoreResources(t *testing.T) {
 			name: "TestShouldBeIgnoredWithAlertsOnWildcard",
 			alerts: Alerts{
 				"fakeres": {
-					{
-						Message:              "Should be ignored",
-						ShouldIgnoreResource: true,
-					},
+					&FakeAlert{"Should be ignored", true},
 				},
 				"other.foobaz": {
-					{
-						Message:              "Should be ignored",
-						ShouldIgnoreResource: true,
-					},
+					&FakeAlert{"Should be ignored", true},
 				},
 				"other.resource": {
-					{
-						Message: "Should not be ignored",
-					},
+					&FakeAlert{"Should not be ignored", false},
 				},
 			},
 			resource: &resource2.FakeResource{
@@ -173,21 +133,13 @@ func TestAlerter_IgnoreResources(t *testing.T) {
 			name: "TestShouldBeIgnoredWithAlertsOnResource",
 			alerts: Alerts{
 				"fakeres": {
-					{
-						Message:              "Should be ignored",
-						ShouldIgnoreResource: true,
-					},
+					&FakeAlert{"Should be ignored", true},
 				},
 				"other.foobaz": {
-					{
-						Message:              "Should be ignored",
-						ShouldIgnoreResource: true,
-					},
+					&FakeAlert{"Should be ignored", true},
 				},
 				"other.resource": {
-					{
-						Message: "Should not be ignored",
-					},
+					&FakeAlert{"Should not be ignored", false},
 				},
 			},
 			resource: &resource2.FakeResource{

--- a/pkg/analyser/analyzer.go
+++ b/pkg/analyser/analyzer.go
@@ -11,6 +11,34 @@ import (
 	"github.com/r3labs/diff/v2"
 )
 
+type UnmanagedSecurityGroupRulesAlert struct{}
+
+func newUnmanagedSecurityGroupRulesAlert() *UnmanagedSecurityGroupRulesAlert {
+	return &UnmanagedSecurityGroupRulesAlert{}
+}
+
+func (u *UnmanagedSecurityGroupRulesAlert) Message() string {
+	return "You have unmanaged security group rules that could be false positives, find out more at https://github.com/cloudskiff/driftctl/blob/main/doc/LIMITATIONS.md#terraform-resources"
+}
+
+func (u *UnmanagedSecurityGroupRulesAlert) ShouldIgnoreResource() bool {
+	return false
+}
+
+type ComputedDiffAlert struct{}
+
+func NewComputedDiffAlert() *ComputedDiffAlert {
+	return &ComputedDiffAlert{}
+}
+
+func (c *ComputedDiffAlert) Message() string {
+	return "You have diffs on computed fields, check the documentation for potential false positive drifts"
+}
+
+func (c *ComputedDiffAlert) ShouldIgnoreResource() bool {
+	return false
+}
+
 type Analyzer struct {
 	alerter *alerter.Alerter
 }
@@ -80,17 +108,11 @@ func (a Analyzer) Analyze(remoteResources, resourcesFromState []resource.Resourc
 	}
 
 	if a.hasUnmanagedSecurityGroupRules(filteredRemoteResource) {
-		a.alerter.SendAlert("",
-			alerter.Alert{
-				Message: "You have unmanaged security group rules that could be false positives, find out more at https://github.com/cloudskiff/driftctl/blob/main/doc/LIMITATIONS.md#terraform-resources",
-			})
+		a.alerter.SendAlert("", newUnmanagedSecurityGroupRulesAlert())
 	}
 
 	if haveComputedDiff {
-		a.alerter.SendAlert("",
-			alerter.Alert{
-				Message: "You have diffs on computed fields, check the documentation for potential false positive drifts",
-			})
+		a.alerter.SendAlert("", NewComputedDiffAlert())
 	}
 
 	// Add remaining unmanaged resources

--- a/pkg/analyser/analyzer_test.go
+++ b/pkg/analyser/analyzer_test.go
@@ -272,9 +272,7 @@ func TestAnalyze(t *testing.T) {
 				},
 				alerts: alerter.Alerts{
 					"": {
-						{
-							Message: "You have diffs on computed fields, check the documentation for potential false positive drifts",
-						},
+						NewComputedDiffAlert(),
 					},
 				},
 			},
@@ -351,9 +349,7 @@ func TestAnalyze(t *testing.T) {
 				},
 				alerts: alerter.Alerts{
 					"": {
-						{
-							Message: "You have diffs on computed fields, check the documentation for potential false positive drifts",
-						},
+						NewComputedDiffAlert(),
 					},
 				},
 			},
@@ -520,21 +516,13 @@ func TestAnalyze(t *testing.T) {
 			},
 			alerts: alerter.Alerts{
 				"fakeres": {
-					{
-						Message:              "Should be ignored",
-						ShouldIgnoreResource: true,
-					},
+					&alerter.FakeAlert{Msg: "Should be ignored", IgnoreResource: true},
 				},
 				"other.foobaz": {
-					{
-						Message:              "Should be ignored",
-						ShouldIgnoreResource: true,
-					},
+					&alerter.FakeAlert{Msg: "Should be ignored", IgnoreResource: true},
 				},
 				"other.resource": {
-					{
-						Message: "Should not be ignored",
-					},
+					&alerter.FakeAlert{Msg: "Should not be ignored"},
 				},
 			},
 			expected: Analysis{
@@ -656,26 +644,16 @@ func TestAnalyze(t *testing.T) {
 				},
 				alerts: alerter.Alerts{
 					"fakeres": {
-						{
-							Message:              "Should be ignored",
-							ShouldIgnoreResource: true,
-						},
+						&alerter.FakeAlert{Msg: "Should be ignored", IgnoreResource: true},
 					},
 					"other.foobaz": {
-						{
-							Message:              "Should be ignored",
-							ShouldIgnoreResource: true,
-						},
+						&alerter.FakeAlert{Msg: "Should be ignored", IgnoreResource: true},
 					},
 					"other.resource": {
-						{
-							Message: "Should not be ignored",
-						},
+						&alerter.FakeAlert{Msg: "Should not be ignored"},
 					},
 					"": {
-						{
-							Message: "You have diffs on computed fields, check the documentation for potential false positive drifts",
-						},
+						NewComputedDiffAlert(),
 					},
 				},
 			},
@@ -875,9 +853,7 @@ func TestAnalyze(t *testing.T) {
 				},
 				alerts: alerter.Alerts{
 					"": {
-						{
-							Message: "You have diffs on computed fields, check the documentation for potential false positive drifts",
-						},
+						NewComputedDiffAlert(),
 					},
 				},
 			},
@@ -916,9 +892,7 @@ func TestAnalyze(t *testing.T) {
 				},
 				alerts: alerter.Alerts{
 					"": {
-						{
-							Message: "You have unmanaged security group rules that could be false positives, find out more at https://github.com/cloudskiff/driftctl/blob/main/doc/LIMITATIONS.md#terraform-resources",
-						},
+						newUnmanagedSecurityGroupRulesAlert(),
 					},
 				},
 			},
@@ -1069,9 +1043,7 @@ func TestAnalysis_MarshalJSON(t *testing.T) {
 	})
 	analysis.SetAlerts(alerter.Alerts{
 		"aws_iam_access_key": {
-			{
-				Message: "This is an alert",
-			},
+			&alerter.FakeAlert{Msg: "This is an alert"},
 		},
 	})
 
@@ -1151,8 +1123,8 @@ func TestAnalysis_UnmarshalJSON(t *testing.T) {
 		},
 		alerts: alerter.Alerts{
 			"aws_iam_access_key": {
-				{
-					Message: "This is an alert",
+				&alerter.SerializedAlert{
+					Msg: "This is an alert",
 				},
 			},
 		},
@@ -1174,4 +1146,6 @@ func TestAnalysis_UnmarshalJSON(t *testing.T) {
 	assert.Equal(t, 2, got.Summary().TotalDeleted)
 	assert.Equal(t, 6, got.Summary().TotalResources)
 	assert.Equal(t, 1, got.Summary().TotalDrifted)
+	assert.Len(t, got.alerts, 1)
+	assert.Equal(t, got.alerts["aws_iam_access_key"][0].Message(), "This is an alert")
 }

--- a/pkg/cmd/scan/output/console.go
+++ b/pkg/cmd/scan/output/console.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/cloudskiff/driftctl/pkg/remote"
+
 	"github.com/cloudskiff/driftctl/pkg/analyser"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	"github.com/fatih/color"
@@ -93,10 +95,19 @@ func (c *Console) Write(analysis *analyser.Analysis) error {
 
 	c.writeSummary(analysis)
 
+	policy := false
 	for _, alerts := range analysis.Alerts() {
 		for _, alert := range alerts {
-			fmt.Printf("%s\n", color.YellowString(alert.Message))
+			fmt.Printf("%s\n", color.YellowString(alert.Message()))
+
+			if _, ok := alert.(*remote.EnumerationAccessDeniedAlert); ok {
+				policy = true
+			}
 		}
+	}
+
+	if policy {
+		fmt.Println(color.YellowString("\nThe latest minimal read-only policy for driftctl is always available here, please update yours: https://github.com/cloudskiff/driftctl/blob/main/doc/cmd/scan/supported_resources/aws.md"))
 	}
 
 	return nil

--- a/pkg/cmd/scan/output/console_test.go
+++ b/pkg/cmd/scan/output/console_test.go
@@ -55,6 +55,12 @@ func TestConsole_Write(t *testing.T) {
 			args:       args{analysis: fakeAnalysisWithComputedFields()},
 			wantErr:    false,
 		},
+		{
+			name:       "test console output with enumeration alerts",
+			goldenfile: "output_access_denied_alert.txt",
+			args:       args{analysis: fakeAnalysisWithEnumerationError()},
+			wantErr:    false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/scan/output/json_test.go
+++ b/pkg/cmd/scan/output/json_test.go
@@ -38,6 +38,14 @@ func TestJSON_Write(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:       "test json output with enumeration alerts",
+			goldenfile: "output_access_denied_alert.json",
+			args: args{
+				analysis: fakeAnalysisWithEnumerationError(),
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cloudskiff/driftctl/pkg/alerter"
 	"github.com/cloudskiff/driftctl/pkg/analyser"
+	"github.com/cloudskiff/driftctl/pkg/remote"
 	testresource "github.com/cloudskiff/driftctl/test/resource"
 	"github.com/r3labs/diff/v2"
 )
@@ -230,9 +231,19 @@ func fakeAnalysisWithComputedFields() *analyser.Analysis {
 	}})
 	a.SetAlerts(alerter.Alerts{
 		"": []alerter.Alert{
-			{
-				Message: "You have diffs on computed fields, check the documentation for potential false positive drifts",
-			},
+			analyser.NewComputedDiffAlert(),
+		},
+	})
+	return &a
+}
+
+func fakeAnalysisWithEnumerationError() *analyser.Analysis {
+	a := analyser.Analysis{}
+	a.SetAlerts(alerter.Alerts{
+		"": []alerter.Alert{
+			remote.NewEnumerationAccessDeniedAlert("aws_vpc", "aws_vpc"),
+			remote.NewEnumerationAccessDeniedAlert("aws_sqs", "aws_sqs"),
+			remote.NewEnumerationAccessDeniedAlert("aws_sns", "aws_sns"),
 		},
 	})
 	return &a

--- a/pkg/cmd/scan/output/testdata/output_access_denied_alert.json
+++ b/pkg/cmd/scan/output/testdata/output_access_denied_alert.json
@@ -1,0 +1,27 @@
+{
+	"summary": {
+		"total_resources": 0,
+		"total_drifted": 0,
+		"total_unmanaged": 0,
+		"total_deleted": 0,
+		"total_managed": 0
+	},
+	"managed": null,
+	"unmanaged": null,
+	"deleted": null,
+	"differences": null,
+	"coverage": 0,
+	"alerts": {
+		"": [
+			{
+				"message": "Ignoring aws_vpc from drift calculation: Listing aws_vpc is forbidden."
+			},
+			{
+				"message": "Ignoring aws_sqs from drift calculation: Listing aws_sqs is forbidden."
+			},
+			{
+				"message": "Ignoring aws_sns from drift calculation: Listing aws_sns is forbidden."
+			}
+		]
+	}
+}

--- a/pkg/cmd/scan/output/testdata/output_access_denied_alert.txt
+++ b/pkg/cmd/scan/output/testdata/output_access_denied_alert.txt
@@ -1,0 +1,8 @@
+Found 0 resource(s)
+ - 0% coverage
+Congrats! Your infrastructure is fully in sync.
+Ignoring aws_vpc from drift calculation: Listing aws_vpc is forbidden.
+Ignoring aws_sqs from drift calculation: Listing aws_sqs is forbidden.
+Ignoring aws_sns from drift calculation: Listing aws_sns is forbidden.
+
+The latest minimal read-only policy for driftctl is always available here, please update yours: https://github.com/cloudskiff/driftctl/blob/main/doc/cmd/scan/supported_resources/aws.md

--- a/pkg/middlewares/aws_route_table_expander_test.go
+++ b/pkg/middlewares/aws_route_table_expander_test.go
@@ -7,7 +7,6 @@ import (
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awsutil"
 	"github.com/cloudskiff/driftctl/mocks"
-	"github.com/cloudskiff/driftctl/pkg/alerter"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	"github.com/cloudskiff/driftctl/pkg/resource/aws"
 	resource2 "github.com/cloudskiff/driftctl/test/resource"
@@ -215,12 +214,12 @@ func TestAwsRouteTableExpander_Execute(t *testing.T) {
 func TestAwsRouteTableExpander_ExecuteWithInvalidRoutes(t *testing.T) {
 
 	mockedAlerter := &mocks.AlerterInterface{}
-	mockedAlerter.On("SendAlert", aws.AwsRouteTableResourceType, alerter.Alert{
-		Message: "Skipped invalid route found in state for aws_route_table.table_from_state",
-	})
-	mockedAlerter.On("SendAlert", aws.AwsDefaultRouteTableResourceType, alerter.Alert{
-		Message: "Skipped invalid route found in state for aws_default_route_table.default_table_from_state",
-	})
+	mockedAlerter.On("SendAlert", aws.AwsRouteTableResourceType, newInvalidRouteAlert(
+		"aws_route_table", "table_from_state",
+	))
+	mockedAlerter.On("SendAlert", aws.AwsDefaultRouteTableResourceType, newInvalidRouteAlert(
+		"aws_default_route_table", "default_table_from_state",
+	))
 
 	input := []resource.Resource{
 		&aws.AwsRouteTable{

--- a/pkg/remote/resource_enumeration_error_handler.go
+++ b/pkg/remote/resource_enumeration_error_handler.go
@@ -4,13 +4,29 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/cloudskiff/driftctl/pkg/alerter"
+	"github.com/sirupsen/logrus"
 )
+
+type EnumerationAccessDeniedAlert struct {
+	message string
+}
+
+func NewEnumerationAccessDeniedAlert(supplierType, listedTypeError string) *EnumerationAccessDeniedAlert {
+	message := fmt.Sprintf("Ignoring %s from drift calculation: Listing %s is forbidden.", supplierType, listedTypeError)
+	return &EnumerationAccessDeniedAlert{message}
+}
+
+func (e *EnumerationAccessDeniedAlert) Message() string {
+	return e.message
+}
+
+func (e *EnumerationAccessDeniedAlert) ShouldIgnoreResource() bool {
+	return true
+}
 
 func HandleResourceEnumerationError(err error, alertr *alerter.Alerter) error {
 	listError, ok := err.(*remoteerror.ResourceEnumerationError)
@@ -24,12 +40,11 @@ func HandleResourceEnumerationError(err error, alertr *alerter.Alerter) error {
 	}
 
 	if reqerr.StatusCode() == 403 || (reqerr.StatusCode() == 400 && strings.Contains(reqerr.Code(), "AccessDenied")) {
-		message := fmt.Sprintf("Ignoring %s from drift calculation: Listing %s is forbidden.", listError.SupplierType(), listError.ListedTypeError())
-		logrus.Debugf(message)
-		alertr.SendAlert(listError.SupplierType(), alerter.Alert{
-			Message:              message,
-			ShouldIgnoreResource: true,
-		})
+		logrus.WithFields(logrus.Fields{
+			"supplier_type": listError.SupplierType(),
+			"listed_type":   listError.ListedTypeError(),
+		}).Debugf("Got an access denied error")
+		alertr.SendAlert(listError.SupplierType(), NewEnumerationAccessDeniedAlert(listError.SupplierType(), listError.ListedTypeError()))
 		return nil
 	}
 

--- a/pkg/remote/resource_enumeration_error_handler_test.go
+++ b/pkg/remote/resource_enumeration_error_handler_test.go
@@ -25,13 +25,13 @@ func TestHandleListAwsError(t *testing.T) {
 		{
 			name:       "Handled error 403",
 			err:        remoteerror.NewResourceEnumerationError(awserr.NewRequestFailure(awserr.New("", "", errors.New("")), 403, ""), resourceaws.AwsVpcResourceType),
-			wantAlerts: alerter.Alerts{"aws_vpc": []alerter.Alert{alerter.Alert{Message: "Ignoring aws_vpc from drift calculation: Listing aws_vpc is forbidden.", ShouldIgnoreResource: true}}},
+			wantAlerts: alerter.Alerts{"aws_vpc": []alerter.Alert{NewEnumerationAccessDeniedAlert("aws_vpc", "aws_vpc")}},
 			wantErr:    false,
 		},
 		{
 			name:       "Handled error AccessDenied",
 			err:        remoteerror.NewResourceEnumerationError(awserr.NewRequestFailure(awserr.New("AccessDeniedException", "", errors.New("")), 403, ""), resourceaws.AwsDynamodbTableResourceType),
-			wantAlerts: alerter.Alerts{"aws_dynamodb_table": []alerter.Alert{alerter.Alert{Message: "Ignoring aws_dynamodb_table from drift calculation: Listing aws_dynamodb_table is forbidden.", ShouldIgnoreResource: true}}},
+			wantAlerts: alerter.Alerts{"aws_dynamodb_table": []alerter.Alert{NewEnumerationAccessDeniedAlert("aws_dynamodb_table", "aws_dynamodb_table")}},
 			wantErr:    false,
 		},
 		{


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #226 
| ❓ Documentation  | no

## Description

I modified the composition of the alerts to make it an interface and be able to interact with its type. We can now display the latest up-to-date policy of driftctl if we encounter a denial of access on a resource, specified by its alert.
These changes led me to retouch the tests and add serialisation on the alerts for the JSON marshal part.

I am open to any remark or discussion.