### PR TITLE
New Homebrew Secrets

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -8,5 +8,5 @@ jobs:
     steps:
       - uses: dawidd6/action-homebrew-bump-formula@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           formula: driftctl


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Homebrew auto bump formula failed last friday because of the token used. I created a new homebrew github api token on the organization level with our internal account for driftctl and change the yml file to use this secrets.