### PR TITLE
Update Cloudfront distribution normalization

### DIFF
--- a/pkg/iac/terraform/state/test/cloudfront_distribution/result.golden.json
+++ b/pkg/iac/terraform/state/test/cloudfront_distribution/result.golden.json
@@ -63,7 +63,81 @@
    }
   ],
   "LoggingConfig": [],
-  "OrderedCacheBehavior": [],
+  "OrderedCacheBehavior": [
+   {
+    "AllowedMethods": [
+     "GET",
+     "HEAD",
+     "OPTIONS"
+    ],
+    "CachedMethods": [
+     "GET",
+     "HEAD",
+     "OPTIONS"
+    ],
+    "Compress": true,
+    "DefaultTtl": 86400,
+    "FieldLevelEncryptionId": null,
+    "MaxTtl": 31536000,
+    "MinTtl": 0,
+    "PathPattern": "/content/immutable/*",
+    "SmoothStreaming": false,
+    "TargetOriginId": "S3-foo-cloudfront",
+    "TrustedSigners": null,
+    "ViewerProtocolPolicy": "redirect-to-https",
+    "ForwardedValues": [
+     {
+      "Headers": [
+       "Origin"
+      ],
+      "QueryString": false,
+      "QueryStringCacheKeys": null,
+      "Cookies": [
+       {
+        "Forward": "none",
+        "WhitelistedNames": null
+       }
+      ]
+     }
+    ],
+    "LambdaFunctionAssociation": null
+   },
+   {
+    "AllowedMethods": [
+     "GET",
+     "HEAD",
+     "OPTIONS"
+    ],
+    "CachedMethods": [
+     "GET",
+     "HEAD"
+    ],
+    "Compress": true,
+    "DefaultTtl": 3600,
+    "FieldLevelEncryptionId": null,
+    "MaxTtl": 86400,
+    "MinTtl": 0,
+    "PathPattern": "/content/*",
+    "SmoothStreaming": false,
+    "TargetOriginId": "S3-foo-cloudfront",
+    "TrustedSigners": null,
+    "ViewerProtocolPolicy": "redirect-to-https",
+    "ForwardedValues": [
+     {
+      "Headers": null,
+      "QueryString": false,
+      "QueryStringCacheKeys": null,
+      "Cookies": [
+       {
+        "Forward": "none",
+        "WhitelistedNames": null
+       }
+      ]
+     }
+    ],
+    "LambdaFunctionAssociation": null
+   }
+  ],
   "Origin": [
    {
     "DomainName": "foo-cloudfront.s3.eu-west-3.amazonaws.com",

--- a/pkg/iac/terraform/state/test/cloudfront_distribution/terraform.tfstate
+++ b/pkg/iac/terraform/state/test/cloudfront_distribution/terraform.tfstate
@@ -65,7 +65,81 @@
             "is_ipv6_enabled": false,
             "last_modified_time": "2021-02-16 10:17:35.404 +0000 UTC",
             "logging_config": [],
-            "ordered_cache_behavior": [],
+            "ordered_cache_behavior": [
+              {
+                "allowed_methods": [
+                  "GET",
+                  "HEAD",
+                  "OPTIONS"
+                ],
+                "cached_methods": [
+                  "GET",
+                  "HEAD",
+                  "OPTIONS"
+                ],
+                "compress": true,
+                "default_ttl": 86400,
+                "field_level_encryption_id": "",
+                "forwarded_values": [
+                  {
+                    "cookies": [
+                      {
+                        "forward": "none",
+                        "whitelisted_names": null
+                      }
+                    ],
+                    "headers": [
+                      "Origin"
+                    ],
+                    "query_string": false,
+                    "query_string_cache_keys": null
+                  }
+                ],
+                "lambda_function_association": [],
+                "max_ttl": 31536000,
+                "min_ttl": 0,
+                "path_pattern": "/content/immutable/*",
+                "smooth_streaming": false,
+                "target_origin_id": "S3-foo-cloudfront",
+                "trusted_signers": [],
+                "viewer_protocol_policy": "redirect-to-https"
+              },
+              {
+                "allowed_methods": [
+                  "GET",
+                  "HEAD",
+                  "OPTIONS"
+                ],
+                "cached_methods": [
+                  "GET",
+                  "HEAD"
+                ],
+                "compress": true,
+                "default_ttl": 3600,
+                "field_level_encryption_id": "",
+                "forwarded_values": [
+                  {
+                    "cookies": [
+                      {
+                        "forward": "none",
+                        "whitelisted_names": null
+                      }
+                    ],
+                    "headers": null,
+                    "query_string": false,
+                    "query_string_cache_keys": null
+                  }
+                ],
+                "lambda_function_association": [],
+                "max_ttl": 86400,
+                "min_ttl": 0,
+                "path_pattern": "/content/*",
+                "smooth_streaming": false,
+                "target_origin_id": "S3-foo-cloudfront",
+                "trusted_signers": null,
+                "viewer_protocol_policy": "redirect-to-https"
+              }
+            ],
             "origin": [
               {
                 "custom_header": [],

--- a/pkg/resource/aws/aws_cloudfront_distribution_ext.go
+++ b/pkg/resource/aws/aws_cloudfront_distribution_ext.go
@@ -52,4 +52,34 @@ func (r *AwsCloudfrontDistribution) normalizeNilPtr() {
 			}
 		}
 	}
+	if r.OrderedCacheBehavior != nil {
+		for i, b := range *r.OrderedCacheBehavior {
+			if b.LambdaFunctionAssociation != nil && len(*b.LambdaFunctionAssociation) == 0 {
+				(*r.OrderedCacheBehavior)[i].LambdaFunctionAssociation = nil
+			}
+			if b.ForwardedValues != nil && len(*b.ForwardedValues) == 0 {
+				(*r.OrderedCacheBehavior)[i].ForwardedValues = nil
+			}
+			if b.TrustedSigners != nil && len(*b.TrustedSigners) == 0 {
+				(*r.OrderedCacheBehavior)[i].TrustedSigners = nil
+			}
+			if b.ForwardedValues != nil {
+				for j, f := range *b.ForwardedValues {
+					if f.Headers != nil && len(*f.Headers) == 0 {
+						(*(*r.OrderedCacheBehavior)[i].ForwardedValues)[j].Headers = nil
+					}
+					if f.Cookies != nil {
+						for k, c := range *f.Cookies {
+							if c.WhitelistedNames != nil && len(*c.WhitelistedNames) == 0 {
+								(*(*(*r.OrderedCacheBehavior)[i].ForwardedValues)[j].Cookies)[k].WhitelistedNames = nil
+							}
+						}
+					}
+				}
+			}
+			if b.FieldLevelEncryptionId != nil && *b.FieldLevelEncryptionId == "" {
+				(*r.OrderedCacheBehavior)[i].FieldLevelEncryptionId = nil
+			}
+		}
+	}
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #277
| ❓ Documentation  | no

## Description

It will loop over empty arrays from resources found in the cloud provider to change them into nil to avoid false positives.

For new item, the output will show all the other values that are not `[]` (empty useless array) or `""` (empty string).

![image](https://user-images.githubusercontent.com/8110579/109043985-291e6680-76d2-11eb-8024-c5ff119008f6.png)
