### PR TITLE
Change range of coverage colors

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,7 @@ comment:
   require_head: yes
 
 coverage:
+  range: 50..70
   status:
     project:
       default:


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Codecov badge should be green as long as we are closed to 70% of coverage.