### PR TITLE
Fix bug on deserializing aws_iam_policy_attachment

### DIFF
--- a/pkg/middlewares/iam_policy_attachment_sanitizer.go
+++ b/pkg/middlewares/iam_policy_attachment_sanitizer.go
@@ -50,28 +50,33 @@ func (m IamPolicyAttachmentSanitizer) Execute(remoteResources, resourcesFromStat
 }
 
 func (m IamPolicyAttachmentSanitizer) sanitize(policyAttachment *resourceaws.AwsIamPolicyAttachment) []resource.Resource {
-	newResources := make([]resource.Resource, 0, len(policyAttachment.Users))
 
-	// we create one attachment per user
-	for _, user := range policyAttachment.Users {
-		newAttachment := *policyAttachment
+	var newResources []resource.Resource
 
-		// Id is generated with unique id in state so we override it with something repeatable
-		newAttachment.Id = fmt.Sprintf("%s-%s", user, *policyAttachment.PolicyArn)
+	if policyAttachment.Users != nil {
+		// we create one attachment per user
+		for _, user := range *policyAttachment.Users {
+			newAttachment := *policyAttachment
 
-		newAttachment.Users = []string{user}
-		newResources = append(newResources, &newAttachment)
+			// Id is generated with unique id in state so we override it with something repeatable
+			newAttachment.Id = fmt.Sprintf("%s-%s", user, *policyAttachment.PolicyArn)
+
+			newAttachment.Users = &[]string{user}
+			newResources = append(newResources, &newAttachment)
+		}
 	}
 
-	// we create one attachment per role
-	for _, role := range policyAttachment.Roles {
-		newAttachment := *policyAttachment
+	if policyAttachment.Roles != nil {
+		// we create one attachment per role
+		for _, role := range *policyAttachment.Roles {
+			newAttachment := *policyAttachment
 
-		// Id is generated with unique id in state so we override it with something repeatable
-		newAttachment.Id = fmt.Sprintf("%s-%s", role, *policyAttachment.PolicyArn)
+			// Id is generated with unique id in state so we override it with something repeatable
+			newAttachment.Id = fmt.Sprintf("%s-%s", role, *policyAttachment.PolicyArn)
 
-		newAttachment.Roles = []string{role}
-		newResources = append(newResources, &newAttachment)
+			newAttachment.Roles = &[]string{role}
+			newResources = append(newResources, &newAttachment)
+		}
 	}
 	return newResources
 }

--- a/pkg/middlewares/iam_policy_attachment_sanitizer_test.go
+++ b/pkg/middlewares/iam_policy_attachment_sanitizer_test.go
@@ -33,19 +33,19 @@ func TestIamPolicyAttachmentSanitizer_Execute(t *testing.T) {
 					&aws.AwsIamPolicyAttachment{
 						Id:        "wrongId",
 						PolicyArn: awssdk.String("arn"),
-						Users:     []string{"jean", "paul", "pierre"},
+						Users:     &[]string{"jean", "paul", "pierre"},
 					},
 					&aws.AwsIamPolicyAttachment{
 						Id:        "wrongId2",
 						PolicyArn: awssdk.String("thisisarn"),
-						Users:     []string{"jean", "paul", "jacques"},
+						Users:     &[]string{"jean", "paul", "jacques"},
 					},
 				},
 				ResourcesFromState: &[]resource.Resource{
 					&aws.AwsIamPolicyAttachment{
 						Id:        "wrongId",
 						PolicyArn: awssdk.String("fromstatearn"),
-						Users:     []string{"jean"},
+						Users:     &[]string{"jean"},
 					},
 				},
 			},
@@ -57,39 +57,39 @@ func TestIamPolicyAttachmentSanitizer_Execute(t *testing.T) {
 					&aws.AwsIamPolicyAttachment{
 						Id:        "jean-arn",
 						PolicyArn: awssdk.String("arn"),
-						Users:     []string{"jean"},
+						Users:     &[]string{"jean"},
 					},
 					&aws.AwsIamPolicyAttachment{
 						Id:        "paul-arn",
 						PolicyArn: awssdk.String("arn"),
-						Users:     []string{"paul"},
+						Users:     &[]string{"paul"},
 					},
 					&aws.AwsIamPolicyAttachment{
 						Id:        "pierre-arn",
 						PolicyArn: awssdk.String("arn"),
-						Users:     []string{"pierre"},
+						Users:     &[]string{"pierre"},
 					},
 					&aws.AwsIamPolicyAttachment{
 						Id:        "jean-thisisarn",
 						PolicyArn: awssdk.String("thisisarn"),
-						Users:     []string{"jean"},
+						Users:     &[]string{"jean"},
 					},
 					&aws.AwsIamPolicyAttachment{
 						Id:        "paul-thisisarn",
 						PolicyArn: awssdk.String("thisisarn"),
-						Users:     []string{"paul"},
+						Users:     &[]string{"paul"},
 					},
 					&aws.AwsIamPolicyAttachment{
 						Id:        "jacques-thisisarn",
 						PolicyArn: awssdk.String("thisisarn"),
-						Users:     []string{"jacques"},
+						Users:     &[]string{"jacques"},
 					},
 				},
 				ResourcesFromState: &[]resource.Resource{
 					&aws.AwsIamPolicyAttachment{
 						Id:        "jean-fromstatearn",
 						PolicyArn: awssdk.String("fromstatearn"),
-						Users:     []string{"jean"},
+						Users:     &[]string{"jean"},
 					},
 				},
 			},
@@ -104,19 +104,19 @@ func TestIamPolicyAttachmentSanitizer_Execute(t *testing.T) {
 					&aws.AwsIamPolicyAttachment{
 						Id:        "wrongId",
 						PolicyArn: awssdk.String("arn"),
-						Roles:     []string{"role1", "role2", "pierre"},
+						Roles:     &[]string{"role1", "role2", "pierre"},
 					},
 					&aws.AwsIamPolicyAttachment{
 						Id:        "wrongId2",
 						PolicyArn: awssdk.String("thisisarn"),
-						Roles:     []string{"role1", "role2", "role3"},
+						Roles:     &[]string{"role1", "role2", "role3"},
 					},
 				},
 				ResourcesFromState: &[]resource.Resource{
 					&aws.AwsIamPolicyAttachment{
 						Id:        "wrongId",
 						PolicyArn: awssdk.String("fromstatearn"),
-						Roles:     []string{"role1"},
+						Roles:     &[]string{"role1"},
 					},
 				},
 			},
@@ -128,39 +128,39 @@ func TestIamPolicyAttachmentSanitizer_Execute(t *testing.T) {
 					&aws.AwsIamPolicyAttachment{
 						Id:        "role1-arn",
 						PolicyArn: awssdk.String("arn"),
-						Roles:     []string{"role1"},
+						Roles:     &[]string{"role1"},
 					},
 					&aws.AwsIamPolicyAttachment{
 						Id:        "role2-arn",
 						PolicyArn: awssdk.String("arn"),
-						Roles:     []string{"role2"},
+						Roles:     &[]string{"role2"},
 					},
 					&aws.AwsIamPolicyAttachment{
 						Id:        "pierre-arn",
 						PolicyArn: awssdk.String("arn"),
-						Roles:     []string{"pierre"},
+						Roles:     &[]string{"pierre"},
 					},
 					&aws.AwsIamPolicyAttachment{
 						Id:        "role1-thisisarn",
 						PolicyArn: awssdk.String("thisisarn"),
-						Roles:     []string{"role1"},
+						Roles:     &[]string{"role1"},
 					},
 					&aws.AwsIamPolicyAttachment{
 						Id:        "role2-thisisarn",
 						PolicyArn: awssdk.String("thisisarn"),
-						Roles:     []string{"role2"},
+						Roles:     &[]string{"role2"},
 					},
 					&aws.AwsIamPolicyAttachment{
 						Id:        "role3-thisisarn",
 						PolicyArn: awssdk.String("thisisarn"),
-						Roles:     []string{"role3"},
+						Roles:     &[]string{"role3"},
 					},
 				},
 				ResourcesFromState: &[]resource.Resource{
 					&aws.AwsIamPolicyAttachment{
 						Id:        "role1-fromstatearn",
 						PolicyArn: awssdk.String("fromstatearn"),
-						Roles:     []string{"role1"},
+						Roles:     &[]string{"role1"},
 					},
 				},
 			},

--- a/pkg/resource/aws/aws_iam_policy_attachment.go
+++ b/pkg/resource/aws/aws_iam_policy_attachment.go
@@ -4,12 +4,12 @@ package aws
 const AwsIamPolicyAttachmentResourceType = "aws_iam_policy_attachment"
 
 type AwsIamPolicyAttachment struct {
-	Groups    []string `cty:"groups"`
-	Id        string   `cty:"id" diff:"Id, identifier" computed:"true"`
-	Name      *string  `cty:"name" diff:"-"`
-	PolicyArn *string  `cty:"policy_arn"`
-	Roles     []string `cty:"roles"`
-	Users     []string `cty:"users"`
+	Groups    *[]string `cty:"groups"`
+	Id        string    `cty:"id" diff:"Id, identifier" computed:"true"`
+	Name      *string   `cty:"name" diff:"-"`
+	PolicyArn *string   `cty:"policy_arn"`
+	Roles     *[]string `cty:"roles"`
+	Users     *[]string `cty:"users"`
 }
 
 func (r *AwsIamPolicyAttachment) TerraformId() string {

--- a/pkg/resource/aws/deserializer/iam_role_policy_attachment_deserializer.go
+++ b/pkg/resource/aws/deserializer/iam_role_policy_attachment_deserializer.go
@@ -36,9 +36,9 @@ func (s IamRolePolicyAttachmentDeserializer) Deserialize(rawList []cty.Value) ([
 			Id:        fmt.Sprintf("%s-%s", *rolePolicyAttachment.Role, *rolePolicyAttachment.PolicyArn), // generate unique id
 			Name:      awssdk.String(rolePolicyAttachment.Id),
 			PolicyArn: rolePolicyAttachment.PolicyArn,
-			Users:     []string{},
-			Groups:    []string{},
-			Roles:     []string{*rolePolicyAttachment.Role},
+			Users:     &[]string{},
+			Groups:    &[]string{},
+			Roles:     &[]string{*rolePolicyAttachment.Role},
 		}
 		resources = append(resources, &policyAttachment)
 	}

--- a/pkg/resource/aws/deserializer/iam_user_policy_attachment_deserializer.go
+++ b/pkg/resource/aws/deserializer/iam_user_policy_attachment_deserializer.go
@@ -36,9 +36,9 @@ func (s IamUserPolicyAttachmentDeserializer) Deserialize(rawList []cty.Value) ([
 			Id:        fmt.Sprintf("%s-%s", *userPolicyAttachment.User, *userPolicyAttachment.PolicyArn), // generate unique id,
 			Name:      awssdk.String(userPolicyAttachment.Id),
 			PolicyArn: userPolicyAttachment.PolicyArn,
-			Users:     []string{*userPolicyAttachment.User},
-			Groups:    []string{},
-			Roles:     []string{},
+			Users:     &[]string{*userPolicyAttachment.User},
+			Groups:    &[]string{},
+			Roles:     &[]string{},
 		}
 		resources = append(resources, &policyAttachment)
 	}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #311 
| ❓ Documentation  | no

## Description
add pointer to user roles and groups
users, roles and groups can be nil but gocty refuse to deserialize in
this case