### PR TITLE
Add line number in log when invalid driftignore line encountered

### DIFF
--- a/pkg/filter/driftignore.go
+++ b/pkg/filter/driftignore.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/cloudskiff/driftctl/pkg/resource"
@@ -35,7 +36,7 @@ func (r *DriftIgnore) readIgnoreFile() error {
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
+	for lineNumber := 1; scanner.Scan(); lineNumber++ {
 		line := scanner.Text()
 		if line == "" || strings.HasPrefix(line, "#") {
 			logrus.WithFields(logrus.Fields{
@@ -47,7 +48,8 @@ func (r *DriftIgnore) readIgnoreFile() error {
 		nbArgs := len(typeVal)
 		if nbArgs < 2 {
 			logrus.WithFields(logrus.Fields{
-				"line": line,
+				"line":    strconv.Itoa(lineNumber),
+				"content": line,
 			}).Warnf("unable to parse line, invalid length, got %d expected >= 2", nbArgs)
 			continue
 		}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #274 
| ❓ Documentation  | no

## Description

Just added line index in logger for invalid field in .driftignore, but i don't understand why it print content first and line after, since i set line then content in logrus.Fields{}
Can avoid itoa conversion if index created outer loop scope.