### PR TITLE
Fix false positive in aws_db_subnet_group

### DIFF
--- a/pkg/resource/aws/aws_db_subnet_group.go
+++ b/pkg/resource/aws/aws_db_subnet_group.go
@@ -8,7 +8,7 @@ type AwsDbSubnetGroup struct {
 	Description *string           `cty:"description"`
 	Id          string            `cty:"id" computed:"true"`
 	Name        *string           `cty:"name" computed:"true"`
-	NamePrefix  *string           `cty:"name_prefix" computed:"true"`
+	NamePrefix  *string           `cty:"name_prefix" computed:"true" diff:"-"`
 	SubnetIds   []string          `cty:"subnet_ids"`
 	Tags        map[string]string `cty:"tags"`
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #327 
| ❓ Documentation  | no

## Description

the name prefix is a terraform only naming field, we need to ignore it 