### PR TITLE
Fix false positive drift on aws_db_instance

### DIFF
--- a/pkg/resource/aws/aws_db_instance.go
+++ b/pkg/resource/aws/aws_db_instance.go
@@ -34,7 +34,7 @@ type AwsDbInstance struct {
 	InstanceClass                      *string            `cty:"instance_class"`
 	Iops                               *int               `cty:"iops"`
 	KmsKeyId                           *string            `cty:"kms_key_id" computed:"true"`
-	LatestRestorableTime               *string            `cty:"latest_restorable_time" computed:"true"`
+	LatestRestorableTime               *string            `cty:"latest_restorable_time" computed:"true" diff:"-"`
 	LicenseModel                       *string            `cty:"license_model" computed:"true"`
 	MaintenanceWindow                  *string            `cty:"maintenance_window" computed:"true"`
 	MaxAllocatedStorage                *int               `cty:"max_allocated_storage"`

--- a/pkg/resource/aws/aws_db_instance_ext.go
+++ b/pkg/resource/aws/aws_db_instance_ext.go
@@ -1,0 +1,22 @@
+package aws
+
+import (
+	"github.com/cloudskiff/driftctl/pkg/resource"
+)
+
+func (r *AwsDbInstance) NormalizeForState() (resource.Resource, error) {
+	if r.SnapshotIdentifier != nil && *r.SnapshotIdentifier == "" {
+		r.SnapshotIdentifier = nil
+	}
+	if r.AllowMajorVersionUpgrade != nil && !*r.AllowMajorVersionUpgrade {
+		r.AllowMajorVersionUpgrade = nil
+	}
+	if r.ApplyImmediately != nil && !*r.ApplyImmediately {
+		r.ApplyImmediately = nil
+	}
+	return r, nil
+}
+
+func (r *AwsDbInstance) NormalizeForProvider() (resource.Resource, error) {
+	return r, nil
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #327 
| ❓ Documentation  | no

## Description

- `LatestRestorableTime` is a read only attribute, drift does not makes sense
- `SnapshotIdentifier` default value `""` and `nil` should not trigger drift
- `AllowMajorVersionUpgrade` default value `false` and `nil` should not trigger drift
- `ApplyImmediately` default value `false` and `nil` should not trigger drift