### PR TITLE
Change error message to avoid unrelated error grouping on sentry

### DIFF
--- a/pkg/driftctl.go
+++ b/pkg/driftctl.go
@@ -28,7 +28,7 @@ func NewDriftCTL(remoteSupplier resource.Supplier, iacSupplier resource.Supplier
 func (d DriftCTL) Run() (*analyser.Analysis, error) {
 	remoteResources, resourcesFromState, err := d.scan()
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to scan resources")
+		return nil, errors.WithStack(err)
 	}
 
 	middleware := middlewares.NewChain(


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

It seems that sentry is grouping issues when it shouldn't be

![image](https://user-images.githubusercontent.com/6154987/110963785-c9bb8a00-8352-11eb-8eae-55ac8513a12e.png)
