### PR TITLE
Remove provider initialization message

### DIFF
--- a/pkg/remote/terraform/provider.go
+++ b/pkg/remote/terraform/provider.go
@@ -128,11 +128,11 @@ func (p *TerraformProvider) configure(alias string) error {
 		"alias": alias,
 	}).Debug("New gRPC client started")
 
-	output.Printf("Terraform provider initialized (name=%s", p.Config.Name)
+	logrus.Debugf("Terraform provider initialized (name=%s", p.Config.Name)
 	if alias != "" {
-		output.Printf(", alias=%s", alias)
+		logrus.Debugf(", alias=%s", alias)
 	}
-	output.Printf(")\n")
+	logrus.Debugf(")\n")
 
 	return nil
 }

--- a/pkg/remote/terraform/provider.go
+++ b/pkg/remote/terraform/provider.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/cloudskiff/driftctl/pkg/output"
 
-	"github.com/cloudskiff/driftctl/pkg/parallel"
-	tf "github.com/cloudskiff/driftctl/pkg/terraform"
 	"github.com/eapache/go-resiliency/retrier"
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/plugin/discovery"
@@ -21,6 +19,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
+
+	"github.com/cloudskiff/driftctl/pkg/parallel"
+	tf "github.com/cloudskiff/driftctl/pkg/terraform"
 )
 
 // "alias" in these struct are a way to namespace gRPC clients.
@@ -128,11 +129,10 @@ func (p *TerraformProvider) configure(alias string) error {
 		"alias": alias,
 	}).Debug("New gRPC client started")
 
-	logrus.Debugf("Terraform provider initialized (name=%s", p.Config.Name)
-	if alias != "" {
-		logrus.Debugf(", alias=%s", alias)
-	}
-	logrus.Debugf(")\n")
+	logrus.WithFields(logrus.Fields{
+		"name":  p.Config.Name,
+		"alias": alias,
+	}).Debug("Terraform provider initialized")
 
 	return nil
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #337
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

When launching a scan, the tool was logging the message "Terraform provider initialized" which means the tool has gained access to the provider's API and is scanning the account, looking for resources in the actual infrastructure. So it can be confusing to the user if you have resources in several regions.