### PR TITLE
Detect & exclude unsupported Terraform versions 

### DIFF
--- a/pkg/iac/terraform/state/terraform_state_reader.go
+++ b/pkg/iac/terraform/state/terraform_state_reader.go
@@ -3,13 +3,7 @@ package state
 import (
 	"fmt"
 
-	"github.com/cloudskiff/driftctl/pkg/iac"
-	"github.com/cloudskiff/driftctl/pkg/iac/config"
-	"github.com/cloudskiff/driftctl/pkg/iac/terraform/state/backend"
-	"github.com/cloudskiff/driftctl/pkg/iac/terraform/state/enumerator"
-	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
-	"github.com/cloudskiff/driftctl/pkg/resource"
-	"github.com/cloudskiff/driftctl/pkg/terraform"
+	"github.com/fatih/color"
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statefile"
@@ -17,6 +11,14 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	ctyconvert "github.com/zclconf/go-cty/cty/convert"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
+
+	"github.com/cloudskiff/driftctl/pkg/iac"
+	"github.com/cloudskiff/driftctl/pkg/iac/config"
+	"github.com/cloudskiff/driftctl/pkg/iac/terraform/state/backend"
+	"github.com/cloudskiff/driftctl/pkg/iac/terraform/state/enumerator"
+	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
+	"github.com/cloudskiff/driftctl/pkg/resource"
+	"github.com/cloudskiff/driftctl/pkg/terraform"
 )
 
 const TerraformStateReaderSupplier = "tfstate"
@@ -51,7 +53,7 @@ func (r *TerraformStateReader) retrieve() (map[string][]cty.Value, error) {
 	}
 	r.backend = b
 
-	state, err := read(r.backend)
+	state, err := read(r.config.Path, r.backend)
 	defer r.backend.Close()
 	if err != nil {
 		return nil, err
@@ -195,7 +197,6 @@ func (r *TerraformStateReader) decode(values map[string][]cty.Value) ([]resource
 }
 
 func (r *TerraformStateReader) Resources() ([]resource.Resource, error) {
-
 	if r.enumerator == nil {
 		return r.retrieveForState(r.config.Path)
 	}
@@ -229,6 +230,11 @@ func (r *TerraformStateReader) retrieveMultiplesStates() ([]resource.Resource, e
 	for _, key := range keys {
 		resources, err := r.retrieveForState(key)
 		if err != nil {
+			if _, ok := err.(*UnsupportedVersionError); ok {
+				color.New(color.Bold, color.FgYellow).Printf("WARNING: %s", err)
+				continue
+			}
+
 			return nil, err
 		}
 		results = append(results, resources...)
@@ -237,18 +243,31 @@ func (r *TerraformStateReader) retrieveMultiplesStates() ([]resource.Resource, e
 	return results, nil
 }
 
-func read(reader backend.Backend) (*states.State, error) {
-	state, err := readState(reader)
+func read(path string, reader backend.Backend) (*states.State, error) {
+	state, err := readState(path, reader)
 	if err != nil {
 		return nil, err
 	}
 	return state, nil
 }
 
-func readState(reader backend.Backend) (*states.State, error) {
+func readState(path string, reader backend.Backend) (*states.State, error) {
 	state, err := statefile.Read(reader)
 	if err != nil {
 		return nil, err
 	}
+
+	supported, err := IsVersionSupported(state.TerraformVersion.String())
+	if err != nil {
+		return nil, err
+	}
+
+	if !supported {
+		return nil, &UnsupportedVersionError{
+			StateFile: path,
+			Version:   state.TerraformVersion,
+		}
+	}
+
 	return state.State, nil
 }

--- a/pkg/iac/terraform/state/terraform_state_reader_test.go
+++ b/pkg/iac/terraform/state/terraform_state_reader_test.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/cloudskiff/driftctl/pkg/output"
 
 	"github.com/cloudskiff/driftctl/pkg/iac"
@@ -23,7 +26,7 @@ import (
 
 func TestReadStateValid(t *testing.T) {
 	reader, _ := os.Open("testdata/v4/valid.tfstate")
-	_, err := readState(reader)
+	_, err := readState("terraform.tfstate", reader)
 	if err != nil {
 		t.Errorf("Unable to read state, %s", err)
 		return
@@ -32,7 +35,7 @@ func TestReadStateValid(t *testing.T) {
 
 func TestReadStateInvalid(t *testing.T) {
 	reader, _ := os.Open("testdata/v4/invalid.tfstate")
-	state, err := readState(reader)
+	state, err := readState("terraform.tfstate", reader)
 	if err == nil || state != nil {
 		t.Errorf("ReadFile invalid state should return error")
 	}
@@ -243,4 +246,42 @@ func convert(got []resource.Resource) []interface{} {
 		panic(err)
 	}
 	return want
+}
+
+func TestTerraformStateReader_VersionSupported(t *testing.T) {
+	tests := []struct {
+		name      string
+		statePath string
+		err       error
+	}{
+		{
+			name:      "should detect unsupported version",
+			statePath: "testdata/v4/unsupported_version.tfstate",
+			err:       errors.New("terraform.tfstate was generated using Terraform 0.10.26 which is currently not supported by driftctl\nPlease read documentation at https://docs.driftctl.com/limitations"),
+		},
+		{
+			name:      "should detect supported version",
+			statePath: "testdata/v4/supported_version.tfstate",
+			err:       nil,
+		},
+		{
+			name:      "should return invalid version error",
+			statePath: "testdata/v4/invalid_version.tfstate",
+			err:       errors.New("Invalid Terraform version string: State file claims to have been written by Terraform version \"invalid\", which is not a valid version string."),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader, err := os.Open(test.statePath)
+			assert.NoError(t, err)
+
+			_, err = readState("terraform.tfstate", reader)
+			if test.err != nil {
+				assert.EqualError(t, err, test.err.Error())
+			} else {
+				assert.Equal(t, test.err, err)
+			}
+		})
+	}
 }

--- a/pkg/iac/terraform/state/testdata/v4/invalid_version.tfstate
+++ b/pkg/iac/terraform/state/testdata/v4/invalid_version.tfstate
@@ -1,0 +1,171 @@
+{
+  "version": 4,
+  "terraform_version": "invalid",
+  "serial": 72,
+  "lineage": "d64a9976-0aa7-980f-8ea8-4056102e13c7",
+  "outputs": {
+    "public_ip": {
+      "value": "15.236.123.61",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "data",
+      "type": "aws_ami",
+      "name": "amazon-linux",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "architecture": "x86_64",
+            "arn": "arn:aws:ec2:eu-west-3::image/ami-0aa9ac13698fff547",
+            "block_device_mappings": [
+              {
+                "device_name": "/dev/xvda",
+                "ebs": {
+                  "delete_on_termination": "true",
+                  "encrypted": "false",
+                  "iops": "0",
+                  "snapshot_id": "snap-03857d0bd1aa43efd",
+                  "volume_size": "8",
+                  "volume_type": "gp2"
+                },
+                "no_device": "",
+                "virtual_name": ""
+              }
+            ],
+            "creation_date": "2020-07-21T18:33:16.000Z",
+            "description": "Amazon Linux AMI 2018.03.0.20200716.0 x86_64 HVM gp2",
+            "executable_users": null,
+            "filter": [
+              {
+                "name": "name",
+                "values": [
+                  "amzn-ami-hvm-*"
+                ]
+              }
+            ],
+            "hypervisor": "xen",
+            "id": "ami-0aa9ac13698fff547",
+            "image_id": "ami-0aa9ac13698fff547",
+            "image_location": "amazon/amzn-ami-hvm-2018.03.0.20200716.0-x86_64-gp2",
+            "image_owner_alias": "amazon",
+            "image_type": "machine",
+            "kernel_id": null,
+            "most_recent": true,
+            "name": "amzn-ami-hvm-2018.03.0.20200716.0-x86_64-gp2",
+            "name_regex": null,
+            "owner_id": "137112412989",
+            "owners": [
+              "amazon"
+            ],
+            "platform": null,
+            "product_codes": [],
+            "public": true,
+            "ramdisk_id": null,
+            "root_device_name": "/dev/xvda",
+            "root_device_type": "ebs",
+            "root_snapshot_id": "snap-03857d0bd1aa43efd",
+            "sriov_net_support": "simple",
+            "state": "available",
+            "state_reason": {
+              "code": "UNSET",
+              "message": "UNSET"
+            },
+            "tags": {},
+            "virtualization_type": "hvm"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "vm",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "ami": "ami-0aa9ac13698fff547",
+            "arn": "arn:aws:ec2:eu-west-3:929327065333:instance/i-07dbbae1c3fc4c194",
+            "associate_public_ip_address": true,
+            "availability_zone": "eu-west-3b",
+            "cpu_core_count": 1,
+            "cpu_threads_per_core": 2,
+            "credit_specification": [
+              {
+                "cpu_credits": "unlimited"
+              }
+            ],
+            "disable_api_termination": false,
+            "ebs_block_device": [],
+            "ebs_optimized": false,
+            "ephemeral_block_device": [],
+            "get_password_data": false,
+            "hibernation": false,
+            "host_id": null,
+            "iam_instance_profile": "",
+            "id": "i-07dbbae1c3fc4c194",
+            "instance_initiated_shutdown_behavior": null,
+            "instance_state": "running",
+            "instance_type": "t3.nano",
+            "ipv6_address_count": 0,
+            "ipv6_addresses": [],
+            "key_name": "",
+            "metadata_options": [
+              {
+                "http_endpoint": "enabled",
+                "http_put_response_hop_limit": 1,
+                "http_tokens": "optional"
+              }
+            ],
+            "monitoring": false,
+            "network_interface": [],
+            "network_interface_id": null,
+            "outpost_arn": "",
+            "password_data": "",
+            "placement_group": "",
+            "primary_network_interface_id": "eni-0e489fe405754f162",
+            "private_dns": "ip-172-31-16-40.eu-west-3.compute.internal",
+            "private_ip": "172.31.16.40",
+            "public_dns": "ec2-15-236-123-61.eu-west-3.compute.amazonaws.com",
+            "public_ip": "15.236.123.61",
+            "root_block_device": [
+              {
+                "delete_on_termination": true,
+                "device_name": "/dev/xvda",
+                "encrypted": false,
+                "iops": 100,
+                "kms_key_id": "",
+                "volume_id": "vol-0d30c5228ef04fe70",
+                "volume_size": 8,
+                "volume_type": "gp2"
+              }
+            ],
+            "security_groups": [
+              "default"
+            ],
+            "source_dest_check": true,
+            "subnet_id": "subnet-49f9ae32",
+            "tags": {
+              "Name": "DEMO VM DESTROY ME - default",
+              "Terraform": "true"
+            },
+            "tenancy": "default",
+            "timeouts": null,
+            "user_data": null,
+            "user_data_base64": null,
+            "volume_tags": {},
+            "vpc_security_group_ids": [
+              "sg-a74815c8"
+            ]
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwidXBkYXRlIjo2MDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/iac/terraform/state/testdata/v4/supported_version.tfstate
+++ b/pkg/iac/terraform/state/testdata/v4/supported_version.tfstate
@@ -1,0 +1,171 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.26",
+  "serial": 72,
+  "lineage": "d64a9976-0aa7-980f-8ea8-4056102e13c7",
+  "outputs": {
+    "public_ip": {
+      "value": "15.236.123.61",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "data",
+      "type": "aws_ami",
+      "name": "amazon-linux",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "architecture": "x86_64",
+            "arn": "arn:aws:ec2:eu-west-3::image/ami-0aa9ac13698fff547",
+            "block_device_mappings": [
+              {
+                "device_name": "/dev/xvda",
+                "ebs": {
+                  "delete_on_termination": "true",
+                  "encrypted": "false",
+                  "iops": "0",
+                  "snapshot_id": "snap-03857d0bd1aa43efd",
+                  "volume_size": "8",
+                  "volume_type": "gp2"
+                },
+                "no_device": "",
+                "virtual_name": ""
+              }
+            ],
+            "creation_date": "2020-07-21T18:33:16.000Z",
+            "description": "Amazon Linux AMI 2018.03.0.20200716.0 x86_64 HVM gp2",
+            "executable_users": null,
+            "filter": [
+              {
+                "name": "name",
+                "values": [
+                  "amzn-ami-hvm-*"
+                ]
+              }
+            ],
+            "hypervisor": "xen",
+            "id": "ami-0aa9ac13698fff547",
+            "image_id": "ami-0aa9ac13698fff547",
+            "image_location": "amazon/amzn-ami-hvm-2018.03.0.20200716.0-x86_64-gp2",
+            "image_owner_alias": "amazon",
+            "image_type": "machine",
+            "kernel_id": null,
+            "most_recent": true,
+            "name": "amzn-ami-hvm-2018.03.0.20200716.0-x86_64-gp2",
+            "name_regex": null,
+            "owner_id": "137112412989",
+            "owners": [
+              "amazon"
+            ],
+            "platform": null,
+            "product_codes": [],
+            "public": true,
+            "ramdisk_id": null,
+            "root_device_name": "/dev/xvda",
+            "root_device_type": "ebs",
+            "root_snapshot_id": "snap-03857d0bd1aa43efd",
+            "sriov_net_support": "simple",
+            "state": "available",
+            "state_reason": {
+              "code": "UNSET",
+              "message": "UNSET"
+            },
+            "tags": {},
+            "virtualization_type": "hvm"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "vm",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "ami": "ami-0aa9ac13698fff547",
+            "arn": "arn:aws:ec2:eu-west-3:929327065333:instance/i-07dbbae1c3fc4c194",
+            "associate_public_ip_address": true,
+            "availability_zone": "eu-west-3b",
+            "cpu_core_count": 1,
+            "cpu_threads_per_core": 2,
+            "credit_specification": [
+              {
+                "cpu_credits": "unlimited"
+              }
+            ],
+            "disable_api_termination": false,
+            "ebs_block_device": [],
+            "ebs_optimized": false,
+            "ephemeral_block_device": [],
+            "get_password_data": false,
+            "hibernation": false,
+            "host_id": null,
+            "iam_instance_profile": "",
+            "id": "i-07dbbae1c3fc4c194",
+            "instance_initiated_shutdown_behavior": null,
+            "instance_state": "running",
+            "instance_type": "t3.nano",
+            "ipv6_address_count": 0,
+            "ipv6_addresses": [],
+            "key_name": "",
+            "metadata_options": [
+              {
+                "http_endpoint": "enabled",
+                "http_put_response_hop_limit": 1,
+                "http_tokens": "optional"
+              }
+            ],
+            "monitoring": false,
+            "network_interface": [],
+            "network_interface_id": null,
+            "outpost_arn": "",
+            "password_data": "",
+            "placement_group": "",
+            "primary_network_interface_id": "eni-0e489fe405754f162",
+            "private_dns": "ip-172-31-16-40.eu-west-3.compute.internal",
+            "private_ip": "172.31.16.40",
+            "public_dns": "ec2-15-236-123-61.eu-west-3.compute.amazonaws.com",
+            "public_ip": "15.236.123.61",
+            "root_block_device": [
+              {
+                "delete_on_termination": true,
+                "device_name": "/dev/xvda",
+                "encrypted": false,
+                "iops": 100,
+                "kms_key_id": "",
+                "volume_id": "vol-0d30c5228ef04fe70",
+                "volume_size": 8,
+                "volume_type": "gp2"
+              }
+            ],
+            "security_groups": [
+              "default"
+            ],
+            "source_dest_check": true,
+            "subnet_id": "subnet-49f9ae32",
+            "tags": {
+              "Name": "DEMO VM DESTROY ME - default",
+              "Terraform": "true"
+            },
+            "tenancy": "default",
+            "timeouts": null,
+            "user_data": null,
+            "user_data_base64": null,
+            "volume_tags": {},
+            "vpc_security_group_ids": [
+              "sg-a74815c8"
+            ]
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwidXBkYXRlIjo2MDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/iac/terraform/state/testdata/v4/unsupported_version.tfstate
+++ b/pkg/iac/terraform/state/testdata/v4/unsupported_version.tfstate
@@ -1,0 +1,171 @@
+{
+  "version": 4,
+  "terraform_version": "0.10.26",
+  "serial": 72,
+  "lineage": "d64a9976-0aa7-980f-8ea8-4056102e13c7",
+  "outputs": {
+    "public_ip": {
+      "value": "15.236.123.61",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "data",
+      "type": "aws_ami",
+      "name": "amazon-linux",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "architecture": "x86_64",
+            "arn": "arn:aws:ec2:eu-west-3::image/ami-0aa9ac13698fff547",
+            "block_device_mappings": [
+              {
+                "device_name": "/dev/xvda",
+                "ebs": {
+                  "delete_on_termination": "true",
+                  "encrypted": "false",
+                  "iops": "0",
+                  "snapshot_id": "snap-03857d0bd1aa43efd",
+                  "volume_size": "8",
+                  "volume_type": "gp2"
+                },
+                "no_device": "",
+                "virtual_name": ""
+              }
+            ],
+            "creation_date": "2020-07-21T18:33:16.000Z",
+            "description": "Amazon Linux AMI 2018.03.0.20200716.0 x86_64 HVM gp2",
+            "executable_users": null,
+            "filter": [
+              {
+                "name": "name",
+                "values": [
+                  "amzn-ami-hvm-*"
+                ]
+              }
+            ],
+            "hypervisor": "xen",
+            "id": "ami-0aa9ac13698fff547",
+            "image_id": "ami-0aa9ac13698fff547",
+            "image_location": "amazon/amzn-ami-hvm-2018.03.0.20200716.0-x86_64-gp2",
+            "image_owner_alias": "amazon",
+            "image_type": "machine",
+            "kernel_id": null,
+            "most_recent": true,
+            "name": "amzn-ami-hvm-2018.03.0.20200716.0-x86_64-gp2",
+            "name_regex": null,
+            "owner_id": "137112412989",
+            "owners": [
+              "amazon"
+            ],
+            "platform": null,
+            "product_codes": [],
+            "public": true,
+            "ramdisk_id": null,
+            "root_device_name": "/dev/xvda",
+            "root_device_type": "ebs",
+            "root_snapshot_id": "snap-03857d0bd1aa43efd",
+            "sriov_net_support": "simple",
+            "state": "available",
+            "state_reason": {
+              "code": "UNSET",
+              "message": "UNSET"
+            },
+            "tags": {},
+            "virtualization_type": "hvm"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "vm",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "ami": "ami-0aa9ac13698fff547",
+            "arn": "arn:aws:ec2:eu-west-3:929327065333:instance/i-07dbbae1c3fc4c194",
+            "associate_public_ip_address": true,
+            "availability_zone": "eu-west-3b",
+            "cpu_core_count": 1,
+            "cpu_threads_per_core": 2,
+            "credit_specification": [
+              {
+                "cpu_credits": "unlimited"
+              }
+            ],
+            "disable_api_termination": false,
+            "ebs_block_device": [],
+            "ebs_optimized": false,
+            "ephemeral_block_device": [],
+            "get_password_data": false,
+            "hibernation": false,
+            "host_id": null,
+            "iam_instance_profile": "",
+            "id": "i-07dbbae1c3fc4c194",
+            "instance_initiated_shutdown_behavior": null,
+            "instance_state": "running",
+            "instance_type": "t3.nano",
+            "ipv6_address_count": 0,
+            "ipv6_addresses": [],
+            "key_name": "",
+            "metadata_options": [
+              {
+                "http_endpoint": "enabled",
+                "http_put_response_hop_limit": 1,
+                "http_tokens": "optional"
+              }
+            ],
+            "monitoring": false,
+            "network_interface": [],
+            "network_interface_id": null,
+            "outpost_arn": "",
+            "password_data": "",
+            "placement_group": "",
+            "primary_network_interface_id": "eni-0e489fe405754f162",
+            "private_dns": "ip-172-31-16-40.eu-west-3.compute.internal",
+            "private_ip": "172.31.16.40",
+            "public_dns": "ec2-15-236-123-61.eu-west-3.compute.amazonaws.com",
+            "public_ip": "15.236.123.61",
+            "root_block_device": [
+              {
+                "delete_on_termination": true,
+                "device_name": "/dev/xvda",
+                "encrypted": false,
+                "iops": 100,
+                "kms_key_id": "",
+                "volume_id": "vol-0d30c5228ef04fe70",
+                "volume_size": 8,
+                "volume_type": "gp2"
+              }
+            ],
+            "security_groups": [
+              "default"
+            ],
+            "source_dest_check": true,
+            "subnet_id": "subnet-49f9ae32",
+            "tags": {
+              "Name": "DEMO VM DESTROY ME - default",
+              "Terraform": "true"
+            },
+            "tenancy": "default",
+            "timeouts": null,
+            "user_data": null,
+            "user_data_base64": null,
+            "volume_tags": {},
+            "vpc_security_group_ids": [
+              "sg-a74815c8"
+            ]
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMCwidXBkYXRlIjo2MDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/iac/terraform/state/versions.go
+++ b/pkg/iac/terraform/state/versions.go
@@ -1,0 +1,43 @@
+package state
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+)
+
+var (
+	// UnsupportedVersionConstraints is an array of version constraints known to be unsupported.
+	// If a given state matches one of these, all resources of the related state will be ignored and marked as drifted.
+	UnsupportedVersionConstraints = []string{"<0.11.0"}
+)
+
+type UnsupportedVersionError struct {
+	StateFile string
+	Version   *version.Version
+}
+
+func (u *UnsupportedVersionError) Error() string {
+	return fmt.Sprintf("%s was generated using Terraform %s which is currently not supported by driftctl\n"+
+		"Please read documentation at https://docs.driftctl.com/limitations", u.StateFile, u.Version)
+}
+
+func IsVersionSupported(rawVersion string) (bool, error) {
+	v, err := version.NewVersion(rawVersion)
+	if err != nil {
+		return false, err
+	}
+
+	for _, rawConstraint := range UnsupportedVersionConstraints {
+		c, err := version.NewConstraint(rawConstraint)
+		if err != nil {
+			return false, err
+		}
+
+		if c.Check(v) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/iac/terraform/state/versions_test.go
+++ b/pkg/iac/terraform/state/versions_test.go
@@ -1,0 +1,76 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnsupportedVersions(t *testing.T) {
+	var tests = []struct {
+		name        string
+		constraints []string
+		version     string
+		supported   bool
+		err         error
+	}{
+		{
+			name:        "should not support 0.13",
+			constraints: []string{"=0.13"},
+			version:     "0.13.0",
+			supported:   false,
+			err:         nil,
+		},
+		{
+			name:        "should return error on version parsing",
+			constraints: UnsupportedVersionConstraints,
+			version:     "test",
+			supported:   false,
+			err:         errors.New("Malformed version: test"),
+		},
+		{
+			name:        "should return error on constraint parsing",
+			constraints: []string{"bad_constraint"},
+			version:     "0.14",
+			supported:   false,
+			err:         errors.New("Malformed constraint: bad_constraint"),
+		},
+		{
+			name:        "should support 0.11",
+			constraints: UnsupportedVersionConstraints,
+			version:     "0.11.0",
+			supported:   true,
+			err:         nil,
+		},
+		{
+			name:        "should support 0.14.8",
+			constraints: UnsupportedVersionConstraints,
+			version:     "0.14.8",
+			supported:   true,
+			err:         nil,
+		},
+		{
+			name:        "should not support <0.11",
+			constraints: UnsupportedVersionConstraints,
+			version:     "0.10.9",
+			supported:   false,
+			err:         nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			UnsupportedVersionConstraints = test.constraints
+
+			got, err := IsVersionSupported(test.version)
+			assert.Equal(t, test.supported, got)
+
+			if err != nil {
+				assert.EqualError(t, test.err, err.Error())
+			} else {
+				assert.Equal(t, test.err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | yes
| ❌ BC Break       | no
| 🔗 Related issues | #340
| ❓ Documentation  | yes <!-- does this require documentation update ? -->

## Description

The goal of this patch is to warn the user about the state they provided in case it's from an unsupported version of Terraform.

> It is expected that running driftctl against a terraform state generated by an unsupported version should not be possible and be reported clearly to the user.
>
> In the case of multiple Terraform versions inside a set of tfstates, they should be ignored so at least some execution can happen. This is probably to combine with the future state exclusion feature.

## Implementation

I used [go-version](https://github.com/hashicorp/go-version) by hashicorp to perform the constraint check on Terraform version state. After parsing the state, the version is checked against the constraint (>= 0.11). If the constraint is satisfied, the scan can continue as usual. If it doesn't, a warning is displayed to tell the user this particular state was generated using an unsupported version of Terraform. The scan continue and the ignored state appears as drifted with 0% coverage.

The version constraints are stored in a variable called `UnsupportedVersionConstraints` : 

```go
var (
	UnsupportedVersionConstraints = []string{"<0.11.0", ">=0.13, <0.14"}
)
```

Example : 

```shell
$ driftctl scan --from tfstate://terraform1.tfstate 
WARNING: terraform1.tfstate was generated using Terraform 0.10.8 which is currently not supported by driftctl
Please read documentation at https://docs.driftctl.com/0.7.0/limitations
Scanning resources: ⣟ (36)
Found unmanaged resources:
  aws_ebs_volume:
    - vol-01bd44304179ba354
    - vol-00fe1a5a8af4c6ef5
  aws_s3_bucket:
    - 09721498761983
    - 09721498761982
    - thisisatestbucket1298
    - thisisatestbucket1398
  aws_instance:
    - i-0ca7afc4ff96d6c4b
Found 7 resource(s)
 - 0% coverage
 - 0 covered by IaC
 - 7 not covered by IaC
 - 0 deleted on cloud provider
 - 0/0 drifted from IaC
exit status 1
```

## About constraints

I still need to figure out which version of Terraform is supported or not. But as stated in #340, we won't support versions below 0.11. So for now, the unsupported constraints are `<0.11`. This patch assume we can have multiple constraints in the future, so it's possible to add a version constraint at any moment : 

- `<0.11`, `=0.13.2` Exclude versions below 0.11 and 0.13.2 
- `=0.9`, `=0.10` Exclude versions 0.9.0 and 0.10.0
- `<0.11`, `>=0.13, <0.14` Exclude versions below 0.11 and all 0.13

**EDIT:** I tested with TF v0.11, v0.14.8, & 0.14.9 and it does not appear to have incompatible behavior. May be we need more tests to ensure we fully support versions >=0.11.

### Known limitations

Although it's simple to add a constraint at any time, it's important to note the limitation about this feature. If we excludes versions below `0.11`, the constraint will looks like this : `<0.11`. But we'll not be able to include any version below 0.11. Also, if we decide to exclude a specific minor version, it's possible to do so using this syntax : `>=0.13, <0.14`