### PR TITLE
remove dynamodb table replica to speed up acc tests

### DIFF
--- a/pkg/resource/aws/testdata/acc/aws_dynamodb_table/main.tf
+++ b/pkg/resource/aws/testdata/acc/aws_dynamodb_table/main.tf
@@ -69,8 +69,4 @@ resource "aws_dynamodb_table" "global-dynamo-test" {
     name = "TestTableHashKey"
     type = "S"
   }
-
-  replica {
-    region_name = "us-east-2"
-  }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | 
| ❓ Documentation  |no <!-- does this require documentation update ? -->

## Description

remove dynamodb table replica to speed up acc tests