### PR TITLE
Add pointer on method receivers for normalisation part

### DIFF
--- a/docs/new-resource.md
+++ b/docs/new-resource.md
@@ -38,23 +38,23 @@ type NormalizedResource interface {
 For example S3Bucket policy is encoded in json but the formatting (newline and tabs) differs when read using the state reader. S3Bucket implements `resource.NormalizedResource`:
 
 ```go
-func (s S3Bucket) NormalizeForState() (resource.Resource, error) {
-	err := normalizePolicy(&s)
-	return &s, err
+func (r *AwsS3Bucket) NormalizeForState() (resource.Resource, error) {
+	err := r.normalizePolicy()
+	return r, err
 }
 
-func (s S3Bucket) NormalizeForProvider() (resource.Resource, error) {
-	err := normalizePolicy(&s)
-	return &s, err
+func (r *AwsS3Bucket) NormalizeForProvider() (resource.Resource, error) {
+	err := r.normalizePolicy()
+	return r, err
 }
 
-func normalizePolicy(s *S3Bucket) error {
-	if s.Policy.Policy != nil {
-		jsonString, err := structure.NormalizeJsonString(*s.Policy.Policy)
+func (r *AwsS3Bucket) normalizePolicy() error {
+	if r.Policy != nil {
+		jsonString, err := structure.NormalizeJsonString(*r.Policy)
 		if err != nil {
 			return err
 		}
-		s.Policy.Policy = &jsonString
+		r.Policy = &jsonString
 	}
 	return nil
 }

--- a/pkg/resource/aws/aws_kms_key_ext.go
+++ b/pkg/resource/aws/aws_kms_key_ext.go
@@ -5,14 +5,14 @@ import (
 	"github.com/cloudskiff/driftctl/pkg/resource"
 )
 
-func (r AwsKmsKey) NormalizeForState() (resource.Resource, error) {
+func (r *AwsKmsKey) NormalizeForState() (resource.Resource, error) {
 	err := r.normalizePolicy()
-	return &r, err
+	return r, err
 }
 
-func (r AwsKmsKey) NormalizeForProvider() (resource.Resource, error) {
+func (r *AwsKmsKey) NormalizeForProvider() (resource.Resource, error) {
 	err := r.normalizePolicy()
-	return &r, err
+	return r, err
 }
 
 func (r *AwsKmsKey) normalizePolicy() error {

--- a/pkg/resource/aws/aws_s3_bucket_policy_ext.go
+++ b/pkg/resource/aws/aws_s3_bucket_policy_ext.go
@@ -5,14 +5,14 @@ import (
 	"github.com/cloudskiff/driftctl/pkg/resource"
 )
 
-func (r AwsS3BucketPolicy) NormalizeForState() (resource.Resource, error) {
+func (r *AwsS3BucketPolicy) NormalizeForState() (resource.Resource, error) {
 	err := r.normalizePolicy()
-	return &r, err
+	return r, err
 }
 
-func (r AwsS3BucketPolicy) NormalizeForProvider() (resource.Resource, error) {
+func (r *AwsS3BucketPolicy) NormalizeForProvider() (resource.Resource, error) {
 	err := r.normalizePolicy()
-	return &r, err
+	return r, err
 }
 
 func (r *AwsS3BucketPolicy) normalizePolicy() error {

--- a/pkg/resource/aws/aws_sns_topic_policy_ext.go
+++ b/pkg/resource/aws/aws_sns_topic_policy_ext.go
@@ -5,14 +5,14 @@ import (
 	"github.com/cloudskiff/driftctl/pkg/resource"
 )
 
-func (r AwsSnsTopicPolicy) NormalizeForState() (resource.Resource, error) {
+func (r *AwsSnsTopicPolicy) NormalizeForState() (resource.Resource, error) {
 	err := r.normalizePolicy()
-	return &r, err
+	return r, err
 }
 
-func (r AwsSnsTopicPolicy) NormalizeForProvider() (resource.Resource, error) {
+func (r *AwsSnsTopicPolicy) NormalizeForProvider() (resource.Resource, error) {
 	err := r.normalizePolicy()
-	return &r, err
+	return r, err
 }
 
 func (r *AwsSnsTopicPolicy) normalizePolicy() error {

--- a/pkg/resource/aws/aws_sqs_queue_policy_ext.go
+++ b/pkg/resource/aws/aws_sqs_queue_policy_ext.go
@@ -5,14 +5,14 @@ import (
 	"github.com/cloudskiff/driftctl/pkg/resource"
 )
 
-func (r AwsSqsQueuePolicy) NormalizeForState() (resource.Resource, error) {
+func (r *AwsSqsQueuePolicy) NormalizeForState() (resource.Resource, error) {
 	err := r.normalizePolicy()
-	return &r, err
+	return r, err
 }
 
-func (r AwsSqsQueuePolicy) NormalizeForProvider() (resource.Resource, error) {
+func (r *AwsSqsQueuePolicy) NormalizeForProvider() (resource.Resource, error) {
 	err := r.normalizePolicy()
-	return &r, err
+	return r, err
 }
 
 func (r *AwsSqsQueuePolicy) normalizePolicy() error {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #302 
| ❓ Documentation  | yes, documentation have been updated

## Description

I add pointers to resource normalization method receivers to avoid redundant copies of objects in memory;
And update this part of the documentation to encourage contributors to do the same in the code.