### PR TITLE
Add details to error reporting flag in help message

### DIFF
--- a/pkg/cmd/driftctl.go
+++ b/pkg/cmd/driftctl.go
@@ -62,7 +62,7 @@ func NewDriftctlCmd(build build.BuildInterface) *DriftctlCmd {
 
 	cmd.PersistentFlags().BoolP("help", "h", false, "Display help for command")
 	cmd.PersistentFlags().BoolP("no-version-check", "", false, "Disable the version check")
-	cmd.PersistentFlags().BoolP("error-reporting", "", false, "Enable error reporting.\nWARNING: may leak sensitive data")
+	cmd.PersistentFlags().BoolP("send-crash-report", "", false, "Enable error reporting. Crash data will be sent to us via Sentry.\nWARNING: may leak sensitive data (please read documentation for more details)\nThis flag should be used only if an error occur during execution")
 
 	cmd.AddCommand(NewScanCmd())
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | **yes**
| 🔗 Related issues | #367 
| ❓ Documentation  | no

## Description

The error reporting flag seems to be confusing.
We need to make it clear that is sends some data to out Sentry server.

So i add an information i found on driftctl-docs error-reporting part to the helper message of the program.