### PR TITLE
Remove LastModified field for aws_lambda_function from drift reports

### DIFF
--- a/pkg/resource/aws/aws_lambda_function.go
+++ b/pkg/resource/aws/aws_lambda_function.go
@@ -14,7 +14,7 @@ type AwsLambdaFunction struct {
 	ImageUri                     *string           `cty:"image_uri"`
 	InvokeArn                    *string           `cty:"invoke_arn" computed:"true"`
 	KmsKeyArn                    *string           `cty:"kms_key_arn"`
-	LastModified                 *string           `cty:"last_modified" computed:"true"`
+	LastModified                 *string           `cty:"last_modified" computed:"true" diff:"-"`
 	Layers                       []string          `cty:"layers"`
 	MemorySize                   *int              `cty:"memory_size"`
 	PackageType                  *string           `cty:"package_type"`


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #369 
| ❓ Documentation  | no

## Description

I deleted lastModified field from aws_lambda_function drift report.