### PR TITLE
Make differences output predictable

### DIFF
--- a/pkg/analyser/analysis.go
+++ b/pkg/analyser/analysis.go
@@ -3,6 +3,7 @@ package analyser
 import (
 	"encoding/json"
 	"sort"
+	"strings"
 
 	"github.com/r3labs/diff/v2"
 
@@ -203,5 +204,17 @@ func SortDifferences(diffs []Difference) []Difference {
 		}
 		return diffs[i].Res.TerraformId() < diffs[j].Res.TerraformId()
 	})
+
+	for _, d := range diffs {
+		SortChanges(d.Changelog)
+	}
+
 	return diffs
+}
+
+func SortChanges(changes []Change) []Change {
+	sort.SliceStable(changes, func(i, j int) bool {
+		return strings.Join(changes[i].Path, ".") < strings.Join(changes[j].Path, ".")
+	})
+	return changes
 }

--- a/pkg/analyser/analysis.go
+++ b/pkg/analyser/analysis.go
@@ -2,10 +2,12 @@ package analyser
 
 import (
 	"encoding/json"
+	"sort"
+
+	"github.com/r3labs/diff/v2"
 
 	"github.com/cloudskiff/driftctl/pkg/alerter"
 	"github.com/cloudskiff/driftctl/pkg/resource"
-	"github.com/r3labs/diff/v2"
 )
 
 type Change struct {
@@ -188,4 +190,18 @@ func (a *Analysis) Summary() Summary {
 
 func (a *Analysis) Alerts() alerter.Alerts {
 	return a.alerts
+}
+
+func (a *Analysis) SortResources() {
+	a.differences = SortDifferences(a.differences)
+}
+
+func SortDifferences(diffs []Difference) []Difference {
+	sort.SliceStable(diffs, func(i, j int) bool {
+		if diffs[i].Res.TerraformType() != diffs[j].Res.TerraformType() {
+			return diffs[i].Res.TerraformType() < diffs[j].Res.TerraformType()
+		}
+		return diffs[i].Res.TerraformId() < diffs[j].Res.TerraformId()
+	})
+	return diffs
 }

--- a/pkg/analyser/analyzer.go
+++ b/pkg/analyser/analyzer.go
@@ -2,7 +2,6 @@ package analyser
 
 import (
 	"reflect"
-	"sort"
 
 	resourceaws "github.com/cloudskiff/driftctl/pkg/resource/aws"
 
@@ -88,9 +87,6 @@ func (a Analyzer) Analyze(remoteResources, resourcesFromState []resource.Resourc
 			continue
 		}
 
-		sort.Slice(delta, func(i, j int) bool {
-			return delta[i].Type < delta[j].Type
-		})
 		changelog := make([]Change, 0, len(delta))
 		for _, change := range delta {
 			if filter.IsFieldIgnored(stateRes, change.Path) {
@@ -121,6 +117,8 @@ func (a Analyzer) Analyze(remoteResources, resourcesFromState []resource.Resourc
 
 	// Add remaining unmanaged resources
 	analysis.AddUnmanaged(filteredRemoteResource...)
+
+	analysis.SortResources()
 
 	analysis.SetAlerts(a.alerter.Retrieve())
 

--- a/pkg/analyser/analyzer.go
+++ b/pkg/analyser/analyzer.go
@@ -6,9 +6,10 @@ import (
 
 	resourceaws "github.com/cloudskiff/driftctl/pkg/resource/aws"
 
+	"github.com/r3labs/diff/v2"
+
 	"github.com/cloudskiff/driftctl/pkg/alerter"
 	"github.com/cloudskiff/driftctl/pkg/resource"
-	"github.com/r3labs/diff/v2"
 )
 
 type UnmanagedSecurityGroupRulesAlert struct{}
@@ -82,28 +83,31 @@ func (a Analyzer) Analyze(remoteResources, resourcesFromState []resource.Resourc
 		analysis.AddManaged(stateRes)
 
 		delta, _ := diff.Diff(stateRes, remoteRes)
-		if len(delta) > 0 {
-			sort.Slice(delta, func(i, j int) bool {
-				return delta[i].Type < delta[j].Type
+
+		if len(delta) == 0 {
+			continue
+		}
+
+		sort.Slice(delta, func(i, j int) bool {
+			return delta[i].Type < delta[j].Type
+		})
+		changelog := make([]Change, 0, len(delta))
+		for _, change := range delta {
+			if filter.IsFieldIgnored(stateRes, change.Path) {
+				continue
+			}
+			c := Change{Change: change}
+			c.Computed = a.isComputedField(stateRes, c)
+			if c.Computed {
+				haveComputedDiff = true
+			}
+			changelog = append(changelog, c)
+		}
+		if len(changelog) > 0 {
+			analysis.AddDifference(Difference{
+				Res:       stateRes,
+				Changelog: changelog,
 			})
-			changelog := make([]Change, 0, len(delta))
-			for _, change := range delta {
-				if filter.IsFieldIgnored(stateRes, change.Path) {
-					continue
-				}
-				c := Change{Change: change}
-				c.Computed = a.isComputedField(stateRes, c)
-				if c.Computed {
-					haveComputedDiff = true
-				}
-				changelog = append(changelog, c)
-			}
-			if len(changelog) > 0 {
-				analysis.AddDifference(Difference{
-					Res:       stateRes,
-					Changelog: changelog,
-				})
-			}
 		}
 	}
 

--- a/pkg/analyser/analyzer_test.go
+++ b/pkg/analyser/analyzer_test.go
@@ -226,6 +226,17 @@ func TestAnalyze(t *testing.T) {
 							{
 								Change: diff.Change{
 									Type: "update",
+									From: "barfoo",
+									To:   "foobar",
+									Path: []string{
+										"BarFoo",
+									},
+								},
+								Computed: true,
+							},
+							{
+								Change: diff.Change{
+									Type: "update",
 									From: "foobar",
 									To:   "barfoo",
 									Path: []string{
@@ -236,13 +247,13 @@ func TestAnalyze(t *testing.T) {
 							{
 								Change: diff.Change{
 									Type: "update",
-									From: "barfoo",
-									To:   "foobar",
+									From: "bar",
+									To:   "baz",
 									Path: []string{
-										"BarFoo",
+										"Struct",
+										"Bar",
 									},
 								},
-								Computed: true,
 							},
 							{
 								Change: diff.Change{
@@ -255,17 +266,6 @@ func TestAnalyze(t *testing.T) {
 									},
 								},
 								Computed: true,
-							},
-							{
-								Change: diff.Change{
-									Type: "update",
-									From: "bar",
-									To:   "baz",
-									Path: []string{
-										"Struct",
-										"Bar",
-									},
-								},
 							},
 						},
 					},
@@ -571,6 +571,17 @@ func TestAnalyze(t *testing.T) {
 							{
 								Change: diff.Change{
 									Type: "update",
+									From: "barfoo",
+									To:   "foobar",
+									Path: []string{
+										"BarFoo",
+									},
+								},
+								Computed: true,
+							},
+							{
+								Change: diff.Change{
+									Type: "update",
 									From: "foobar",
 									To:   "barfoo",
 									Path: []string{
@@ -581,13 +592,13 @@ func TestAnalyze(t *testing.T) {
 							{
 								Change: diff.Change{
 									Type: "update",
-									From: "barfoo",
-									To:   "foobar",
+									From: "bar",
+									To:   "baz",
 									Path: []string{
-										"BarFoo",
+										"Struct",
+										"Bar",
 									},
 								},
-								Computed: true,
 							},
 							{
 								Change: diff.Change{
@@ -604,13 +615,16 @@ func TestAnalyze(t *testing.T) {
 							{
 								Change: diff.Change{
 									Type: "update",
-									From: "bar",
-									To:   "baz",
+									From: "foo",
+									To:   "oof",
 									Path: []string{
-										"Struct",
-										"Bar",
+										"StructSlice",
+										"0",
+										"Array",
+										"0",
 									},
 								},
+								Computed: true,
 							},
 							{
 								Change: diff.Change{
@@ -621,20 +635,6 @@ func TestAnalyze(t *testing.T) {
 										"StructSlice",
 										"0",
 										"String",
-									},
-								},
-								Computed: true,
-							},
-							{
-								Change: diff.Change{
-									Type: "update",
-									From: "foo",
-									To:   "oof",
-									Path: []string{
-										"StructSlice",
-										"0",
-										"Array",
-										"0",
 									},
 								},
 								Computed: true,
@@ -768,18 +768,6 @@ func TestAnalyze(t *testing.T) {
 							{
 								Change: diff.Change{
 									Type: "update",
-									From: "baz",
-									To:   "bazdiff",
-									Path: []string{
-										"Struct",
-										"Baz",
-									},
-								},
-								Computed: true,
-							},
-							{
-								Change: diff.Change{
-									Type: "update",
 									From: "bar",
 									To:   "bardiff",
 									Path: []string{
@@ -788,6 +776,18 @@ func TestAnalyze(t *testing.T) {
 									},
 								},
 								Computed: false,
+							},
+							{
+								Change: diff.Change{
+									Type: "update",
+									From: "baz",
+									To:   "bazdiff",
+									Path: []string{
+										"Struct",
+										"Baz",
+									},
+								},
+								Computed: true,
 							},
 						},
 					},
@@ -823,19 +823,6 @@ func TestAnalyze(t *testing.T) {
 							},
 							{
 								Change: diff.Change{
-									Type: "update",
-									From: "one",
-									To:   "onediff",
-									Path: []string{
-										"StructSlice",
-										"0",
-										"String",
-									},
-								},
-								Computed: true,
-							},
-							{
-								Change: diff.Change{
 									Type: "create",
 									From: nil,
 									To:   "diff",
@@ -844,6 +831,19 @@ func TestAnalyze(t *testing.T) {
 										"0",
 										"Array",
 										"1",
+									},
+								},
+								Computed: true,
+							},
+							{
+								Change: diff.Change{
+									Type: "update",
+									From: "one",
+									To:   "onediff",
+									Path: []string{
+										"StructSlice",
+										"0",
+										"String",
 									},
 								},
 								Computed: true,

--- a/pkg/analyser/analyzer_test.go
+++ b/pkg/analyser/analyzer_test.go
@@ -811,20 +811,6 @@ func TestAnalyze(t *testing.T) {
 						Changelog: Changelog{
 							{
 								Change: diff.Change{
-									Type: "create",
-									From: nil,
-									To:   "diff",
-									Path: []string{
-										"StructSlice",
-										"0",
-										"Array",
-										"1",
-									},
-								},
-								Computed: true,
-							},
-							{
-								Change: diff.Change{
 									Type: "update",
 									From: "baz",
 									To:   "bazdiff",
@@ -844,6 +830,20 @@ func TestAnalyze(t *testing.T) {
 										"StructSlice",
 										"0",
 										"String",
+									},
+								},
+								Computed: true,
+							},
+							{
+								Change: diff.Change{
+									Type: "create",
+									From: nil,
+									To:   "diff",
+									Path: []string{
+										"StructSlice",
+										"0",
+										"Array",
+										"1",
 									},
 								},
 								Computed: true,

--- a/pkg/analyser/analyzer_test.go
+++ b/pkg/analyser/analyzer_test.go
@@ -615,13 +615,12 @@ func TestAnalyze(t *testing.T) {
 							{
 								Change: diff.Change{
 									Type: "update",
-									From: "foo",
-									To:   "oof",
+									From: "one",
+									To:   "two",
 									Path: []string{
 										"StructSlice",
 										"0",
-										"Array",
-										"0",
+										"String",
 									},
 								},
 								Computed: true,
@@ -629,12 +628,13 @@ func TestAnalyze(t *testing.T) {
 							{
 								Change: diff.Change{
 									Type: "update",
-									From: "one",
-									To:   "two",
+									From: "foo",
+									To:   "oof",
 									Path: []string{
 										"StructSlice",
 										"0",
-										"String",
+										"Array",
+										"0",
 									},
 								},
 								Computed: true,
@@ -900,6 +900,11 @@ func TestAnalyze(t *testing.T) {
 		},
 	}
 
+	differ, err := diff.NewDiffer(diff.SliceOrdering(true))
+	if err != nil {
+		t.Fatalf("Error creating new differ: %e", err)
+	}
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			filter := &mocks.Filter{}
@@ -930,7 +935,7 @@ func TestAnalyze(t *testing.T) {
 				t.Errorf("Drifted state does not match, got %t expected %t", result.IsSync(), !c.hasDrifted)
 			}
 
-			managedChanges, err := diff.Diff(result.Managed(), c.expected.Managed())
+			managedChanges, err := differ.Diff(result.Managed(), c.expected.Managed())
 			if err != nil {
 				t.Fatalf("Unable to compare %+v", err)
 			}
@@ -940,7 +945,7 @@ func TestAnalyze(t *testing.T) {
 				}
 			}
 
-			unmanagedChanges, err := diff.Diff(result.Unmanaged(), c.expected.Unmanaged())
+			unmanagedChanges, err := differ.Diff(result.Unmanaged(), c.expected.Unmanaged())
 			if err != nil {
 				t.Fatalf("Unable to compare %+v", err)
 			}
@@ -950,7 +955,7 @@ func TestAnalyze(t *testing.T) {
 				}
 			}
 
-			deletedChanges, err := diff.Diff(result.Deleted(), c.expected.Deleted())
+			deletedChanges, err := differ.Diff(result.Deleted(), c.expected.Deleted())
 			if err != nil {
 				t.Fatalf("Unable to compare %+v", err)
 			}
@@ -960,7 +965,7 @@ func TestAnalyze(t *testing.T) {
 				}
 			}
 
-			diffChanges, err := diff.Diff(result.Differences(), c.expected.Differences())
+			diffChanges, err := differ.Diff(result.Differences(), c.expected.Differences())
 			if err != nil {
 				t.Fatalf("Unable to compare %+v", err)
 			}
@@ -970,7 +975,7 @@ func TestAnalyze(t *testing.T) {
 				}
 			}
 
-			summaryChanges, err := diff.Diff(c.expected.Summary(), result.Summary())
+			summaryChanges, err := differ.Diff(c.expected.Summary(), result.Summary())
 			if err != nil {
 				t.Fatalf("Unable to compare %+v", err)
 			}
@@ -980,7 +985,7 @@ func TestAnalyze(t *testing.T) {
 				}
 			}
 
-			alertsChanges, err := diff.Diff(result.Alerts(), c.expected.Alerts())
+			alertsChanges, err := differ.Diff(result.Alerts(), c.expected.Alerts())
 			if err != nil {
 				t.Fatalf("Unable to compare %+v", err)
 			}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | **yes**
| 🔗 Related issues | #374
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Differences was expected to be sorted but it turns out the sort was placed at the wrong place in the code, making it completely useless. This PR, which follow the same implementation of #356, intend to fix the issue. We'll surely come across conflicts but they should be easy to resolve.