### PR TITLE
display last number of resources scanned and hide animation character when progress bar end

### DIFF
--- a/pkg/output/progress.go
+++ b/pkg/output/progress.go
@@ -47,8 +47,8 @@ func (p *progress) Start() {
 
 func (p *progress) Stop() {
 	if p.started.Swap(false) {
+		Printf("Scanned resources:    (%d)\n", p.count.Load())
 		close(p.endChan)
-		Printf("\n")
 	}
 }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | **yes**
| 🔗 Related issues | #371 
| ❓ Documentation  | no

## Description

Make the number of scanned resources after the spinner during scan reliable and hide progress bar animation when it end.