### PR TITLE
Add missing 'make deps' steps in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ jobs:
               exit 1
             fi
       - run: make install-tools
+      - run: make deps
       - run: make lint
   test:
     docker:
@@ -77,6 +78,7 @@ jobs:
     steps:
       - checkout
       - run: make install-tools
+      - run: make deps
       - run: make test
       - run:
           name: Codecov upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,6 @@ jobs:
     steps:
       - checkout
       - run: make install-tools
-      - run: make deps
       - run: make test
       - run:
           name: Codecov upload


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Following https://github.com/cloudskiff/driftctl/commit/3bf8fe65f99ec8bd764cc31a14fb5474648fcb53, the CI was failing because Go dependencies were missing.