### PR TITLE
Fix false positive report on FinalSnapshotIdentifier field

### DIFF
--- a/pkg/resource/aws/aws_db_instance.go
+++ b/pkg/resource/aws/aws_db_instance.go
@@ -25,7 +25,7 @@ type AwsDbInstance struct {
 	Endpoint                           *string            `cty:"endpoint" computed:"true"`
 	Engine                             *string            `cty:"engine" computed:"true"`
 	EngineVersion                      *string            `cty:"engine_version" computed:"true"`
-	FinalSnapshotIdentifier            *string            `cty:"final_snapshot_identifier"`
+	FinalSnapshotIdentifier            *string            `cty:"final_snapshot_identifier" diff:"-"`
 	HostedZoneId                       *string            `cty:"hosted_zone_id" computed:"true"`
 	IamDatabaseAuthenticationEnabled   *bool              `cty:"iam_database_authentication_enabled"`
 	Id                                 string             `cty:"id" computed:"true"`


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | yes
| 🔗 Related issues | #384
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Using the "rds" module, `aws_db_instance` keeps reporting a drifted resource.