### PR TITLE
Prevent go test to update go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ release:
 
 .PHONY: test
 test: deps
-	$(GOTEST) --format testname --junitfile unit-tests.xml -- -coverprofile=cover.out.tmp -coverpkg=.,./pkg/... ./...
+	$(GOTEST) --format testname --junitfile unit-tests.xml -- -mod=readonly -coverprofile=cover.out.tmp -coverpkg=.,./pkg/... ./...
 	cat cover.out.tmp | grep -v "mock_" > cover.out
 
 .PHONY: coverage


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Prevent `go test` to mess up with go.mod