### PR TITLE
Fix aws_route53_record error when deserializing resource (null value is not allowed)

### DIFF
--- a/pkg/iac/terraform/state/terraform_state_reader_test.go
+++ b/pkg/iac/terraform/state/terraform_state_reader_test.go
@@ -49,6 +49,7 @@ func TestTerraformStateReader_AWS_Resources(t *testing.T) {
 		{name: "Route 53 zone", dirName: "route53_zone", wantErr: false},
 		{name: "Route 53 record - single record", dirName: "route53_record", wantErr: false},
 		{name: "Route 53 record - multiples zones, multiples records", dirName: "route53_record_multiples", wantErr: false},
+		{name: "Route 53 record - empty records", dirName: "route53_record_null_records", wantErr: false},
 		{name: "s3 full", dirName: "s3_full", wantErr: false},
 		{name: "RDS DB instance", dirName: "db_instance", wantErr: false},
 		{name: "RDS DB Subnet group", dirName: "db_subnet_group", wantErr: false},

--- a/pkg/iac/terraform/state/test/route53_record_null_records/result.golden.json
+++ b/pkg/iac/terraform/state/test/route53_record_null_records/result.golden.json
@@ -1,0 +1,20 @@
+[
+ {
+  "AllowOverwrite": true,
+  "Fqdn": "foo-0.com",
+  "HealthCheckId": "",
+  "Id": "Z1035360GLIB82T1EH2G_foo-0.com_NS",
+  "MultivalueAnswerRoutingPolicy": null,
+  "Name": "foo-0.com",
+  "Records": null,
+  "SetIdentifier": "",
+  "Ttl": 172800,
+  "Type": "NS",
+  "ZoneId": "Z1035360GLIB82T1EH2G",
+  "Alias": null,
+  "FailoverRoutingPolicy": [],
+  "GeolocationRoutingPolicy": [],
+  "LatencyRoutingPolicy": [],
+  "WeightedRoutingPolicy": []
+ }
+]

--- a/pkg/iac/terraform/state/test/route53_record_null_records/terraform.tfstate
+++ b/pkg/iac/terraform/state/test/route53_record_null_records/terraform.tfstate
@@ -1,0 +1,42 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.28",
+  "serial": 111,
+  "lineage": "bb54c6d5-e17e-32af-f929-762d81156285",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_route53_record",
+      "name": "ns",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "schema_version": 2,
+          "attributes": {
+            "alias": [],
+            "allow_overwrite": true,
+            "failover_routing_policy": [],
+            "fqdn": "foo-0.com",
+            "geolocation_routing_policy": [],
+            "health_check_id": "",
+            "id": "Z1035360GLIB82T1EH2G_foo-0.com_NS",
+            "latency_routing_policy": [],
+            "multivalue_answer_routing_policy": null,
+            "name": "foo-0.com",
+            "records": null,
+            "set_identifier": "",
+            "ttl": 172800,
+            "type": "NS",
+            "weighted_routing_policy": [],
+            "zone_id": "Z1035360GLIB82T1EH2G"
+          },
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
+          "dependencies": [
+            "aws_route53_zone.foobar"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/middlewares/route53_records_test.go
+++ b/pkg/middlewares/route53_records_test.go
@@ -82,7 +82,7 @@ func TestDefaultRoute53RecordShouldNotBeIgnoredWhenManaged(t *testing.T) {
 	}
 	managedDefaultRecord := remoteResources[1].(*aws.AwsRoute53Record)
 	if *managedDefaultRecord.Type != "NS" {
-		t.Error("Default record is ignored but sholuld not be")
+		t.Error("Default record is ignored but should not be")
 	}
 
 	ignoredRecord := remoteResources[2].(*aws.AwsRoute53Record)

--- a/pkg/resource/aws/aws_route53_record.go
+++ b/pkg/resource/aws/aws_route53_record.go
@@ -4,17 +4,17 @@ package aws
 const AwsRoute53RecordResourceType = "aws_route53_record"
 
 type AwsRoute53Record struct {
-	AllowOverwrite                *bool    `cty:"allow_overwrite" diff:"-" computed:"true"`
-	Fqdn                          *string  `cty:"fqdn" computed:"true"`
-	HealthCheckId                 *string  `cty:"health_check_id"`
-	Id                            string   `cty:"id" computed:"true"`
-	MultivalueAnswerRoutingPolicy *bool    `cty:"multivalue_answer_routing_policy"`
-	Name                          *string  `cty:"name" diff:"-"`
-	Records                       []string `cty:"records"`
-	SetIdentifier                 *string  `cty:"set_identifier"`
-	Ttl                           *int     `cty:"ttl"`
-	Type                          *string  `cty:"type"`
-	ZoneId                        *string  `cty:"zone_id"`
+	AllowOverwrite                *bool     `cty:"allow_overwrite" diff:"-" computed:"true"`
+	Fqdn                          *string   `cty:"fqdn" computed:"true"`
+	HealthCheckId                 *string   `cty:"health_check_id"`
+	Id                            string    `cty:"id" computed:"true"`
+	MultivalueAnswerRoutingPolicy *bool     `cty:"multivalue_answer_routing_policy"`
+	Name                          *string   `cty:"name" diff:"-"`
+	Records                       *[]string `cty:"records"`
+	SetIdentifier                 *string   `cty:"set_identifier"`
+	Ttl                           *int      `cty:"ttl"`
+	Type                          *string   `cty:"type"`
+	ZoneId                        *string   `cty:"zone_id"`
 	Alias                         *[]struct {
 		EvaluateTargetHealth *bool   `cty:"evaluate_target_health"`
 		Name                 *string `cty:"name"`

--- a/pkg/resource/aws/aws_route53_record_ext.go
+++ b/pkg/resource/aws/aws_route53_record_ext.go
@@ -27,7 +27,7 @@ func (r *AwsRoute53Record) NormalizeForState() (resource.Resource, error) {
 		r.SetIdentifier = aws.String("")
 	}
 
-	// This ensures that if we find a nil value we don't drift
+	// This ensures that if we find an empty records value we don't drift
 	if r.Records != nil && len(*r.Records) == 0 {
 		r.Records = nil
 	}

--- a/pkg/resource/aws/aws_route53_record_ext.go
+++ b/pkg/resource/aws/aws_route53_record_ext.go
@@ -16,15 +16,25 @@ func (r *AwsRoute53Record) NormalizeForState() (resource.Resource, error) {
 	}
 
 	// On first run, this field is set to null in state file and to "" after one refresh or apply
-	// This ensure that if we find a nil value we dont drift
+	// This ensures that if we find a nil value we don't drift
 	if r.HealthCheckId == nil {
 		r.HealthCheckId = aws.String("")
 	}
 
 	// On first run, this field is set to null in state file and to "" after one refresh or apply
-	// This ensure that if we find a nil value we dont drift
+	// This ensures that if we find a nil value we don't drift
 	if r.SetIdentifier == nil {
 		r.SetIdentifier = aws.String("")
+	}
+
+	// This ensures that if we find a nil value we don't drift
+	if r.Records != nil && len(*r.Records) == 0 {
+		r.Records = nil
+	}
+
+	// This ensures that if we find a nil value we don't drift
+	if r.Ttl == nil {
+		r.Ttl = aws.Int(0)
 	}
 
 	// Since AWS returns the FQDN as the name of the remote record, we must change the Id of the
@@ -46,6 +56,12 @@ func (r *AwsRoute53Record) NormalizeForState() (resource.Resource, error) {
 }
 
 func (r *AwsRoute53Record) NormalizeForProvider() (resource.Resource, error) {
+
+	// This ensures that if we find a nil value we don't drift
+	if r.Records != nil && len(*r.Records) == 0 {
+		r.Records = nil
+	}
+
 	return r, nil
 }
 

--- a/pkg/resource/aws/aws_route53_record_test.go
+++ b/pkg/resource/aws/aws_route53_record_test.go
@@ -27,3 +27,21 @@ func TestAcc_AwsRoute53Record_WithFQDNAsId(t *testing.T) {
 		},
 	})
 }
+
+func TestAcc_AwsRoute53Record_WithAlias(t *testing.T) {
+	acceptance.Run(t, acceptance.AccTestCase{
+		Paths: []string{"./testdata/acc/aws_route53_record_with_alias"},
+		Args:  []string{"scan", "--filter", "Type=='aws_route53_record'"},
+		Checks: []acceptance.AccCheck{
+			{
+				Check: func(result *acceptance.ScanResult, stdout string, err error) {
+					if err != nil {
+						t.Fatal(err)
+					}
+					result.AssertDriftCountTotal(0)
+					result.Equal(2, result.Summary().TotalManaged)
+				},
+			},
+		},
+	})
+}

--- a/pkg/resource/aws/testdata/acc/aws_route53_record_with_alias/.terraform.lock.hcl
+++ b/pkg/resource/aws/testdata/acc/aws_route53_record_with_alias/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.19.0"
+  constraints = "~> 3.19.0"
+  hashes = [
+    "h1:+7Vi7p13+cnrxjXbfJiTimGSFR97xCaQwkkvWcreLns=",
+    "h1:xur9tF49NgsovNnmwmBR8RdpN8Fcg1TD4CKQPJD6n1A=",
+    "zh:185a5259153eb9ee4699d4be43b3d509386b473683392034319beee97d470c3b",
+    "zh:2d9a0a01f93e8d16539d835c02b8b6e1927b7685f4076e96cb07f7dd6944bc6c",
+    "zh:703f6da36b1b5f3497baa38fccaa7765fb8a2b6440344e4c97172516b49437dd",
+    "zh:770855565462abadbbddd98cb357d2f1a8f30f68a358cb37cbd5c072cb15b377",
+    "zh:8008db43149fe4345301f81e15e6d9ddb47aa5e7a31648f9b290af96ad86e92a",
+    "zh:8cdd27d375da6dcb7687f1fed126b7c04efce1671066802ee876dbbc9c66ec79",
+    "zh:be22ae185005690d1a017c1b909e0d80ab567e239b4f06ecacdba85080667c1c",
+    "zh:d2d02e72dbd80f607636cd6237a6c862897caabc635c7b50c0cb243d11246723",
+    "zh:d8f125b66a1eda2555c0f9bbdf12036a5f8d073499a22ca9e4812b68067fea31",
+    "zh:f5a98024c64d5d2973ff15b093725a074c0cb4afde07ef32c542e69f17ac90bc",
+  ]
+}

--- a/pkg/resource/aws/testdata/acc/aws_route53_record_with_alias/providers.tf
+++ b/pkg/resource/aws/testdata/acc/aws_route53_record_with_alias/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = "us-east-1"
+}
+terraform {
+  required_providers {
+    aws = {
+      version = "~> 3.19.0"
+    }
+  }
+}

--- a/pkg/resource/aws/testdata/acc/aws_route53_record_with_alias/route53.tf
+++ b/pkg/resource/aws/testdata/acc/aws_route53_record_with_alias/route53.tf
@@ -1,0 +1,22 @@
+resource "aws_route53_zone" "foo-zone" {
+  name = "foo-2.com"
+}
+
+resource "aws_route53_record" "alias" {
+    zone_id = aws_route53_zone.foo-zone.zone_id
+    name    = "alias.foo-2.com"
+    type    = "A"
+    alias {
+        evaluate_target_health = false
+        name                   = aws_route53_record.www.name
+        zone_id                = aws_route53_zone.foo-zone.zone_id
+    }
+}
+
+resource "aws_route53_record" "www" {
+    zone_id = aws_route53_zone.foo-zone.zone_id
+    name    = "www.foo-2.com"
+    type    = "A"
+    ttl     = "300"
+    records = ["1.1.1.1"]
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #375 
| ❓ Documentation  | no

## Description

Everything is in the #375 ticket.
We have also fixed new false positive.