### PR TITLE
Return explicit error on bad http status code

### DIFF
--- a/pkg/iac/terraform/state/backend/http_reader.go
+++ b/pkg/iac/terraform/state/backend/http_reader.go
@@ -1,6 +1,8 @@
 package backend
 
 import (
+	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -29,6 +31,16 @@ func NewHTTPReader(rawURL string, opts *Options) (*HTTPBackend, error) {
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
+	}
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 400 {
+		return nil, fmt.Errorf("error in backend HTTP(s): non-200 OK status code: %s body: \"%s\"", res.Status, buf.String())
 	}
 
 	return &HTTPBackend{rawURL, res.Body}, nil

--- a/pkg/iac/terraform/state/backend/http_reader.go
+++ b/pkg/iac/terraform/state/backend/http_reader.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const BackendKeyHTTP = "http"
@@ -38,8 +39,10 @@ func NewHTTPReader(rawURL string, opts *Options) (*HTTPBackend, error) {
 		return nil, err
 	}
 
+	logrus.WithFields(logrus.Fields{"body": buf.String()}).Trace("HTTP(s) backend response")
+
 	if res.StatusCode < 200 || res.StatusCode >= 400 {
-		return nil, errors.Errorf("error in backend HTTP(s): non-200 OK status code: %s body: \"%s\"", res.Status, buf.String())
+		return nil, errors.Errorf("error requesting HTTP(s) backend state: status code: %d", res.StatusCode)
 	}
 
 	return &HTTPBackend{rawURL, res.Body}, nil

--- a/pkg/iac/terraform/state/backend/http_reader.go
+++ b/pkg/iac/terraform/state/backend/http_reader.go
@@ -2,7 +2,6 @@ package backend
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -40,7 +39,7 @@ func NewHTTPReader(rawURL string, opts *Options) (*HTTPBackend, error) {
 	}
 
 	if res.StatusCode < 200 || res.StatusCode >= 400 {
-		return nil, fmt.Errorf("error in backend HTTP(s): non-200 OK status code: %s body: \"%s\"", res.Status, buf.String())
+		return nil, errors.Errorf("error in backend HTTP(s): non-200 OK status code: %s body: \"%s\"", res.Status, buf.String())
 	}
 
 	return &HTTPBackend{rawURL, res.Body}, nil

--- a/pkg/iac/terraform/state/backend/http_reader_test.go
+++ b/pkg/iac/terraform/state/backend/http_reader_test.go
@@ -53,7 +53,7 @@ func TestNewHTTPReader(t *testing.T) {
 				},
 			},
 			wantURL: "https://raw.githubusercontent.com/cloudskiff/driftctl-badprojecturl",
-			wantErr: errors.New("error in backend HTTP(s): non-200 OK status code: 404 Not Found body: \"404: Not Found\""),
+			wantErr: errors.New("error requesting HTTP(s) backend state: status code: 404"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #382
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

> Using the `--from tfstate+https://` new backend support to access terraform states, if I request the wrong file, I expect to know about it (like "`Sorry, no t3rr4f0rm.tfstate is available at this location`"), more than a json parsing issue (as there's no file to parse obviously) 

This patch returns an explicit error when the HTTP status code is below 200 or above 399.

**Example**

```shell
$  driftctl scan --from tfstate+https://gitlab.com/api/v4/projects/25255199/terraform/state/terraform/versions/1
Scanning resources: ⣻ (0)
error in backend HTTP(s): non-200 OK status code: 401 Unauthorized body: "{"message":"401 Unauthorized"}"
exit status 1
```