### PR TITLE
Fix #409 do not list directory when using s3 as state backend

### DIFF
--- a/pkg/iac/terraform/state/enumerator/s3.go
+++ b/pkg/iac/terraform/state/enumerator/s3.go
@@ -3,6 +3,7 @@ package enumerator
 import (
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
@@ -45,7 +46,9 @@ func (s *S3Enumerator) Enumerate() ([]string, error) {
 	}
 	err := s.client.ListObjectsV2Pages(input, func(output *s3.ListObjectsV2Output, lastPage bool) bool {
 		for _, metadata := range output.Contents {
-			keys = append(keys, strings.Join([]string{bucket, *metadata.Key}, "/"))
+			if aws.Int64Value(metadata.Size) > 0 {
+				keys = append(keys, strings.Join([]string{bucket, *metadata.Key}, "/"))
+			}
 		}
 		return !lastPage
 	})


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #409 
| ❓ Documentation  | no

## Description

- Ignore directory (size <= 0) when listing bucket object
- Add test for empty directory