### PR TITLE
Rename total_drifted to total_changed in JSON output

### DIFF
--- a/pkg/analyser/analysis.go
+++ b/pkg/analyser/analysis.go
@@ -25,7 +25,7 @@ type Difference struct {
 
 type Summary struct {
 	TotalResources int `json:"total_resources"`
-	TotalDrifted   int `json:"total_drifted"`
+	TotalDrifted   int `json:"total_changed"`
 	TotalUnmanaged int `json:"total_unmanaged"`
 	TotalDeleted   int `json:"total_missing"`
 	TotalManaged   int `json:"total_managed"`

--- a/pkg/analyser/testdata/output.json
+++ b/pkg/analyser/testdata/output.json
@@ -1,7 +1,7 @@
 {
 	"summary": {
 		"total_resources": 6,
-		"total_drifted": 1,
+		"total_changed": 1,
 		"total_unmanaged": 2,
 		"total_missing": 2,
 		"total_managed": 2

--- a/pkg/cmd/scan/output/testdata/output.json
+++ b/pkg/cmd/scan/output/testdata/output.json
@@ -1,7 +1,7 @@
 {
 	"summary": {
 		"total_resources": 6,
-		"total_drifted": 1,
+		"total_changed": 1,
 		"total_unmanaged": 2,
 		"total_missing": 2,
 		"total_managed": 2

--- a/pkg/cmd/scan/output/testdata/output_access_denied_alert_aws.json
+++ b/pkg/cmd/scan/output/testdata/output_access_denied_alert_aws.json
@@ -1,7 +1,7 @@
 {
 	"summary": {
 		"total_resources": 0,
-		"total_drifted": 0,
+		"total_changed": 0,
 		"total_unmanaged": 0,
 		"total_missing": 0,
 		"total_managed": 0

--- a/pkg/cmd/scan/output/testdata/output_access_denied_alert_github.json
+++ b/pkg/cmd/scan/output/testdata/output_access_denied_alert_github.json
@@ -1,7 +1,7 @@
 {
 	"summary": {
 		"total_resources": 0,
-		"total_drifted": 0,
+		"total_changed": 0,
 		"total_unmanaged": 0,
 		"total_missing": 0,
 		"total_managed": 0

--- a/pkg/cmd/scan/output/testdata/output_computed_fields.json
+++ b/pkg/cmd/scan/output/testdata/output_computed_fields.json
@@ -1,7 +1,7 @@
 {
 	"summary": {
 		"total_resources": 1,
-		"total_drifted": 1,
+		"total_changed": 1,
 		"total_unmanaged": 0,
 		"total_missing": 0,
 		"total_managed": 1

--- a/pkg/cmd/scan/output/testdata/output_multiples_times.json
+++ b/pkg/cmd/scan/output/testdata/output_multiples_times.json
@@ -1,7 +1,7 @@
 {
 	"summary": {
 		"total_resources": 0,
-		"total_drifted": 0,
+		"total_changed": 0,
 		"total_unmanaged": 0,
 		"total_missing": 0,
 		"total_managed": 0


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | yes
| 🔗 Related issues | #372
| ❓ Documentation  | yes <!-- does this require documentation update ? -->

## Description

In PR #379, it was forgotten to update the `total_drifted` property according to the new output terminology.