### PR TITLE
Use a deep link for known limitations docs

### DIFF
--- a/pkg/analyser/analyzer.go
+++ b/pkg/analyser/analyzer.go
@@ -18,7 +18,7 @@ func newUnmanagedSecurityGroupRulesAlert() *UnmanagedSecurityGroupRulesAlert {
 }
 
 func (u *UnmanagedSecurityGroupRulesAlert) Message() string {
-	return "You have unmanaged security group rules that could be false positives, find out more at https://docs.driftctl.com/0.7.0/limitations#terraform-resources"
+	return "You have unmanaged security group rules that could be false positives, find out more at https://docs.driftctl.com/limitations"
 }
 
 func (u *UnmanagedSecurityGroupRulesAlert) ShouldIgnoreResource() bool {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #426
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Replace a link to limitation documentation by a dedicated deep link.