### PR TITLE
Rename total_drifted to total_changed in JSON testdata

### DIFF
--- a/pkg/analyser/testdata/input.json
+++ b/pkg/analyser/testdata/input.json
@@ -1,7 +1,7 @@
 {
   "summary": {
     "total_resources": 6,
-    "total_drifted": 1,
+    "total_changed": 1,
     "total_unmanaged": 2,
     "total_missing": 2,
     "total_managed": 2


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | https://github.com/cloudskiff/driftctl/pull/429#discussion_r612531346
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Fix a typo in JSON testdata. The tests are still passing because that field overridden by the number of element in the differences property.