### PR TITLE
Add Reunion Island flag to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To learn more about compiling driftctl and contributing, please refer to the [co
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification and is brought to you by these [awesome contributors](CONTRIBUTORS.md).
 
-Build with ❤️️ from 🇫🇷 🇯🇵 🇬🇷 🇸🇪 🇺🇸
+Build with ❤️️ from 🇫🇷 🇯🇵 🇬🇷 🇸🇪 🇺🇸 🇷🇪 
 
 ---
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

For prosperity and shoutout to my island, I'd love to see the Reunion Island flag in the readme.