### PR TITLE
Replace Sentry message by debug log

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func run() int {
 }
 
 func flushSentry() {
-	fmt.Print("Sending error report ...")
-	gosentry.Flush(60 * time.Second)
-	fmt.Printf(" done, thank you %s\n", color.RedString("❤️"))
+	ttl := 60 * time.Second
+	ok := gosentry.Flush(ttl)
+	logrus.WithField("timeout", ttl).WithField("success", ok).Debug("Flushed Sentry events")
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #423
| ❓ Documentation  | yes <!-- does this require documentation update ? -->

## Description

We can't know if something was captured by sentry, so we display a message by default no matter what the user do. This patch remove this message and add a debug log to know when a Sentry report was sent without confusing the user.