### PR TITLE
Add ignore-missing flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
           command: |
             curl -s -o codecov https://codecov.io/bash \
               && VERSION=$(grep 'VERSION=\".*\"' codecov | cut -d'"' -f2) \
-              && shasum -a 512 -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM)
+              && shasum -a 512 -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM)
       - run:
           name: Codecov upload
           command: |


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Add the `--ignore-missing` flag to the check of the Codecov's Bash Uploader.