### PR TITLE
Change json identation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -45,6 +45,7 @@ ij_go_wrap_func_result_newline_before_rparen = true
 
 [*.json]
 insert_final_newline = false
+indent_size = 2
 
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
Mos of our json files are indented with two spaces, this proposal is to set this in editorconfig as 4 space indentation in our big json files (golden files) seems excessive