### PR TITLE
Display ec2 instance name when tag name exist

### DIFF
--- a/pkg/resource/aws/aws_instance_ext.go
+++ b/pkg/resource/aws/aws_instance_ext.go
@@ -1,6 +1,10 @@
 package aws
 
-import "github.com/cloudskiff/driftctl/pkg/resource"
+import (
+	"fmt"
+
+	"github.com/cloudskiff/driftctl/pkg/resource"
+)
 
 func (r *AwsInstance) NormalizeForState() (resource.Resource, error) {
 	if r.RootBlockDevice != nil && len(*r.RootBlockDevice) == 0 {
@@ -20,4 +24,11 @@ func (r *AwsInstance) NormalizeForProvider() (resource.Resource, error) {
 		r.EbsBlockDevice = nil
 	}
 	return r, nil
+}
+
+func (r *AwsInstance) String() string {
+	if name, ok := r.Tags["Name"]; ok {
+		return fmt.Sprintf("%s (Name: %s)", r.TerraformId(), name)
+	}
+	return r.TerraformId()
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #419
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

>  We should display the instance name for aws_ec2_instance and other resource that use tags for a name.