### PR TITLE
Add a missing line break in warning message

### DIFF
--- a/pkg/iac/terraform/state/terraform_state_reader.go
+++ b/pkg/iac/terraform/state/terraform_state_reader.go
@@ -234,7 +234,7 @@ func (r *TerraformStateReader) retrieveMultiplesStates() ([]resource.Resource, e
 		resources, err := r.retrieveForState(key)
 		if err != nil {
 			if _, ok := err.(*UnsupportedVersionError); ok {
-				color.New(color.Bold, color.FgYellow).Printf("WARNING: %s", err)
+				color.New(color.Bold, color.FgYellow).Printf("WARNING: %s\n", err)
 				continue
 			}
 

--- a/pkg/iac/terraform/state/terraform_state_reader_test.go
+++ b/pkg/iac/terraform/state/terraform_state_reader_test.go
@@ -263,7 +263,7 @@ func TestTerraformStateReader_VersionSupported(t *testing.T) {
 		{
 			name:      "should detect unsupported version",
 			statePath: "testdata/v4/unsupported_version.tfstate",
-			err:       errors.New("terraform.tfstate was generated using Terraform 0.10.26 which is currently not supported by driftctl\nPlease read documentation at https://docs.driftctl.com/limitations"),
+			err:       errors.New("terraform.tfstate was generated using Terraform 0.10.26 which is currently not supported by driftctl. Please read documentation at https://docs.driftctl.com/limitations"),
 		},
 		{
 			name:      "should detect supported version",

--- a/pkg/iac/terraform/state/versions.go
+++ b/pkg/iac/terraform/state/versions.go
@@ -18,8 +18,7 @@ type UnsupportedVersionError struct {
 }
 
 func (u *UnsupportedVersionError) Error() string {
-	return fmt.Sprintf("%s was generated using Terraform %s which is currently not supported by driftctl\n"+
-		"Please read documentation at https://docs.driftctl.com/limitations", u.StateFile, u.Version)
+	return fmt.Sprintf("%s was generated using Terraform %s which is currently not supported by driftctl. Please read documentation at https://docs.driftctl.com/limitations", u.StateFile, u.Version)
 }
 
 func IsVersionSupported(rawVersion string) (bool, error) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #340
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Tests of the unsupported TF version detection (https://github.com/cloudskiff/driftctl/issues/340#issuecomment-834591744) showed that the message is not formatted properly.

Before : 
![image](https://user-images.githubusercontent.com/16480203/117631421-862ba380-b17c-11eb-9455-8203a4a679aa.png)

After : 
![image](https://user-images.githubusercontent.com/16480203/117631512-9a6fa080-b17c-11eb-93d1-3b734922fbde.png)

