### PR TITLE
Create driftignore generator command

### DIFF
--- a/pkg/analyser/analysis.go
+++ b/pkg/analyser/analysis.go
@@ -2,6 +2,7 @@ package analyser
 
 import (
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -55,6 +56,13 @@ type serializableAnalysis struct {
 	Differences []serializableDifference               `json:"differences"`
 	Coverage    int                                    `json:"coverage"`
 	Alerts      map[string][]alerter.SerializableAlert `json:"alerts"`
+}
+
+type GenDriftIgnoreOptions struct {
+	ExcludeUnmanaged bool
+	ExcludeDeleted   bool
+	ExcludeDrifted   bool
+	InputPath        string
 }
 
 func (a Analysis) MarshalJSON() ([]byte, error) {
@@ -201,6 +209,40 @@ func (a *Analysis) SortResources() {
 	a.differences = SortDifferences(a.differences)
 }
 
+func (a *Analysis) DriftIgnoreList(opts GenDriftIgnoreOptions) (int, string) {
+	var list []string
+
+	resourceCount := 0
+
+	addResources := func(res ...resource.Resource) {
+		for _, r := range res {
+			list = append(list, fmt.Sprintf("%s.%s", r.TerraformType(), escapeKey(r.TerraformId())))
+		}
+		resourceCount += len(res)
+	}
+	addDifferences := func(diff ...Difference) {
+		for _, d := range diff {
+			addResources(d.Res)
+		}
+		resourceCount += len(diff)
+	}
+
+	if !opts.ExcludeUnmanaged && a.Summary().TotalUnmanaged > 0 {
+		list = append(list, "# Resources not covered by IaC")
+		addResources(a.Unmanaged()...)
+	}
+	if !opts.ExcludeDeleted && a.Summary().TotalDeleted > 0 {
+		list = append(list, "# Missing resources")
+		addResources(a.Deleted()...)
+	}
+	if !opts.ExcludeDrifted && a.Summary().TotalDrifted > 0 {
+		list = append(list, "# Changed resources")
+		addDifferences(a.Differences()...)
+	}
+
+	return resourceCount, strings.Join(list, "\n")
+}
+
 func SortDifferences(diffs []Difference) []Difference {
 	sort.SliceStable(diffs, func(i, j int) bool {
 		if diffs[i].Res.TerraformType() != diffs[j].Res.TerraformType() {
@@ -221,4 +263,11 @@ func SortChanges(changes []Change) []Change {
 		return strings.Join(changes[i].Path, ".") < strings.Join(changes[j].Path, ".")
 	})
 	return changes
+}
+
+func escapeKey(line string) string {
+	line = strings.ReplaceAll(line, `\`, `\\`)
+	line = strings.ReplaceAll(line, `.`, `\.`)
+
+	return line
 }

--- a/pkg/cmd/driftctl.go
+++ b/pkg/cmd/driftctl.go
@@ -66,6 +66,7 @@ func NewDriftctlCmd(build build.BuildInterface) *DriftctlCmd {
 	cmd.PersistentFlags().BoolP("send-crash-report", "", false, "Enable error reporting. Crash data will be sent to us via Sentry.\nWARNING: may leak sensitive data (please read the documentation for more details)\nThis flag should be used only if an error occurs during execution")
 
 	cmd.AddCommand(NewScanCmd())
+	cmd.AddCommand(NewGenDriftIgnoreCmd())
 
 	return cmd
 }

--- a/pkg/cmd/gen_driftignore.go
+++ b/pkg/cmd/gen_driftignore.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/cloudskiff/driftctl/pkg/analyser"
+	"github.com/spf13/cobra"
+)
+
+func NewGenDriftIgnoreCmd() *cobra.Command {
+	opts := &analyser.GenDriftIgnoreOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "gen-driftignore",
+		Short:   "Generate a .driftignore file based on your scan result",
+		Long:    "This command will generate a new .driftignore file containing your current drifts and send output to /dev/stdout",
+		Example: "driftctl scan -o json://stdout | driftctl gen-driftignore",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, list, err := genDriftIgnore(opts)
+			if err != nil {
+				return err
+			}
+
+			fmt.Print(list)
+
+			return nil
+		},
+	}
+
+	fl := cmd.Flags()
+
+	fl.BoolVar(&opts.ExcludeUnmanaged, "exclude-unmanaged", false, "Exclude resources not managed by IaC")
+	fl.BoolVar(&opts.ExcludeDeleted, "exclude-missing", false, "Exclude missing resources")
+	fl.BoolVar(&opts.ExcludeDrifted, "exclude-changed", false, "Exclude resources that changed on cloud provider")
+	fl.StringVarP(&opts.InputPath, "from", "f", "/dev/stdin", "Input where the JSON should be parsed")
+
+	return cmd
+}
+
+func genDriftIgnore(opts *analyser.GenDriftIgnoreOptions) (int, string, error) {
+	input, err := os.ReadFile(opts.InputPath)
+	if err != nil {
+		return 0, "", err
+	}
+
+	analysis := &analyser.Analysis{}
+	err = json.Unmarshal(input, analysis)
+	if err != nil {
+		return 0, "", err
+	}
+
+	n, list := analysis.DriftIgnoreList(*opts)
+
+	return n, list, nil
+}

--- a/pkg/cmd/gen_driftignore.go
+++ b/pkg/cmd/gen_driftignore.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/cloudskiff/driftctl/pkg/analyser"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -18,6 +19,10 @@ func NewGenDriftIgnoreCmd() *cobra.Command {
 		Long:  "This command will generate a new .driftignore file containing your current drifts and send output to /dev/stdout\n\nExample: driftctl scan -o json://stdout | driftctl gen-driftignore > .driftignore",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.InputPath == "" {
+				return errors.New("Error: you need to specify an input to parse JSON from")
+			}
+
 			_, list, err := genDriftIgnore(opts)
 			if err != nil {
 				return err
@@ -34,7 +39,7 @@ func NewGenDriftIgnoreCmd() *cobra.Command {
 	fl.BoolVar(&opts.ExcludeUnmanaged, "exclude-unmanaged", false, "Exclude resources not managed by IaC")
 	fl.BoolVar(&opts.ExcludeDeleted, "exclude-missing", false, "Exclude missing resources")
 	fl.BoolVar(&opts.ExcludeDrifted, "exclude-changed", false, "Exclude resources that changed on cloud provider")
-	fl.StringVarP(&opts.InputPath, "from", "f", "/dev/stdin", "Input where the JSON should be parsed from")
+	fl.StringVarP(&opts.InputPath, "input", "i", "", "Input where the JSON should be parsed from")
 
 	return cmd
 }

--- a/pkg/cmd/gen_driftignore.go
+++ b/pkg/cmd/gen_driftignore.go
@@ -20,7 +20,7 @@ func NewGenDriftIgnoreCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.InputPath == "" {
-				return errors.New("Error: you need to specify an input to parse JSON from")
+				return errors.New("Error: you must specify an input to parse JSON from. Use driftctl gen-driftignore -i <drifts.json>\nGenerate a JSON file using the output flag: driftctl scan -o json://path/to/drifts.json")
 			}
 
 			_, list, err := genDriftIgnore(opts)

--- a/pkg/cmd/gen_driftignore.go
+++ b/pkg/cmd/gen_driftignore.go
@@ -13,11 +13,10 @@ func NewGenDriftIgnoreCmd() *cobra.Command {
 	opts := &analyser.GenDriftIgnoreOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "gen-driftignore",
-		Short:   "Generate a .driftignore file based on your scan result",
-		Long:    "This command will generate a new .driftignore file containing your current drifts and send output to /dev/stdout",
-		Example: "driftctl scan -o json://stdout | driftctl gen-driftignore",
-		Args:    cobra.NoArgs,
+		Use:   "gen-driftignore",
+		Short: "Generate a .driftignore file based on your scan result",
+		Long:  "This command will generate a new .driftignore file containing your current drifts and send output to /dev/stdout\n\nExample: driftctl scan -o json://stdout | driftctl gen-driftignore > .driftignore",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_, list, err := genDriftIgnore(opts)
 			if err != nil {
@@ -35,7 +34,7 @@ func NewGenDriftIgnoreCmd() *cobra.Command {
 	fl.BoolVar(&opts.ExcludeUnmanaged, "exclude-unmanaged", false, "Exclude resources not managed by IaC")
 	fl.BoolVar(&opts.ExcludeDeleted, "exclude-missing", false, "Exclude missing resources")
 	fl.BoolVar(&opts.ExcludeDrifted, "exclude-changed", false, "Exclude resources that changed on cloud provider")
-	fl.StringVarP(&opts.InputPath, "from", "f", "/dev/stdin", "Input where the JSON should be parsed")
+	fl.StringVarP(&opts.InputPath, "from", "f", "/dev/stdin", "Input where the JSON should be parsed from")
 
 	return cmd
 }

--- a/pkg/cmd/gen_driftignore_test.go
+++ b/pkg/cmd/gen_driftignore_test.go
@@ -59,7 +59,7 @@ func TestGenDriftIgnoreCmd_Input(t *testing.T) {
 			name:   "test error when input flag is not specified",
 			args:   []string{},
 			output: "",
-			err:    errors.New("Error: you need to specify an input to parse JSON from"),
+			err:    errors.New("Error: you must specify an input to parse JSON from. Use driftctl gen-driftignore -i <drifts.json>\nGenerate a JSON file using the output flag: driftctl scan -o json://path/to/drifts.json"),
 		},
 	}
 

--- a/pkg/cmd/gen_driftignore_test.go
+++ b/pkg/cmd/gen_driftignore_test.go
@@ -21,39 +21,45 @@ func TestGenDriftIgnoreCmd_Input(t *testing.T) {
 	}{
 		{
 			name:   "test error on invalid input",
-			args:   []string{"-f", "./testdata/input_stdin_invalid.json"},
+			args:   []string{"-i", "./testdata/input_stdin_invalid.json"},
 			output: "./testdata/output_stdin_empty.txt",
 			err:    errors.New("invalid character 'i' looking for beginning of value"),
 		},
 		{
 			name:   "test empty driftignore with valid input",
-			args:   []string{"-f", "./testdata/input_stdin_empty.json"},
+			args:   []string{"-i", "./testdata/input_stdin_empty.json"},
 			output: "./testdata/output_stdin_empty.txt",
 			err:    nil,
 		},
 		{
 			name:   "test driftignore content with valid input",
-			args:   []string{"-f", "./testdata/input_stdin_valid.json"},
+			args:   []string{"-i", "./testdata/input_stdin_valid.json"},
 			output: "./testdata/output_stdin_valid.txt",
 			err:    nil,
 		},
 		{
 			name:   "test driftignore content with valid input and filter missing & changed only",
-			args:   []string{"-f", "./testdata/input_stdin_valid.json", "--exclude-unmanaged"},
+			args:   []string{"-i", "./testdata/input_stdin_valid.json", "--exclude-unmanaged"},
 			output: "./testdata/output_stdin_valid_filter.txt",
 			err:    nil,
 		},
 		{
 			name:   "test driftignore content with valid input and filter unmanaged only",
-			args:   []string{"-f", "./testdata/input_stdin_valid.json", "--exclude-missing", "--exclude-changed"},
+			args:   []string{"-i", "./testdata/input_stdin_valid.json", "--exclude-missing", "--exclude-changed"},
 			output: "./testdata/output_stdin_valid_filter2.txt",
 			err:    nil,
 		},
 		{
 			name:   "test error when input file does not exist",
-			args:   []string{"-f", "doesnotexist"},
+			args:   []string{"-i", "doesnotexist"},
 			output: "./testdata/output_stdin_valid_filter2.txt",
 			err:    errors.New("open doesnotexist: no such file or directory"),
+		},
+		{
+			name:   "test error when input flag is not specified",
+			args:   []string{},
+			output: "",
+			err:    errors.New("Error: you need to specify an input to parse JSON from"),
 		},
 	}
 
@@ -62,18 +68,13 @@ func TestGenDriftIgnoreCmd_Input(t *testing.T) {
 			rootCmd := &cobra.Command{Use: "root"}
 			rootCmd.AddCommand(NewGenDriftIgnoreCmd())
 
-			output, err := os.ReadFile(c.output)
-			if err != nil {
-				t.Fatal(err)
-			}
-
 			stdout := os.Stdout // keep backup of the real stdout
 			r, w, _ := os.Pipe()
 			os.Stdout = w
 
 			args := append([]string{"gen-driftignore"}, c.args...)
 
-			_, err = test.Execute(rootCmd, args...)
+			_, err := test.Execute(rootCmd, args...)
 			if c.err != nil {
 				assert.EqualError(t, err, c.err.Error())
 				return
@@ -94,7 +95,14 @@ func TestGenDriftIgnoreCmd_Input(t *testing.T) {
 			os.Stdout = stdout // restoring the real stdout
 			result := <-outC
 
-			assert.Equal(t, string(output), string(result))
+			if c.output != "" {
+				output, err := os.ReadFile(c.output)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, string(output), string(result))
+			}
 		})
 	}
 }
@@ -112,8 +120,8 @@ func TestGenDriftIgnoreCmd_ValidFlags(t *testing.T) {
 		{args: []string{"gen-driftignore", "--exclude-missing"}},
 		{args: []string{"gen-driftignore", "--exclude-changed"}},
 		{args: []string{"gen-driftignore", "--exclude-changed=false", "--exclude-missing=false", "--exclude-unmanaged=true"}},
-		{args: []string{"gen-driftignore", "--from", "/dev/stdin"}},
-		{args: []string{"gen-driftignore", "-f", "/dev/stdout"}},
+		{args: []string{"gen-driftignore", "--input", "/dev/stdin"}},
+		{args: []string{"gen-driftignore", "-i", "/dev/stdout"}},
 	}
 
 	for _, tt := range cases {
@@ -141,8 +149,8 @@ func TestGenDriftIgnoreCmd_InvalidFlags(t *testing.T) {
 		{args: []string{"gen-driftignore", "--drifted"}, err: errors.New("unknown flag: --drifted")},
 		{args: []string{"gen-driftignore", "--changed"}, err: errors.New("unknown flag: --changed")},
 		{args: []string{"gen-driftignore", "--missing"}, err: errors.New("unknown flag: --missing")},
-		{args: []string{"gen-driftignore", "--from"}, err: errors.New("flag needs an argument: --from")},
-		{args: []string{"gen-driftignore", "-f"}, err: errors.New("flag needs an argument: 'f' in -f")},
+		{args: []string{"gen-driftignore", "--input"}, err: errors.New("flag needs an argument: --input")},
+		{args: []string{"gen-driftignore", "-i"}, err: errors.New("flag needs an argument: 'i' in -i")},
 	}
 
 	for _, tt := range cases {

--- a/pkg/cmd/gen_driftignore_test.go
+++ b/pkg/cmd/gen_driftignore_test.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/cloudskiff/driftctl/test"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenDriftIgnoreCmd_Input(t *testing.T) {
+	cases := []struct {
+		name   string
+		args   []string
+		output string
+		err    error
+	}{
+		{
+			name:   "test error on invalid input",
+			args:   []string{"-f", "./testdata/input_stdin_invalid.json"},
+			output: "./testdata/output_stdin_empty.txt",
+			err:    errors.New("invalid character 'i' looking for beginning of value"),
+		},
+		{
+			name:   "test empty driftignore with valid input",
+			args:   []string{"-f", "./testdata/input_stdin_empty.json"},
+			output: "./testdata/output_stdin_empty.txt",
+			err:    nil,
+		},
+		{
+			name:   "test driftignore content with valid input",
+			args:   []string{"-f", "./testdata/input_stdin_valid.json"},
+			output: "./testdata/output_stdin_valid.txt",
+			err:    nil,
+		},
+		{
+			name:   "test driftignore content with valid input and filter missing & changed only",
+			args:   []string{"-f", "./testdata/input_stdin_valid.json", "--exclude-unmanaged"},
+			output: "./testdata/output_stdin_valid_filter.txt",
+			err:    nil,
+		},
+		{
+			name:   "test driftignore content with valid input and filter unmanaged only",
+			args:   []string{"-f", "./testdata/input_stdin_valid.json", "--exclude-missing", "--exclude-changed"},
+			output: "./testdata/output_stdin_valid_filter2.txt",
+			err:    nil,
+		},
+		{
+			name:   "test error when input file does not exist",
+			args:   []string{"-f", "doesnotexist"},
+			output: "./testdata/output_stdin_valid_filter2.txt",
+			err:    errors.New("open doesnotexist: no such file or directory"),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rootCmd := &cobra.Command{Use: "root"}
+			rootCmd.AddCommand(NewGenDriftIgnoreCmd())
+
+			output, err := os.ReadFile(c.output)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			stdout := os.Stdout // keep backup of the real stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			args := append([]string{"gen-driftignore"}, c.args...)
+
+			_, err = test.Execute(rootCmd, args...)
+			if c.err != nil {
+				assert.EqualError(t, err, c.err.Error())
+				return
+			} else {
+				assert.Equal(t, c.err, err)
+			}
+
+			outC := make(chan []byte)
+			// copy the output in a separate goroutine so printing can't block indefinitely
+			go func() {
+				var buf bytes.Buffer
+				_, _ = io.Copy(&buf, r)
+				outC <- buf.Bytes()
+			}()
+
+			// back to normal state
+			w.Close()
+			os.Stdout = stdout // restoring the real stdout
+			result := <-outC
+
+			assert.Equal(t, string(output), string(result))
+		})
+	}
+}
+
+func TestGenDriftIgnoreCmd_ValidFlags(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "root"}
+	genDriftIgnoreCmd := NewGenDriftIgnoreCmd()
+	genDriftIgnoreCmd.RunE = func(_ *cobra.Command, args []string) error { return nil }
+	rootCmd.AddCommand(genDriftIgnoreCmd)
+
+	cases := []struct {
+		args []string
+	}{
+		{args: []string{"gen-driftignore", "--exclude-unmanaged"}},
+		{args: []string{"gen-driftignore", "--exclude-missing"}},
+		{args: []string{"gen-driftignore", "--exclude-changed"}},
+		{args: []string{"gen-driftignore", "--exclude-changed=false", "--exclude-missing=false", "--exclude-unmanaged=true"}},
+		{args: []string{"gen-driftignore", "--from", "/dev/stdin"}},
+		{args: []string{"gen-driftignore", "-f", "/dev/stdout"}},
+	}
+
+	for _, tt := range cases {
+		output, err := test.Execute(rootCmd, tt.args...)
+		if output != "" {
+			t.Errorf("Unexpected output: %v", output)
+		}
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+}
+
+func TestGenDriftIgnoreCmd_InvalidFlags(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "root"}
+	genDriftIgnoreCmd := NewGenDriftIgnoreCmd()
+	genDriftIgnoreCmd.RunE = func(_ *cobra.Command, args []string) error { return nil }
+	rootCmd.AddCommand(genDriftIgnoreCmd)
+
+	cases := []struct {
+		args []string
+		err  error
+	}{
+		{args: []string{"gen-driftignore", "--deleted"}, err: errors.New("unknown flag: --deleted")},
+		{args: []string{"gen-driftignore", "--drifted"}, err: errors.New("unknown flag: --drifted")},
+		{args: []string{"gen-driftignore", "--changed"}, err: errors.New("unknown flag: --changed")},
+		{args: []string{"gen-driftignore", "--missing"}, err: errors.New("unknown flag: --missing")},
+		{args: []string{"gen-driftignore", "--from"}, err: errors.New("flag needs an argument: --from")},
+		{args: []string{"gen-driftignore", "-f"}, err: errors.New("flag needs an argument: 'f' in -f")},
+	}
+
+	for _, tt := range cases {
+		_, err := test.Execute(rootCmd, tt.args...)
+		assert.EqualError(t, err, tt.err.Error())
+	}
+}

--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -201,11 +201,9 @@ func scanRun(opts *pkg.ScanOptions) error {
 		telemetry.SendTelemetry(analysis)
 	}
 
-	if analysis.Summary().TotalResources-analysis.Summary().TotalManaged > 0 {
-		fmt.Println("\nHint: use gen-driftignore command to generate a .driftignore file based on your drifts")
-	}
-
 	if !analysis.IsSync() {
+		globaloutput.Printf("\nHint: use gen-driftignore command to generate a .driftignore file based on your drifts\n")
+
 		return cmderrors.InfrastructureNotInSync{}
 	}
 

--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -201,6 +201,10 @@ func scanRun(opts *pkg.ScanOptions) error {
 		telemetry.SendTelemetry(analysis)
 	}
 
+	if analysis.Summary().TotalResources-analysis.Summary().TotalManaged > 0 {
+		fmt.Println("\nHint: use gen-driftignore command to generate a .driftignore file based on your drifts")
+	}
+
 	if !analysis.IsSync() {
 		return cmderrors.InfrastructureNotInSync{}
 	}

--- a/pkg/cmd/testdata/input_stdin_empty.json
+++ b/pkg/cmd/testdata/input_stdin_empty.json
@@ -1,0 +1,15 @@
+{
+  "summary": {
+    "total_resources": 0,
+    "total_changed": 0,
+    "total_unmanaged": 0,
+    "total_missing": 0,
+    "total_managed": 0
+  },
+  "managed": null,
+  "unmanaged": null,
+  "missing": null,
+  "differences": null,
+  "coverage": 0,
+  "alerts": null
+}

--- a/pkg/cmd/testdata/input_stdin_invalid.json
+++ b/pkg/cmd/testdata/input_stdin_invalid.json
@@ -1,0 +1,1 @@
+invalid

--- a/pkg/cmd/testdata/input_stdin_valid.json
+++ b/pkg/cmd/testdata/input_stdin_valid.json
@@ -1,0 +1,112 @@
+{
+  "summary": {
+    "total_resources": 12,
+    "total_changed": 1,
+    "total_unmanaged": 11,
+    "total_missing": 0,
+    "total_managed": 1
+  },
+  "managed": [
+    {
+      "id": "test-20210416154114486700000001",
+      "type": "aws_s3_bucket"
+    }
+  ],
+  "unmanaged": [
+    {
+      "id": "driftctl",
+      "type": "aws_iam_user"
+    },
+    {
+      "id": "sundowndev",
+      "type": "aws_iam_user"
+    },
+    {
+      "id": "test_user",
+      "type": "aws_iam_user"
+    },
+    {
+      "id": "OrganizationAccountAccessRole:AdministratorAccess",
+      "type": "aws_iam_role_policy"
+    },
+    {
+      "id": "driftctl_assume_role:driftctl_policy.10",
+      "type": "aws_iam_role_policy"
+    },
+    {
+      "id": "OrganizationAccountAccessRole",
+      "type": "aws_iam_role"
+    },
+    {
+      "id": "driftctl_assume\\_role",
+      "type": "aws_iam_role"
+    },
+    {
+      "id": "driftctl:driftctlrole",
+      "type": "aws_iam_user_policy"
+    },
+    {
+      "id": "AKIAXYUOJZ3H5YCXF34G",
+      "type": "aws_iam_access_key"
+    },
+    {
+      "id": "AKIAXYUOJZ3HV2LTLXD2",
+      "type": "aws_iam_access_key"
+    },
+    {
+      "id": "AKIAXYUOJZ3HUSPPQQ4L",
+      "type": "aws_iam_access_key"
+    }
+  ],
+  "missing": [
+    {
+      "id": "testuser1",
+      "type": "aws_iam_user"
+    },
+    {
+      "id": "testrole1",
+      "type": "aws_iam_role"
+    }
+  ],
+  "differences": [
+    {
+      "res": {
+        "id": "test-20210416154114486700000001",
+        "type": "aws_s3_bucket"
+      },
+      "changelog": [
+        {
+          "type": "update",
+          "path": [
+            "BucketPrefix"
+          ],
+          "from": "test-",
+          "to": null,
+          "computed": false
+        },
+        {
+          "type": "create",
+          "path": [
+            "Tags",
+            "tag2"
+          ],
+          "from": null,
+          "to": "value",
+          "computed": false
+        },
+        {
+          "type": "update",
+          "path": [
+            "Tags",
+            "test"
+          ],
+          "from": "test",
+          "to": "test1",
+          "computed": false
+        }
+      ]
+    }
+  ],
+  "coverage": 8,
+  "alerts": null
+}

--- a/pkg/cmd/testdata/output_stdin_valid.txt
+++ b/pkg/cmd/testdata/output_stdin_valid.txt
@@ -1,0 +1,17 @@
+# Resources not covered by IaC
+aws_iam_user.driftctl
+aws_iam_user.sundowndev
+aws_iam_user.test_user
+aws_iam_role_policy.OrganizationAccountAccessRole:AdministratorAccess
+aws_iam_role_policy.driftctl_assume_role:driftctl_policy\.10
+aws_iam_role.OrganizationAccountAccessRole
+aws_iam_role.driftctl_assume\\_role
+aws_iam_user_policy.driftctl:driftctlrole
+aws_iam_access_key.AKIAXYUOJZ3H5YCXF34G
+aws_iam_access_key.AKIAXYUOJZ3HV2LTLXD2
+aws_iam_access_key.AKIAXYUOJZ3HUSPPQQ4L
+# Missing resources
+aws_iam_user.testuser1
+aws_iam_role.testrole1
+# Changed resources
+aws_s3_bucket.test-20210416154114486700000001

--- a/pkg/cmd/testdata/output_stdin_valid_filter.txt
+++ b/pkg/cmd/testdata/output_stdin_valid_filter.txt
@@ -1,0 +1,5 @@
+# Missing resources
+aws_iam_user.testuser1
+aws_iam_role.testrole1
+# Changed resources
+aws_s3_bucket.test-20210416154114486700000001

--- a/pkg/cmd/testdata/output_stdin_valid_filter2.txt
+++ b/pkg/cmd/testdata/output_stdin_valid_filter2.txt
@@ -1,0 +1,12 @@
+# Resources not covered by IaC
+aws_iam_user.driftctl
+aws_iam_user.sundowndev
+aws_iam_user.test_user
+aws_iam_role_policy.OrganizationAccountAccessRole:AdministratorAccess
+aws_iam_role_policy.driftctl_assume_role:driftctl_policy\.10
+aws_iam_role.OrganizationAccountAccessRole
+aws_iam_role.driftctl_assume\\_role
+aws_iam_user_policy.driftctl:driftctlrole
+aws_iam_access_key.AKIAXYUOJZ3H5YCXF34G
+aws_iam_access_key.AKIAXYUOJZ3HV2LTLXD2
+aws_iam_access_key.AKIAXYUOJZ3HUSPPQQ4L


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #415
| ❓ Documentation  | yes <!-- does this require documentation update ? -->

**:warning: NOTICE: this is a backport of #433 into v0.9.0. This feature was removed of v0.8.0 because of UX issues.** The whole feature should be reviewed again. Few improvements has been made in the CLI documentation to help end-user better understand how to use the command.

TL;DR: The purpose of this change is to be able to generate a .driftignore file containing current drifts.

## Context

New users can struggle when trying the tool because the output is too large and hard to read. They might want to ignore all the current drifts so they can start introduce the tool in their workflow quickly and fix the current issues later. This feature allows them to create a driftignore file from a JSON output.

## Flags

- `--exclude-unmanaged` allows to control whether unmanaged resources are included or not
- `--exclude-missing` allows to control whether missing resources are included or not
- `--exclude-changed` allows to control whether changed resources are included or not

## Examples

```shell
# Ignore all current drifts
$ driftctl scan -o json://stdout | driftctl gen-driftignore -f /dev/stdin > .driftignore

# Changed resources will not be included
$ driftctl scan --from tfstate://state1.tfstate -o json://stdout | driftctl gen-driftignore --exclude-changed

# Unmanaged resources will not be included
$ cat result.json | driftctl gen-driftignore --exclude-unmanaged
```