### PR TITLE
Disable count in scan progress bar

### DIFF
--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -156,7 +156,7 @@ func scanRun(opts *pkg.ScanOptions) error {
 	supplierLibrary := resource.NewSupplierLibrary()
 
 	iacProgress := globaloutput.NewProgress("Scanning states", "Scanned states", true)
-	scanProgress := globaloutput.NewProgress("Scanning resources", "Scanned resources", true)
+	scanProgress := globaloutput.NewProgress("Scanning resources", "Scanned resources", false)
 
 	resourceSchemaRepository := resource.NewSchemaRepository()
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #476
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Previously, the total number of scanned resources was not the same as the one "found". Reason includes resources ignored, filtered, or internally processed. This patch removes the count from the scan progress bar.