### PR TITLE
Add number of driftignore lines to telemetry

### DIFF
--- a/pkg/analyser/analysis.go
+++ b/pkg/analyser/analysis.go
@@ -35,14 +35,15 @@ type Summary struct {
 }
 
 type Analysis struct {
-	unmanaged   []resource.Resource
-	managed     []resource.Resource
-	deleted     []resource.Resource
-	differences []Difference
-	summary     Summary
-	alerts      alerter.Alerts
-	Duration    time.Duration
-	Date        time.Time
+	unmanaged        []resource.Resource
+	managed          []resource.Resource
+	deleted          []resource.Resource
+	differences      []Difference
+	summary          Summary
+	alerts           alerter.Alerts
+	Duration         time.Duration
+	Date             time.Time
+	IgnoreRulesCount int
 }
 
 type serializableDifference struct {

--- a/pkg/analyser/analysis.go
+++ b/pkg/analyser/analysis.go
@@ -35,15 +35,14 @@ type Summary struct {
 }
 
 type Analysis struct {
-	unmanaged        []resource.Resource
-	managed          []resource.Resource
-	deleted          []resource.Resource
-	differences      []Difference
-	summary          Summary
-	alerts           alerter.Alerts
-	Duration         time.Duration
-	Date             time.Time
-	IgnoreRulesCount int
+	unmanaged   []resource.Resource
+	managed     []resource.Resource
+	deleted     []resource.Resource
+	differences []Difference
+	summary     Summary
+	alerts      alerter.Alerts
+	Duration    time.Duration
+	Date        time.Time
 }
 
 type serializableDifference struct {

--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -224,7 +224,7 @@ func scanRun(opts *pkg.ScanOptions) error {
 		ctl.Stop()
 	}()
 
-	analysis, err := ctl.Run()
+	analysis, ignoreRulesCount, err := ctl.Run()
 	if err != nil {
 		return err
 	}
@@ -237,7 +237,7 @@ func scanRun(opts *pkg.ScanOptions) error {
 	globaloutput.Printf(color.WhiteString("Scan duration: %s\n", analysis.Duration.Round(time.Second)))
 
 	if !opts.DisableTelemetry {
-		telemetry.SendTelemetry(analysis)
+		telemetry.SendTelemetry(analysis, ignoreRulesCount)
 	}
 
 	globaloutput.Printf(color.WhiteString("Provider version used to scan: %s. Use --tf-provider-version to use another version.\n"), resourceSchemaRepository.ProviderVersion.String())

--- a/pkg/driftctl.go
+++ b/pkg/driftctl.go
@@ -135,6 +135,7 @@ func (d DriftCTL) Run() (*analyser.Analysis, error) {
 
 	analysis.Duration = time.Since(start)
 	analysis.Date = time.Now()
+	analysis.IgnoreRulesCount = driftIgnore.RulesCount()
 
 	return &analysis, nil
 }

--- a/pkg/driftctl_test.go
+++ b/pkg/driftctl_test.go
@@ -100,7 +100,7 @@ func runTest(t *testing.T, cases TestCases) {
 
 			driftctl := pkg.NewDriftCTL(remoteSupplier, stateSupplier, testAlerter, resourceFactory, c.options, scanProgress, iacProgress, repo)
 
-			analysis, err := driftctl.Run()
+			analysis, _, err := driftctl.Run()
 
 			c.assert(test.NewScanResult(t, analysis), err)
 			scanProgress.AssertExpectations(t)

--- a/pkg/filter/driftignore_test.go
+++ b/pkg/filter/driftignore_test.go
@@ -14,10 +14,11 @@ import (
 
 func TestDriftIgnore_IsResourceIgnored(t *testing.T) {
 	tests := []struct {
-		name      string
-		resources []resource.Resource
-		want      []bool
-		path      string
+		name       string
+		resources  []resource.Resource
+		want       []bool
+		path       string
+		rulesCount int
 	}{
 		{
 			name: "drift_ignore_no_file",
@@ -30,7 +31,8 @@ func TestDriftIgnore_IsResourceIgnored(t *testing.T) {
 			want: []bool{
 				false,
 			},
-			path: "testdata/drift_ignore_no_file/.driftignore",
+			path:       "testdata/drift_ignore_no_file/.driftignore",
+			rulesCount: 0,
 		},
 		{
 			name: "drift_ignore_empty",
@@ -43,7 +45,8 @@ func TestDriftIgnore_IsResourceIgnored(t *testing.T) {
 			want: []bool{
 				false,
 			},
-			path: "testdata/drift_ignore_empty/.driftignore",
+			path:       "testdata/drift_ignore_empty/.driftignore",
+			rulesCount: 0,
 		},
 		{
 			name: "drift_ignore_invalid_lines",
@@ -61,7 +64,8 @@ func TestDriftIgnore_IsResourceIgnored(t *testing.T) {
 				false,
 				true,
 			},
-			path: "testdata/drift_ignore_invalid_lines/.driftignore",
+			path:       "testdata/drift_ignore_invalid_lines/.driftignore",
+			rulesCount: 8,
 		},
 		{
 			name: "drift_ignore_valid",
@@ -119,7 +123,8 @@ func TestDriftIgnore_IsResourceIgnored(t *testing.T) {
 				true,
 				true,
 			},
-			path: "testdata/drift_ignore_valid/.driftignore",
+			path:       "testdata/drift_ignore_valid/.driftignore",
+			rulesCount: 6,
 		},
 		{
 			name: "drift_ignore_wildcard",
@@ -162,7 +167,8 @@ func TestDriftIgnore_IsResourceIgnored(t *testing.T) {
 				false,
 				true,
 			},
-			path: "testdata/drift_ignore_wildcard/.driftignore",
+			path:       "testdata/drift_ignore_wildcard/.driftignore",
+			rulesCount: 3,
 		},
 		{
 			name: "drift_ignore_all_exclude",
@@ -215,7 +221,8 @@ func TestDriftIgnore_IsResourceIgnored(t *testing.T) {
 				false,
 				true,
 			},
-			path: "testdata/drift_ignore_all_exclude/.driftignore",
+			path:       "testdata/drift_ignore_all_exclude/.driftignore",
+			rulesCount: 3,
 		},
 	}
 	for _, tt := range tests {
@@ -229,6 +236,7 @@ func TestDriftIgnore_IsResourceIgnored(t *testing.T) {
 				got = append(got, r.IsResourceIgnored(res))
 			}
 			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.rulesCount, r.RulesCount())
 		})
 	}
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -12,12 +12,13 @@ import (
 )
 
 type telemetry struct {
-	Version        string `json:"version"`
-	Os             string `json:"os"`
-	Arch           string `json:"arch"`
-	TotalResources int    `json:"total_resources"`
-	TotalManaged   int    `json:"total_managed"`
-	Duration       uint   `json:"duration"`
+	Version          string `json:"version"`
+	Os               string `json:"os"`
+	Arch             string `json:"arch"`
+	TotalResources   int    `json:"total_resources"`
+	TotalManaged     int    `json:"total_managed"`
+	Duration         uint   `json:"duration"`
+	IgnoreRulesCount int    `json:"ignore_rules_count"`
 }
 
 func SendTelemetry(analysis *analyser.Analysis) {
@@ -27,12 +28,13 @@ func SendTelemetry(analysis *analyser.Analysis) {
 	}
 
 	t := telemetry{
-		Version:        version.Current(),
-		Os:             runtime.GOOS,
-		Arch:           runtime.GOARCH,
-		TotalResources: analysis.Summary().TotalResources,
-		TotalManaged:   analysis.Summary().TotalManaged,
-		Duration:       uint(analysis.Duration.Seconds() + 0.5),
+		Version:          version.Current(),
+		Os:               runtime.GOOS,
+		Arch:             runtime.GOARCH,
+		TotalResources:   analysis.Summary().TotalResources,
+		TotalManaged:     analysis.Summary().TotalManaged,
+		Duration:         uint(analysis.Duration.Seconds() + 0.5),
+		IgnoreRulesCount: analysis.IgnoreRulesCount,
 	}
 
 	body, err := json.Marshal(t)

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -21,7 +21,7 @@ type telemetry struct {
 	IgnoreRulesCount int    `json:"ignore_rules_count"`
 }
 
-func SendTelemetry(analysis *analyser.Analysis) {
+func SendTelemetry(analysis *analyser.Analysis, ignoreRulesCount int) {
 
 	if analysis == nil {
 		return
@@ -34,7 +34,7 @@ func SendTelemetry(analysis *analyser.Analysis) {
 		TotalResources:   analysis.Summary().TotalResources,
 		TotalManaged:     analysis.Summary().TotalManaged,
 		Duration:         uint(analysis.Duration.Seconds() + 0.5),
-		IgnoreRulesCount: analysis.IgnoreRulesCount,
+		IgnoreRulesCount: ignoreRulesCount,
 	}
 
 	body, err := json.Marshal(t)

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -20,10 +20,11 @@ func TestSendTelemetry(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 
 	tests := []struct {
-		name         string
-		analysis     *analyser.Analysis
-		expectedBody *telemetry
-		response     *http.Response
+		name             string
+		analysis         *analyser.Analysis
+		IgnoreRulesCount int
+		expectedBody     *telemetry
+		response         *http.Response
 	}{
 		{
 			name: "valid analysis",
@@ -32,9 +33,9 @@ func TestSendTelemetry(t *testing.T) {
 				a.AddManaged(&resource.FakeResource{})
 				a.AddUnmanaged(&resource.FakeResource{})
 				a.Duration = 123.4 * 1e9 // 123.4 seconds
-				a.IgnoreRulesCount = 24
 				return a
 			}(),
+			IgnoreRulesCount: 24,
 			expectedBody: &telemetry{
 				Version:          version.Current(),
 				Os:               runtime.GOOS,
@@ -93,7 +94,7 @@ func TestSendTelemetry(t *testing.T) {
 					},
 				)
 			}
-			SendTelemetry(tt.analysis)
+			SendTelemetry(tt.analysis, tt.IgnoreRulesCount)
 		})
 	}
 }

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -32,15 +32,17 @@ func TestSendTelemetry(t *testing.T) {
 				a.AddManaged(&resource.FakeResource{})
 				a.AddUnmanaged(&resource.FakeResource{})
 				a.Duration = 123.4 * 1e9 // 123.4 seconds
+				a.IgnoreRulesCount = 24
 				return a
 			}(),
 			expectedBody: &telemetry{
-				Version:        version.Current(),
-				Os:             runtime.GOOS,
-				Arch:           runtime.GOARCH,
-				TotalResources: 2,
-				TotalManaged:   1,
-				Duration:       123,
+				Version:          version.Current(),
+				Os:               runtime.GOOS,
+				Arch:             runtime.GOARCH,
+				TotalResources:   2,
+				TotalManaged:     1,
+				Duration:         123,
+				IgnoreRulesCount: 24,
 			},
 		},
 		{


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #443
| ❓ Documentation  | yes <!-- does this require documentation update ? -->

## Description

This PR adds number of driftignore lines to telemetry.