### PR TITLE
Add nat_gateways to ec2_repository

### DIFF
--- a/pkg/remote/aws/repository/ec2_repository.go
+++ b/pkg/remote/aws/repository/ec2_repository.go
@@ -17,6 +17,7 @@ type EC2Repository interface {
 	ListAllKeyPairs() ([]*ec2.KeyPairInfo, error)
 	ListAllInternetGateways() ([]*ec2.InternetGateway, error)
 	ListAllSubnets() ([]*ec2.Subnet, []*ec2.Subnet, error)
+	ListAllNatGateways() ([]*ec2.NatGateway, error)
 }
 
 type EC2Client interface {
@@ -157,4 +158,21 @@ func (r *ec2Repository) ListAllSubnets() ([]*ec2.Subnet, []*ec2.Subnet, error) {
 		return nil, nil, err
 	}
 	return subnets, defaultSubnets, nil
+}
+
+func (r *ec2Repository) ListAllNatGateways() ([]*ec2.NatGateway, error) {
+	var result []*ec2.NatGateway
+	input := ec2.DescribeNatGatewaysInput{}
+	err := r.client.DescribeNatGatewaysPages(&input,
+		func(resp *ec2.DescribeNatGatewaysOutput, lastPage bool) bool {
+			result = append(result, resp.NatGateways...)
+			return !lastPage
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/pkg/remote/aws/repository/ec2_repository_test.go
+++ b/pkg/remote/aws/repository/ec2_repository_test.go
@@ -615,3 +615,76 @@ func Test_ec2Repository_ListAllSubnets(t *testing.T) {
 		})
 	}
 }
+
+func Test_ec2Repository_ListAllNatGateways(t *testing.T) {
+	tests := []struct {
+		name    string
+		mocks   func(client *MockEC2Client)
+		want    []*ec2.NatGateway
+		wantErr error
+	}{
+		{
+			name: "List only gateways with multiple pages",
+			mocks: func(client *MockEC2Client) {
+				client.On("DescribeNatGatewaysPages",
+					&ec2.DescribeNatGatewaysInput{},
+					mock.MatchedBy(func(callback func(res *ec2.DescribeNatGatewaysOutput, lastPage bool) bool) bool {
+						callback(&ec2.DescribeNatGatewaysOutput{
+							NatGateways: []*ec2.NatGateway{
+								{
+									NatGatewayId: aws.String("nat-0"),
+								},
+								{
+									NatGatewayId: aws.String("nat-1"),
+								},
+							},
+						}, false)
+						callback(&ec2.DescribeNatGatewaysOutput{
+							NatGateways: []*ec2.NatGateway{
+								{
+									NatGatewayId: aws.String("nat-2"),
+								},
+								{
+									NatGatewayId: aws.String("nat-3"),
+								},
+							},
+						}, true)
+						return true
+					})).Return(nil)
+			},
+			want: []*ec2.NatGateway{
+				{
+					NatGatewayId: aws.String("nat-0"),
+				},
+				{
+					NatGatewayId: aws.String("nat-1"),
+				},
+				{
+					NatGatewayId: aws.String("nat-2"),
+				},
+				{
+					NatGatewayId: aws.String("nat-3"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &MockEC2Client{}
+			tt.mocks(client)
+			r := &ec2Repository{
+				client: client,
+			}
+			got, err := r.ListAllNatGateways()
+			assert.Equal(t, tt.wantErr, err)
+			changelog, err := diff.Diff(got, tt.want)
+			assert.Nil(t, err)
+			if len(changelog) > 0 {
+				for _, change := range changelog {
+					t.Errorf("%s: %s -> %s", strings.Join(change.Path, "."), change.From, change.To)
+				}
+				t.Fail()
+			}
+		})
+	}
+}

--- a/pkg/remote/aws/repository/mock_EC2Repository.go
+++ b/pkg/remote/aws/repository/mock_EC2Repository.go
@@ -58,6 +58,29 @@ func (_m *MockEC2Repository) ListAllAddressesAssociation() ([]string, error) {
 	return r0, r1
 }
 
+// ListAllNatGateways provides a mock function with given fields:
+func (_m *MockEC2Repository) ListAllNatGateways() ([]*ec2.NatGateway, error) {
+	ret := _m.Called()
+
+	var r0 []*ec2.NatGateway
+	if rf, ok := ret.Get(0).(func() []*ec2.NatGateway); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*ec2.NatGateway)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListAllImages provides a mock function with given fields:
 func (_m *MockEC2Repository) ListAllImages() ([]*ec2.Image, error) {
 	ret := _m.Called()


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #165 
| ❓ Documentation  | no

## Description

Add nat_gateway_supplier to ec2_repository to avoid possible hidden dependency.