### PR TITLE
Fix terraform file for db_subnet_group

### DIFF
--- a/pkg/resource/aws/testdata/acc/aws_db_subnet_group/terraform.tf
+++ b/pkg/resource/aws/testdata/acc/aws_db_subnet_group/terraform.tf
@@ -15,21 +15,25 @@ resource "aws_vpc" "vpc" {
 resource "aws_subnet" "subnet1" {
     vpc_id = aws_vpc.vpc.id
     cidr_block = "10.1.0.0/24"
+    availability_zone = "us-east-1a"
 }
 
 resource "aws_subnet" "subnet2" {
     vpc_id = aws_vpc.vpc.id
     cidr_block = "10.1.1.0/24"
+    availability_zone = "us-east-1b"
 }
 
 resource "aws_subnet" "subnet3" {
     vpc_id = aws_vpc.vpc.id
     cidr_block = "10.1.2.0/24"
+    availability_zone = "us-east-1c"
 }
 
 resource "aws_subnet" "subnet4" {
     vpc_id = aws_vpc.vpc.id
     cidr_block = "10.1.3.0/24"
+    availability_zone = "us-east-1a"
 }
 
 resource "aws_db_subnet_group" "foo" {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | 
| ❓ Documentation  | no

## Description

Needed 2 subnets in 2 different AZ to make the db_subnet_group work as expected.