### PR TITLE
Add route_table and route_table_association to ec2_repository

### DIFF
--- a/pkg/remote/aws/route_table_association_supplier.go
+++ b/pkg/remote/aws/route_table_association_supplier.go
@@ -2,8 +2,9 @@ package aws
 
 import (
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/cloudskiff/driftctl/pkg/remote/aws/repository"
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
+	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	"github.com/cloudskiff/driftctl/pkg/resource/aws"
 	awsdeserializer "github.com/cloudskiff/driftctl/pkg/resource/aws/deserializer"
@@ -16,7 +17,7 @@ import (
 type RouteTableAssociationSupplier struct {
 	reader       terraform.ResourceReader
 	deserializer deserializer.CTYDeserializer
-	client       ec2iface.EC2API
+	client       repository.EC2Repository
 	runner       *terraform.ParallelResourceReader
 }
 
@@ -24,16 +25,15 @@ func NewRouteTableAssociationSupplier(provider *AWSTerraformProvider) *RouteTabl
 	return &RouteTableAssociationSupplier{
 		provider,
 		awsdeserializer.NewRouteTableAssociationDeserializer(),
-		ec2.New(provider.session),
+		repository.NewEC2Repository(provider.session),
 		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 
 func (s *RouteTableAssociationSupplier) Resources() ([]resource.Resource, error) {
-
-	tables, err := listRouteTables(s.client, aws.AwsRouteTableAssociationResourceType)
+	tables, err := s.client.ListAllRouteTables()
 	if err != nil {
-		return nil, err
+		return nil, remoteerror.NewResourceEnumerationErrorWithType(err, aws.AwsRouteTableAssociationResourceType, aws.AwsRouteTableResourceType)
 	}
 
 	for _, t := range tables {

--- a/pkg/remote/aws/route_table_association_supplier_test.go
+++ b/pkg/remote/aws/route_table_association_supplier_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cloudskiff/driftctl/pkg/remote/aws/repository"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	resourceaws "github.com/cloudskiff/driftctl/pkg/resource/aws"
@@ -12,7 +13,6 @@ import (
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/cloudskiff/driftctl/mocks"
 	"github.com/cloudskiff/driftctl/pkg/parallel"
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
 	"github.com/cloudskiff/driftctl/pkg/resource"
@@ -29,122 +29,104 @@ func TestRouteTableAssociationSupplier_Resources(t *testing.T) {
 	cases := []struct {
 		test    string
 		dirName string
-		mocks   func(client *mocks.FakeEC2)
+		mocks   func(client *repository.MockEC2Repository)
 		err     error
 	}{
 		{
 			test:    "no route table associations (test for nil values)",
 			dirName: "route_table_assoc_empty",
-			mocks: func(client *mocks.FakeEC2) {
-				client.On("DescribeRouteTablesPages",
-					&ec2.DescribeRouteTablesInput{},
-					mock.MatchedBy(func(callback func(res *ec2.DescribeRouteTablesOutput, lastPage bool) bool) bool {
-						callback(&ec2.DescribeRouteTablesOutput{
-							RouteTables: []*ec2.RouteTable{
-								{
-									RouteTableId: awssdk.String("assoc_with_nil"),
-									Associations: []*ec2.RouteTableAssociation{
-										{
-											AssociationState:        nil,
-											GatewayId:               nil,
-											Main:                    nil,
-											RouteTableAssociationId: nil,
-											RouteTableId:            nil,
-											SubnetId:                nil,
-										},
-									},
-								},
-								{
-									RouteTableId: awssdk.String("nil_assoc"),
-								},
+			mocks: func(client *repository.MockEC2Repository) {
+				client.On("ListAllRouteTables").Once().Return([]*ec2.RouteTable{
+					{
+						RouteTableId: awssdk.String("assoc_with_nil"),
+						Associations: []*ec2.RouteTableAssociation{
+							{
+								AssociationState:        nil,
+								GatewayId:               nil,
+								Main:                    nil,
+								RouteTableAssociationId: nil,
+								RouteTableId:            nil,
+								SubnetId:                nil,
 							},
-						}, true)
-						return true
-					})).Return(nil)
+						},
+					},
+					{
+						RouteTableId: awssdk.String("nil_assoc"),
+					},
+				}, nil)
 			},
 			err: nil,
 		},
 		{
 			test:    "route_table_association (mixed subnet and gateway associations)",
 			dirName: "route_table_assoc",
-			mocks: func(client *mocks.FakeEC2) {
-				client.On("DescribeRouteTablesPages",
-					&ec2.DescribeRouteTablesInput{},
-					mock.MatchedBy(func(callback func(res *ec2.DescribeRouteTablesOutput, lastPage bool) bool) bool {
-						callback(&ec2.DescribeRouteTablesOutput{
-							RouteTables: []*ec2.RouteTable{
-								{
-									RouteTableId: aws.String("rtb-05aa6c5673311a17b"), // route
-									Associations: []*ec2.RouteTableAssociation{
-										{ // Should be ignored
-											AssociationState: &ec2.RouteTableAssociationState{
-												State: awssdk.String("disassociated"),
-											},
-											GatewayId: awssdk.String("dummy-id"),
-										},
-										{ // Should be ignored
-											SubnetId:  nil,
-											GatewayId: nil,
-										},
-										{ // assoc_route_subnet1
-											AssociationState: &ec2.RouteTableAssociationState{
-												State: awssdk.String("associated"),
-											},
-											Main:                    awssdk.Bool(false),
-											RouteTableAssociationId: awssdk.String("rtbassoc-0809598f92dbec03b"),
-											RouteTableId:            awssdk.String("rtb-05aa6c5673311a17b"),
-											SubnetId:                awssdk.String("subnet-05185af647b2eeda3"),
-										},
-										{ // assoc_route_subnet
-											AssociationState: &ec2.RouteTableAssociationState{
-												State: awssdk.String("associated"),
-											},
-											Main:                    awssdk.Bool(false),
-											RouteTableAssociationId: awssdk.String("rtbassoc-01957791b2cfe6ea4"),
-											RouteTableId:            awssdk.String("rtb-05aa6c5673311a17b"),
-											SubnetId:                awssdk.String("subnet-0e93dbfa2e5dd8282"),
-										},
-										{ // assoc_route_subnet2
-											AssociationState: &ec2.RouteTableAssociationState{
-												State: awssdk.String("associated"),
-											},
-											GatewayId:               nil,
-											Main:                    awssdk.Bool(false),
-											RouteTableAssociationId: awssdk.String("rtbassoc-0b4f97ea57490e213"),
-											RouteTableId:            awssdk.String("rtb-05aa6c5673311a17b"),
-											SubnetId:                awssdk.String("subnet-0fd966efd884d0362"),
-										},
-									},
+			mocks: func(client *repository.MockEC2Repository) {
+				client.On("ListAllRouteTables").Once().Return([]*ec2.RouteTable{
+					{
+						RouteTableId: aws.String("rtb-05aa6c5673311a17b"), // route
+						Associations: []*ec2.RouteTableAssociation{
+							{ // Should be ignored
+								AssociationState: &ec2.RouteTableAssociationState{
+									State: awssdk.String("disassociated"),
 								},
-								{
-									RouteTableId: aws.String("rtb-09df7cc9d16de9f8f"), // route2
-									Associations: []*ec2.RouteTableAssociation{
-										{ // assoc_route2_gateway
-											AssociationState: &ec2.RouteTableAssociationState{
-												State: awssdk.String("associated"),
-											},
-											RouteTableAssociationId: awssdk.String("rtbassoc-0a79ccacfceb4944b"),
-											RouteTableId:            awssdk.String("rtb-09df7cc9d16de9f8f"),
-											GatewayId:               awssdk.String("igw-0238f6e09185ac954"),
-										},
-									},
-								},
+								GatewayId: awssdk.String("dummy-id"),
 							},
-						}, true)
-						return true
-					})).Return(nil)
+							{ // Should be ignored
+								SubnetId:  nil,
+								GatewayId: nil,
+							},
+							{ // assoc_route_subnet1
+								AssociationState: &ec2.RouteTableAssociationState{
+									State: awssdk.String("associated"),
+								},
+								Main:                    awssdk.Bool(false),
+								RouteTableAssociationId: awssdk.String("rtbassoc-0809598f92dbec03b"),
+								RouteTableId:            awssdk.String("rtb-05aa6c5673311a17b"),
+								SubnetId:                awssdk.String("subnet-05185af647b2eeda3"),
+							},
+							{ // assoc_route_subnet
+								AssociationState: &ec2.RouteTableAssociationState{
+									State: awssdk.String("associated"),
+								},
+								Main:                    awssdk.Bool(false),
+								RouteTableAssociationId: awssdk.String("rtbassoc-01957791b2cfe6ea4"),
+								RouteTableId:            awssdk.String("rtb-05aa6c5673311a17b"),
+								SubnetId:                awssdk.String("subnet-0e93dbfa2e5dd8282"),
+							},
+							{ // assoc_route_subnet2
+								AssociationState: &ec2.RouteTableAssociationState{
+									State: awssdk.String("associated"),
+								},
+								GatewayId:               nil,
+								Main:                    awssdk.Bool(false),
+								RouteTableAssociationId: awssdk.String("rtbassoc-0b4f97ea57490e213"),
+								RouteTableId:            awssdk.String("rtb-05aa6c5673311a17b"),
+								SubnetId:                awssdk.String("subnet-0fd966efd884d0362"),
+							},
+						},
+					},
+					{
+						RouteTableId: aws.String("rtb-09df7cc9d16de9f8f"), // route2
+						Associations: []*ec2.RouteTableAssociation{
+							{ // assoc_route2_gateway
+								AssociationState: &ec2.RouteTableAssociationState{
+									State: awssdk.String("associated"),
+								},
+								RouteTableAssociationId: awssdk.String("rtbassoc-0a79ccacfceb4944b"),
+								RouteTableId:            awssdk.String("rtb-09df7cc9d16de9f8f"),
+								GatewayId:               awssdk.String("igw-0238f6e09185ac954"),
+							},
+						},
+					},
+				}, nil)
 			},
 			err: nil,
 		},
 		{
 			test:    "Cannot list route table",
 			dirName: "route_table_assoc_empty",
-			mocks: func(client *mocks.FakeEC2) {
-				client.On("DescribeRouteTablesPages",
-					&ec2.DescribeRouteTablesInput{},
-					mock.MatchedBy(func(callback func(res *ec2.DescribeRouteTablesOutput, lastPage bool) bool) bool {
-						return true
-					})).Return(awserr.NewRequestFailure(nil, 403, ""))
+			mocks: func(client *repository.MockEC2Repository) {
+				client.On("ListAllRouteTables").Once().Return(nil, awserr.NewRequestFailure(nil, 403, ""))
 			},
 			err: remoteerror.NewResourceEnumerationErrorWithType(awserr.NewRequestFailure(nil, 403, ""), resourceaws.AwsRouteTableAssociationResourceType, resourceaws.AwsRouteTableResourceType),
 		},
@@ -164,7 +146,7 @@ func TestRouteTableAssociationSupplier_Resources(t *testing.T) {
 		}
 
 		t.Run(c.test, func(tt *testing.T) {
-			fakeEC2 := mocks.FakeEC2{}
+			fakeEC2 := repository.MockEC2Repository{}
 			c.mocks(&fakeEC2)
 			provider := mocks2.NewMockedGoldenTFProvider(c.dirName, providerLibrary.Provider(terraform.AWS), shouldUpdate)
 			routeTableAssociationDeserializer := awsdeserializer.NewRouteTableAssociationDeserializer()

--- a/pkg/remote/aws/route_table_supplier.go
+++ b/pkg/remote/aws/route_table_supplier.go
@@ -3,10 +3,10 @@ package aws
 import (
 	"errors"
 
+	"github.com/cloudskiff/driftctl/pkg/remote/aws/repository"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/cloudskiff/driftctl/pkg/remote/deserializer"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	"github.com/cloudskiff/driftctl/pkg/resource/aws"
@@ -21,7 +21,7 @@ type RouteTableSupplier struct {
 	reader                        terraform.ResourceReader
 	defaultRouteTableDeserializer deserializer.CTYDeserializer
 	routeTableDeserializer        deserializer.CTYDeserializer
-	client                        ec2iface.EC2API
+	client                        repository.EC2Repository
 	defaultRouteTableRunner       *terraform.ParallelResourceReader
 	routeTableRunner              *terraform.ParallelResourceReader
 }
@@ -31,17 +31,16 @@ func NewRouteTableSupplier(provider *AWSTerraformProvider) *RouteTableSupplier {
 		provider,
 		awsdeserializer.NewDefaultRouteTableDeserializer(),
 		awsdeserializer.NewRouteTableDeserializer(),
-		ec2.New(provider.session),
+		repository.NewEC2Repository(provider.session),
 		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 		terraform.NewParallelResourceReader(provider.Runner().SubRunner()),
 	}
 }
 
 func (s *RouteTableSupplier) Resources() ([]resource.Resource, error) {
-
-	results, err := listRouteTables(s.client, aws.AwsRouteTableResourceType)
+	results, err := s.client.ListAllRouteTables()
 	if err != nil {
-		return nil, err
+		return nil, remoteerror.NewResourceEnumerationError(err, aws.AwsRouteTableResourceType)
 	}
 
 	retrievedDefaultRouteTables := []*ec2.RouteTable{}
@@ -127,21 +126,4 @@ func (s *RouteTableSupplier) readRouteTable(routeTable ec2.RouteTable, isMain bo
 		return cty.NilVal, err
 	}
 	return *val, nil
-}
-
-func listRouteTables(client ec2iface.EC2API, supplierType string) ([]*ec2.RouteTable, error) {
-	var routeTables []*ec2.RouteTable
-	input := ec2.DescribeRouteTablesInput{}
-	err := client.DescribeRouteTablesPages(&input,
-		func(resp *ec2.DescribeRouteTablesOutput, lastPage bool) bool {
-			routeTables = append(routeTables, resp.RouteTables...)
-			return !lastPage
-		},
-	)
-
-	if err != nil {
-		return nil, remoteerror.NewResourceEnumerationErrorWithType(err, supplierType, aws.AwsRouteTableResourceType)
-	}
-
-	return routeTables, nil
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #165 
| ❓ Documentation  | no

## Description

Add route_table_supplier/route_table_association_supplier to ec2_repository to avoid possible hidden dependency.