### PR TITLE
Add vpc_supplier to ec2_repository

### DIFF
--- a/pkg/remote/aws/repository/mock_EC2Repository.go
+++ b/pkg/remote/aws/repository/mock_EC2Repository.go
@@ -251,6 +251,38 @@ func (_m *MockEC2Repository) ListAllSubnets() ([]*ec2.Subnet, []*ec2.Subnet, err
 	return r0, r1, r2
 }
 
+// ListAllVPCs provides a mock function with given fields:
+func (_m *MockEC2Repository) ListAllVPCs() ([]*ec2.Vpc, []*ec2.Vpc, error) {
+	ret := _m.Called()
+
+	var r0 []*ec2.Vpc
+	if rf, ok := ret.Get(0).(func() []*ec2.Vpc); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*ec2.Vpc)
+		}
+	}
+
+	var r1 []*ec2.Vpc
+	if rf, ok := ret.Get(1).(func() []*ec2.Vpc); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]*ec2.Vpc)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func() error); ok {
+		r2 = rf()
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // ListAllVolumes provides a mock function with given fields:
 func (_m *MockEC2Repository) ListAllVolumes() ([]*ec2.Volume, error) {
 	ret := _m.Called()


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #165 
| ❓ Documentation  | no

## Description

Add vpc_supplier to ec2_repository to avoid possible hidden dependency.