### PR TITLE
Fix aws_db_instance false-positives

### DIFF
--- a/pkg/resource/aws/aws_db_instance_ext.go
+++ b/pkg/resource/aws/aws_db_instance_ext.go
@@ -14,9 +14,15 @@ func (r *AwsDbInstance) NormalizeForState() (resource.Resource, error) {
 	if r.ApplyImmediately != nil && !*r.ApplyImmediately {
 		r.ApplyImmediately = nil
 	}
+	if r.CharacterSetName != nil && *r.CharacterSetName == "" {
+		r.CharacterSetName = nil
+	}
 	return r, nil
 }
 
 func (r *AwsDbInstance) NormalizeForProvider() (resource.Resource, error) {
+	if r.CharacterSetName != nil && *r.CharacterSetName == "" {
+		r.CharacterSetName = nil
+	}
 	return r, nil
 }

--- a/pkg/resource/aws/aws_db_instance_test.go
+++ b/pkg/resource/aws/aws_db_instance_test.go
@@ -1,0 +1,26 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/cloudskiff/driftctl/test"
+	"github.com/cloudskiff/driftctl/test/acceptance"
+)
+
+func TestAcc_AwsDbInstance_WithCharacterSetName(t *testing.T) {
+	acceptance.Run(t, acceptance.AccTestCase{
+		Paths: []string{"./testdata/acc/aws_db_instance"},
+		Args:  []string{"scan", "--filter", "Type=='aws_db_instance'"},
+		Checks: []acceptance.AccCheck{
+			{
+				Check: func(result *test.ScanResult, stdout string, err error) {
+					if err != nil {
+						t.Fatal(err)
+					}
+					result.AssertDriftCountTotal(0)
+					result.Equal(1, result.Summary().TotalManaged)
+				},
+			},
+		},
+	})
+}

--- a/pkg/resource/aws/aws_db_instance_test.go
+++ b/pkg/resource/aws/aws_db_instance_test.go
@@ -13,6 +13,9 @@ func TestAcc_AwsDbInstance(t *testing.T) {
 		Args:  []string{"scan", "--filter", "Type=='aws_db_instance'"},
 		Checks: []acceptance.AccCheck{
 			{
+				Env: map[string]string{
+					"AWS_REGION": "us-east-1",
+				},
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/resource/aws/aws_db_instance_test.go
+++ b/pkg/resource/aws/aws_db_instance_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloudskiff/driftctl/test/acceptance"
 )
 
-func TestAcc_AwsDbInstance_WithCharacterSetName(t *testing.T) {
+func TestAcc_AwsDbInstance(t *testing.T) {
 	acceptance.Run(t, acceptance.AccTestCase{
 		Paths: []string{"./testdata/acc/aws_db_instance"},
 		Args:  []string{"scan", "--filter", "Type=='aws_db_instance'"},
@@ -17,8 +17,8 @@ func TestAcc_AwsDbInstance_WithCharacterSetName(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					result.AssertDriftCountTotal(0)
-					result.Equal(1, result.Summary().TotalManaged)
+					result.AssertInfrastructureIsInSync()
+					result.AssertManagedCount(1)
 				},
 			},
 		},

--- a/pkg/resource/aws/testdata/acc/aws_db_instance/.terraform.lock.hcl
+++ b/pkg/resource/aws/testdata/acc/aws_db_instance/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.19.0"
+  constraints = "~> 3.19.0"
+  hashes = [
+    "h1:+7Vi7p13+cnrxjXbfJiTimGSFR97xCaQwkkvWcreLns=",
+    "h1:xur9tF49NgsovNnmwmBR8RdpN8Fcg1TD4CKQPJD6n1A=",
+    "zh:185a5259153eb9ee4699d4be43b3d509386b473683392034319beee97d470c3b",
+    "zh:2d9a0a01f93e8d16539d835c02b8b6e1927b7685f4076e96cb07f7dd6944bc6c",
+    "zh:703f6da36b1b5f3497baa38fccaa7765fb8a2b6440344e4c97172516b49437dd",
+    "zh:770855565462abadbbddd98cb357d2f1a8f30f68a358cb37cbd5c072cb15b377",
+    "zh:8008db43149fe4345301f81e15e6d9ddb47aa5e7a31648f9b290af96ad86e92a",
+    "zh:8cdd27d375da6dcb7687f1fed126b7c04efce1671066802ee876dbbc9c66ec79",
+    "zh:be22ae185005690d1a017c1b909e0d80ab567e239b4f06ecacdba85080667c1c",
+    "zh:d2d02e72dbd80f607636cd6237a6c862897caabc635c7b50c0cb243d11246723",
+    "zh:d8f125b66a1eda2555c0f9bbdf12036a5f8d073499a22ca9e4812b68067fea31",
+    "zh:f5a98024c64d5d2973ff15b093725a074c0cb4afde07ef32c542e69f17ac90bc",
+  ]
+}

--- a/pkg/resource/aws/testdata/acc/aws_db_instance/db_instance.tf
+++ b/pkg/resource/aws/testdata/acc/aws_db_instance/db_instance.tf
@@ -1,0 +1,11 @@
+resource "aws_db_instance" "default" {
+  allocated_storage    = 10
+  engine               = "mysql"
+  engine_version       = "5.7"
+  instance_class       = "db.t3.micro"
+  name                 = "mydb"
+  username             = "foo"
+  password             = "foobarbaz"
+  parameter_group_name = "default.mysql5.7"
+  skip_final_snapshot  = true
+}

--- a/pkg/resource/aws/testdata/acc/aws_db_instance/db_instance.tf
+++ b/pkg/resource/aws/testdata/acc/aws_db_instance/db_instance.tf
@@ -1,3 +1,13 @@
+provider "aws" {
+    region = "us-east-1"
+}
+
+terraform {
+    required_providers {
+        aws = "3.19.0"
+    }
+}
+
 resource "aws_db_instance" "default" {
   allocated_storage    = 10
   engine               = "mysql"


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #542 
| ❓ Documentation  | no

## Description

Fix false positive for aws_db_instance CharacterSetName
Add Acc test.
Maybe it's need to change pkg/iac/terraform/state/test/db_instance/terraform.tfstate and pkg/iac/terraform/state/test/db_instance/result.golden.json, let me know.