### PR TITLE
Remove terraform installation step in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,14 +28,6 @@ jobs:
           version: "1.16.2"
           # Disable cache at it seem to broke go 1.16 installation
           cache: false
-      - run:
-          name: install dependencies
-          command: |
-            sudo apt-get -qq update && sudo apt-get -qq -y install unzip
-            curl "https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_linux_amd64.zip" --output terraform.zip
-            unzip terraform.zip
-            sudo mv terraform /usr/local/bin && sudo chmod +x /usr/local/bin
-            terraform version
       - run: make deps
       - run: make install-tools
       - run:


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Since acceptance tests manage Terraform installation automatically (introduced in  #416), we don't need to install Terraform globally anymore.