### PR TITLE
Fix error reporting in http state reader

### DIFF
--- a/pkg/iac/terraform/state/backend/http_reader.go
+++ b/pkg/iac/terraform/state/backend/http_reader.go
@@ -46,7 +46,11 @@ func (h *HTTPBackend) Read(p []byte) (n int, err error) {
 			return 0, errors.Errorf("error requesting HTTP(s) backend state: status code: %d", res.StatusCode)
 		}
 	}
-	return h.reader.Read(p)
+	read, err := h.reader.Read(p)
+	if err != nil {
+		return 0, err
+	}
+	return read, nil
 }
 
 func (h *HTTPBackend) Close() error {

--- a/pkg/iac/terraform/state/backend/http_reader.go
+++ b/pkg/iac/terraform/state/backend/http_reader.go
@@ -46,11 +46,7 @@ func (h *HTTPBackend) Read(p []byte) (n int, err error) {
 			return 0, errors.Errorf("error requesting HTTP(s) backend state: status code: %d", res.StatusCode)
 		}
 	}
-	read, err := h.reader.Read(p)
-	if err != nil {
-		return 0, err
-	}
-	return read, nil
+	return h.reader.Read(p)
 }
 
 func (h *HTTPBackend) Close() error {

--- a/pkg/iac/terraform/state/terraform_state_reader.go
+++ b/pkg/iac/terraform/state/terraform_state_reader.go
@@ -2,12 +2,14 @@ package state
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cloudskiff/driftctl/pkg/output"
 	"github.com/fatih/color"
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/states"
 	"github.com/hashicorp/terraform/states/statefile"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
 	ctyconvert "github.com/zclconf/go-cty/cty/convert"
@@ -220,6 +222,9 @@ func (r *TerraformStateReader) retrieveMultiplesStates() ([]resource.Resource, e
 func read(path string, reader backend.Backend) (*states.State, error) {
 	state, err := readState(path, reader)
 	if err != nil {
+		if _, ok := reader.(*backend.HTTPBackend); ok && strings.Contains(err.Error(), "The state file could not be parsed as JSON") {
+			return nil, errors.Errorf("given url is not a valid statefile")
+		}
 		return nil, err
 	}
 	return state, nil

--- a/pkg/iac/terraform/state/terraform_state_reader.go
+++ b/pkg/iac/terraform/state/terraform_state_reader.go
@@ -226,7 +226,7 @@ func read(path string, reader backend.Backend) (*states.State, error) {
 	state, err := readState(path, reader)
 	if err != nil {
 		if _, ok := reader.(*backend.HTTPBackend); ok && strings.Contains(err.Error(), "The state file could not be parsed as JSON") {
-			return nil, errors.Errorf("given url is not a valid statefile")
+			return nil, errors.Errorf("given url is not a valid state file")
 		}
 		return nil, err
 	}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #494 
| ❓ Documentation  | no

## Description

We can't recover summary of errors from the _.HTTPBackend because casting isn't possible with this structure.
So i just add an error check before returning at the end of the method.
Maybe it's need to add some test to keep track of this change, but i'll do it tomorrow after discuss it with the team.