### PR TITLE
Fix crash when capacity is set to 0 in cache

### DIFF
--- a/pkg/remote/cache/cache.go
+++ b/pkg/remote/cache/cache.go
@@ -49,6 +49,10 @@ func (c *LRUCache) Put(key string, value interface{}) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if c.cap == 0 {
+		return false
+	}
+
 	// if the key already exists, move to front and update the value
 	if node, ok := c.m[key]; ok {
 		c.l.MoveToFront(node)

--- a/pkg/remote/cache/cache_test.go
+++ b/pkg/remote/cache/cache_test.go
@@ -69,4 +69,31 @@ func TestCache(t *testing.T) {
 		}
 		assert.Equal(t, 5, cache.Len())
 	})
+
+	t.Run("should ignore keys when capacity is 0", func(t *testing.T) {
+		keys := []struct {
+			key   string
+			value interface{}
+		}{
+			{
+				"test",
+				[]string{"slice"},
+			},
+			{
+				"test",
+				[]string{},
+			},
+			{
+				"test2",
+				[]resource.FakeResource{},
+			},
+		}
+		cache := New(0)
+
+		for _, k := range keys {
+			assert.Equal(t, false, cache.Put(k.key, k.value))
+			assert.Equal(t, nil, cache.Get(k.key))
+		}
+		assert.Equal(t, 0, cache.Len())
+	})
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

In some cases, we may want to not use the cache although it's required. It may be for testing purposes or simply because of a technical limitation. We already use a capacity of 0 in supplier unit tests, because we don't need to cache values. For now, a capacity of 0 result in a nil pointer dereference error. This PR fixes the issue simply by ignoring keys when capacity is set to 0.