### PR TITLE
fix #601 by checking arn correctness and sending a different alert

### DIFF
--- a/pkg/remote/aws/sns_topic_subscription_supplier.go
+++ b/pkg/remote/aws/sns_topic_subscription_supplier.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -29,6 +30,22 @@ func (p *pendingTopicAlert) Message() string {
 }
 
 func (p *pendingTopicAlert) ShouldIgnoreResource() bool {
+	return false
+}
+
+type wrongArnTopicAlert struct {
+	arn      string
+	endpoint *string
+}
+
+func (p *wrongArnTopicAlert) Message() string {
+	return fmt.Sprintf("%s with incorrect subscription arn (%s) for endpoint \"%s\" will be ignored",
+		aws.AwsSnsTopicSubscriptionResourceType,
+		p.arn,
+		awssdk.StringValue(p.endpoint))
+}
+
+func (p *wrongArnTopicAlert) ShouldIgnoreResource() bool {
 	return false
 }
 
@@ -71,12 +88,22 @@ func (s *SNSTopicSubscriptionSupplier) Resources() ([]resource.Resource, error) 
 }
 
 func (s *SNSTopicSubscriptionSupplier) readTopicSubscription(subscription *sns.Subscription, alertr alerter.AlerterInterface) (cty.Value, error) {
-	if subscription.SubscriptionArn != nil && *subscription.SubscriptionArn == "PendingConfirmation" {
-		alertr.SendAlert(
-			fmt.Sprintf("%s.%s", aws.AwsSnsTopicSubscriptionResourceType, *subscription.SubscriptionArn),
-			&pendingTopicAlert{subscription.Endpoint},
-		)
-		return cty.NilVal, nil
+	if subscription.SubscriptionArn != nil && !arn.IsARN(*subscription.SubscriptionArn) {
+		switch *subscription.SubscriptionArn {
+		case "PendingConfirmation":
+			alertr.SendAlert(
+				fmt.Sprintf("%s.%s", aws.AwsSnsTopicSubscriptionResourceType, *subscription.SubscriptionArn),
+				&pendingTopicAlert{subscription.Endpoint},
+			)
+			return cty.NilVal, nil
+		default:
+			alertr.SendAlert(
+				fmt.Sprintf("%s.%s", aws.AwsSnsTopicSubscriptionResourceType, *subscription.SubscriptionArn),
+				&wrongArnTopicAlert{*subscription.SubscriptionArn, subscription.Endpoint},
+			)
+			return cty.NilVal, nil
+
+		}
 	}
 
 	val, err := s.reader.ReadResource(terraform.ReadResourceArgs{

--- a/pkg/remote/aws/sns_topic_subscription_supplier.go
+++ b/pkg/remote/aws/sns_topic_subscription_supplier.go
@@ -19,20 +19,6 @@ import (
 	"github.com/cloudskiff/driftctl/pkg/terraform"
 )
 
-type pendingTopicAlert struct {
-	endpoint *string
-}
-
-func (p *pendingTopicAlert) Message() string {
-	return fmt.Sprintf("%s with pending confirmation status for endpoint \"%s\" will be ignored",
-		aws.AwsSnsTopicSubscriptionResourceType,
-		awssdk.StringValue(p.endpoint))
-}
-
-func (p *pendingTopicAlert) ShouldIgnoreResource() bool {
-	return false
-}
-
 type wrongArnTopicAlert struct {
 	arn      string
 	endpoint *string
@@ -89,21 +75,11 @@ func (s *SNSTopicSubscriptionSupplier) Resources() ([]resource.Resource, error) 
 
 func (s *SNSTopicSubscriptionSupplier) readTopicSubscription(subscription *sns.Subscription, alertr alerter.AlerterInterface) (cty.Value, error) {
 	if subscription.SubscriptionArn != nil && !arn.IsARN(*subscription.SubscriptionArn) {
-		switch *subscription.SubscriptionArn {
-		case "PendingConfirmation":
-			alertr.SendAlert(
-				fmt.Sprintf("%s.%s", aws.AwsSnsTopicSubscriptionResourceType, *subscription.SubscriptionArn),
-				&pendingTopicAlert{subscription.Endpoint},
-			)
-			return cty.NilVal, nil
-		default:
-			alertr.SendAlert(
-				fmt.Sprintf("%s.%s", aws.AwsSnsTopicSubscriptionResourceType, *subscription.SubscriptionArn),
-				&wrongArnTopicAlert{*subscription.SubscriptionArn, subscription.Endpoint},
-			)
-			return cty.NilVal, nil
-
-		}
+		alertr.SendAlert(
+			fmt.Sprintf("%s.%s", aws.AwsSnsTopicSubscriptionResourceType, *subscription.SubscriptionArn),
+			&wrongArnTopicAlert{*subscription.SubscriptionArn, subscription.Endpoint},
+		)
+		return cty.NilVal, nil
 	}
 
 	val, err := s.reader.ReadResource(terraform.ReadResourceArgs{

--- a/pkg/remote/aws/sns_topic_subscription_supplier_test.go
+++ b/pkg/remote/aws/sns_topic_subscription_supplier_test.go
@@ -59,11 +59,12 @@ func TestSNSTopicSubscriptionSupplier_Resources(t *testing.T) {
 			err: nil,
 		},
 		{
-			test:    "Multiple SNSTopic Subscription with one pending",
+			test:    "Multiple SNSTopic Subscription with one pending and one incorrect",
 			dirName: "sns_topic_subscription_multiple",
 			mocks: func(client *mocks.SNSRepository) {
 				client.On("ListAllSubscriptions").Return([]*sns.Subscription{
 					{SubscriptionArn: aws.String("PendingConfirmation"), Endpoint: aws.String("TEST")},
+					{SubscriptionArn: aws.String("Incorrect"), Endpoint: aws.String("INCORRECT")},
 					{SubscriptionArn: aws.String("arn:aws:sns:us-east-1:526954929923:user-updates-topic2:c0f794c5-a009-4db4-9147-4c55959787fa")},
 					{SubscriptionArn: aws.String("arn:aws:sns:us-east-1:526954929923:user-updates-topic:b6e66147-2b31-4486-8d4b-2a2272264c8e")},
 				}, nil)
@@ -71,6 +72,9 @@ func TestSNSTopicSubscriptionSupplier_Resources(t *testing.T) {
 			alerts: map[string][]alerter.Alert{
 				"aws_sns_topic_subscription.PendingConfirmation": []alerter.Alert{
 					&pendingTopicAlert{aws.String("TEST")},
+				},
+				"aws_sns_topic_subscription.Incorrect": []alerter.Alert{
+					&wrongArnTopicAlert{"Incorrect", aws.String("INCORRECT")},
 				},
 			},
 			err: nil,

--- a/pkg/remote/aws/sns_topic_subscription_supplier_test.go
+++ b/pkg/remote/aws/sns_topic_subscription_supplier_test.go
@@ -71,7 +71,7 @@ func TestSNSTopicSubscriptionSupplier_Resources(t *testing.T) {
 			},
 			alerts: map[string][]alerter.Alert{
 				"aws_sns_topic_subscription.PendingConfirmation": []alerter.Alert{
-					&pendingTopicAlert{aws.String("TEST")},
+					&wrongArnTopicAlert{"PendingConfirmation", aws.String("TEST")},
 				},
 				"aws_sns_topic_subscription.Incorrect": []alerter.Alert{
 					&wrongArnTopicAlert{"Incorrect", aws.String("INCORRECT")},


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #601 
| ❓ Documentation  | yes <!-- does this require documentation update ? -->

## Description

fix #601 by checking arn correctness and sending a different alertt.