### PR TITLE
Enable diff on instance_initiated_shutdown_behavior field

### DIFF
--- a/pkg/resource/aws/aws_instance.go
+++ b/pkg/resource/aws/aws_instance.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"github.com/cloudskiff/driftctl/pkg/resource"
+	"github.com/hashicorp/go-version"
 )
 
 const AwsInstanceResourceType = "aws_instance"
@@ -10,7 +11,10 @@ func initAwsInstanceMetaData(resourceSchemaRepository resource.SchemaRepositoryI
 	resourceSchemaRepository.SetNormalizeFunc(AwsInstanceResourceType, func(res *resource.AbstractResource) {
 		val := res.Attrs
 		val.SafeDelete([]string{"timeouts"})
-		val.SafeDelete([]string{"instance_initiated_shutdown_behavior"})
+
+		if v, _ := version.NewVersion("3.38.0"); res.Schema().ProviderVersion.LessThan(v) {
+			val.SafeDelete([]string{"instance_initiated_shutdown_behavior"})
+		}
 	})
 	resourceSchemaRepository.SetHumanReadableAttributesFunc(AwsInstanceResourceType, func(res *resource.AbstractResource) map[string]string {
 		val := res.Attrs


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #446
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Previously we disabled diff on this field because of an issue on the provider side. Now this issue has been resolved, we can safely enable the diff back but according to a specific version constraint.