### PR TITLE
Add missing new line at end of gen-driftignore output

### DIFF
--- a/pkg/cmd/gen_driftignore.go
+++ b/pkg/cmd/gen_driftignore.go
@@ -28,7 +28,9 @@ func NewGenDriftIgnoreCmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Print(list)
+			if len(list) > 0 {
+				fmt.Printf("\n%s\n", list)
+			}
 
 			return nil
 		},

--- a/pkg/cmd/testdata/output_stdin_valid.txt
+++ b/pkg/cmd/testdata/output_stdin_valid.txt
@@ -1,3 +1,4 @@
+
 # Resources not covered by IaC
 aws_iam_user.driftctl
 aws_iam_user.sundowndev

--- a/pkg/cmd/testdata/output_stdin_valid_append.txt
+++ b/pkg/cmd/testdata/output_stdin_valid_append.txt
@@ -1,4 +1,4 @@
-
+aws_sqs_queue.https://sqs\.us-east-1\.amazonaws\.com/141177182257/queue-6qaidu\.fifo
 # Resources not covered by IaC
 aws_iam_user.driftctl
 aws_iam_user.sundowndev
@@ -11,3 +11,8 @@ aws_iam_user_policy.driftctl:driftctlrole
 aws_iam_access_key.AKIAXYUOJZ3H5YCXF34G
 aws_iam_access_key.AKIAXYUOJZ3HV2LTLXD2
 aws_iam_access_key.AKIAXYUOJZ3HUSPPQQ4L
+# Missing resources
+aws_iam_user.testuser1
+aws_iam_role.testrole1
+# Changed resources
+aws_s3_bucket.test-20210416154114486700000001

--- a/pkg/cmd/testdata/output_stdin_valid_filter.txt
+++ b/pkg/cmd/testdata/output_stdin_valid_filter.txt
@@ -1,3 +1,4 @@
+
 # Missing resources
 aws_iam_user.testuser1
 aws_iam_role.testrole1


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #633
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.