### PR TITLE
Fix random ordering in console output

### DIFF
--- a/pkg/cmd/scan/output/console_test.go
+++ b/pkg/cmd/scan/output/console_test.go
@@ -29,8 +29,31 @@ func TestConsole_Write(t *testing.T) {
 		{
 			name:       "test console output",
 			goldenfile: "output.txt",
-			args:       args{analysis: fakeAnalysis()},
-			wantErr:    false,
+			args: args{analysis: func() *analyser.Analysis {
+				a := fakeAnalysis()
+				a.AddDeleted(
+					&testresource.FakeResource{
+						Id:   "test-id-1",
+						Type: "aws_test_resource",
+					},
+					&testresource.FakeResource{
+						Id:   "test-id-2",
+						Type: "aws_test_resource",
+					},
+				)
+				a.AddUnmanaged(
+					&testresource.FakeResource{
+						Id:   "test-id-1",
+						Type: "aws_testing_resource",
+					},
+					&testresource.FakeResource{
+						Id:   "test-id-2",
+						Type: "aws_resource",
+					},
+				)
+				return a
+			}()},
+			wantErr: false,
 		},
 		{
 			name:       "test console output no drift",
@@ -101,7 +124,7 @@ func TestConsole_Write(t *testing.T) {
 			}()
 
 			// back to normal state
-			w.Close()
+			assert.Nil(t, w.Close())
 			os.Stdout = stdout // restoring the real stdout
 			os.Stderr = stderr
 			out := <-outC

--- a/pkg/cmd/scan/output/testdata/output.txt
+++ b/pkg/cmd/scan/output/testdata/output.txt
@@ -2,7 +2,14 @@ Found missing resources:
   aws_deleted_resource:
     - deleted-id-1
     - deleted-id-2
+  aws_test_resource:
+    - test-id-1
+    - test-id-2
 Found resources not covered by IaC:
+  aws_resource:
+    - test-id-2
+  aws_testing_resource:
+    - test-id-1
   aws_unmanaged_resource:
     - unmanaged-id-1
     - unmanaged-id-2
@@ -11,9 +18,9 @@ Found changed resources:
         ~ updated.field: "foobar" => "barfoo"
         + new.field: <nil> => "newValue"
         - a: "oldValue" => <nil>
-Found 6 resource(s)
- - 33% coverage
+Found 10 resource(s)
+ - 20% coverage
  - 2 covered by IaC
- - 2 not covered by IaC
- - 2 missing on cloud provider
+ - 4 not covered by IaC
+ - 4 missing on cloud provider
  - 1/2 changed outside of IaC


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #616
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

This PR fixes a random ordering in the console output. I changed the groupByType function interface so it now returns a sorted slice of strings. The reason is we can't sort map keys in Go, it's impossible. So the only proper I found to fix this issue is to base the for loop on the sorted slice, not the map.