### PR TITLE
Fix issue when enumerating s3 states on windows

### DIFF
--- a/pkg/iac/terraform/state/enumerator/s3.go
+++ b/pkg/iac/terraform/state/enumerator/s3.go
@@ -56,7 +56,7 @@ func (s *S3Enumerator) Enumerate() ([]string, error) {
 			if aws.Int64Value(metadata.Size) > 0 {
 				key := *metadata.Key
 				if match, _ := doublestar.Match(fullPattern, key); match {
-					files = append(files, filepath.Join(bucket, key))
+					files = append(files, strings.Join([]string{bucket, key}, "/"))
 				}
 			}
 		}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

We were using `path.join` to concatenate s3 path but on windows it return a string with backslashes. As it is not really a path we do not have to use `path.join` but `strings.join` with hardcoded `/` character

![image](https://user-images.githubusercontent.com/6154987/122072466-e22abd00-cdf7-11eb-90df-5fe65f12391e.png)
