### PR TITLE
Fix state enumeration on s3 on win when using wildcards

### DIFF
--- a/pkg/iac/terraform/state/enumerator/glob.go
+++ b/pkg/iac/terraform/state/enumerator/glob.go
@@ -25,7 +25,7 @@ func HasMeta(path string) bool {
 
 func splitDirPattern(p string) (base string, pattern string) {
 	base = p
-	sep := string(os.PathSeparator)
+	sep := "/"
 
 	for {
 		if !HasMeta(base) {

--- a/pkg/iac/terraform/state/enumerator/s3.go
+++ b/pkg/iac/terraform/state/enumerator/s3.go
@@ -2,7 +2,6 @@ package enumerator
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -44,7 +43,10 @@ func (s *S3Enumerator) Enumerate() ([]string, error) {
 	bucket := bucketPath[0]
 	prefix, pattern := GlobS3(strings.Join(bucketPath[1:], "/"))
 
-	fullPattern := filepath.Join(prefix, pattern)
+	fullPattern := prefix
+	if pattern != "" {
+		fullPattern = strings.Join([]string{prefix, pattern}, "/")
+	}
 
 	files := make([]string, 0)
 	input := &s3.ListObjectsV2Input{


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #
| ❓ Documentation  | no

## Description

Fix usage of wildcards patterns in S3 state enumeration on windows cause by incorrect use of native path separator in a S3 context.