### PR TITLE
Allow to override OS_ARCH in build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,16 +32,16 @@ os_archs=(
     windows/amd64
 )
 
-if [ -n "$OS_ARCH" ]; then
-  os_archs=("$OS_ARCH")
-fi
-
 if [ $ENV != "release" ]; then
     echo "+ Building env: dev"
     # If its dev mode, only build for ourself
     os_archs=("$(go env GOOS)/$(go env GOARCH)")
     # And set version to git commit
     VERSION="${GIT_COMMIT}${GIT_DIRTY}"
+fi
+
+if [ -n "$OS_ARCH" ]; then
+  os_archs=("$OS_ARCH")
 fi
 
 echo "ARCH: ${os_archs[*]}"


### PR DESCRIPTION
Allows us to cross compile a specific version locally :

```
➜ OS_ARCH=windows/amd64 make build
scripts/build.sh
Bash: 5.1.8(1)-release
+ Building env: dev
ARCH: windows/amd64
+ Removing old binaries ...
+ Building with flags: -X github.com/cloudskiff/driftctl/pkg/version.version=7fe9b13d
Number of parallel builds: 2

-->   windows/amd64: github.com/cloudskiff/driftctl

```