### PR TITLE
Fix false positive on aws_s3_bucket.bucket_prefix

### DIFF
--- a/pkg/resource/aws/aws_s3_bucket.go
+++ b/pkg/resource/aws/aws_s3_bucket.go
@@ -15,5 +15,6 @@ func initAwsS3BucketMetaData(resourceSchemaRepository resource.SchemaRepositoryI
 	resourceSchemaRepository.SetNormalizeFunc(AwsS3BucketResourceType, func(res *resource.AbstractResource) {
 		val := res.Attrs
 		val.SafeDelete([]string{"force_destroy"})
+		val.SafeDelete([]string{"bucket_prefix"})
 	})
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #614 
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

This PR closes #614 by ignoring `bucket_prefix` attribute of `aws_s3_bucket` as it is an internal Terraform property.

The change is trivial and I've tested it in my AWS account, but I can probably add unit tests if needed.