### PR TITLE
Fix ses_smtp_password false positive

### DIFF
--- a/pkg/resource/aws/aws_iam_access_key.go
+++ b/pkg/resource/aws/aws_iam_access_key.go
@@ -14,6 +14,7 @@ func initAwsIAMAccessKeyMetaData(resourceSchemaRepository resource.SchemaReposit
 		// We can't detect drift if we cannot retrieve latest value from aws API for fields like secrets, passwords etc ...
 		val.SafeDelete([]string{"secret"})
 		val.SafeDelete([]string{"ses_smtp_password_v4"})
+		val.SafeDelete([]string{"ses_smtp_password"})
 		val.SafeDelete([]string{"encrypted_secret"})
 		val.SafeDelete([]string{"key_fingerprint"})
 		val.SafeDelete([]string{"pgp_key"})


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #649 
| ❓ Documentation  | no

## Description

Fix ses_smtp_password false positive for:
driftctl version: 0.10.0-pre
terraform version: 1.0.0
terraform providers versions: aws@2.70.0

Apparently with the refacto it's not necessary to add a test case ?