### PR TITLE
Display terraform provider version in output

### DIFF
--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/cloudskiff/driftctl/pkg/telemetry"
+	"github.com/fatih/color"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -227,6 +228,8 @@ func scanRun(opts *pkg.ScanOptions) error {
 	if !opts.DisableTelemetry {
 		telemetry.SendTelemetry(analysis)
 	}
+
+	globaloutput.Printf(color.WhiteString("Provider version used to scan: %s. Use --tf-provider-version to use another version.\n"), resourceSchemaRepository.ProviderVersion.String())
 
 	if !analysis.IsSync() {
 		globaloutput.Printf("\nHint: use gen-driftignore command to generate a .driftignore file based on your drifts\n")

--- a/pkg/resource/schemas.go
+++ b/pkg/resource/schemas.go
@@ -46,7 +46,8 @@ type SchemaRepositoryInterface interface {
 }
 
 type SchemaRepository struct {
-	schemas map[string]*Schema
+	schemas         map[string]*Schema
+	ProviderVersion *version.Version
 }
 
 func NewSchemaRepository() *SchemaRepository {
@@ -81,6 +82,7 @@ func (r *SchemaRepository) Init(v string, schema map[string]providers.Schema) er
 	if err != nil {
 		return err
 	}
+	r.ProviderVersion = providerVersion
 	for typ, sch := range schema {
 		attributeMetas := map[string]AttributeSchema{}
 		for s, attribute := range sch.Block.Attributes {
@@ -92,7 +94,7 @@ func (r *SchemaRepository) Init(v string, schema map[string]providers.Schema) er
 		r.fetchNestedBlocks("", attributeMetas, sch.Block.BlockTypes)
 
 		r.schemas[typ] = &Schema{
-			ProviderVersion: providerVersion,
+			ProviderVersion: r.ProviderVersion,
 			SchemaVersion:   sch.Version,
 			Attributes:      attributeMetas,
 		}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #646
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

> As a driftctl user,
> I want to know the version of the provider used by driftctl to scan my account against my tfstate
> So that I can keep my Terraform config in sync with driftctl scan

This PR simply add a log message at the end of scan with the provider's version. Also the default value is now set in the scan command controller, rather than the AWS provider init function.

![image](https://user-images.githubusercontent.com/16480203/122394781-a36f4100-cf76-11eb-943e-af1a8baeea8e.png)