### PR TITLE
Add a way to override s3 config/profile with env var

### DIFF
--- a/pkg/envproxy/env_proxy.go
+++ b/pkg/envproxy/env_proxy.go
@@ -6,9 +6,9 @@ import (
 )
 
 type EnvProxy struct {
-	varPrefix  string
-	varPattern string
-	DefaultEnv map[string]string
+	fromPrefix string
+	toPrefix   string
+	defaultEnv map[string]string
 }
 
 func NewEnvProxy() *EnvProxy {
@@ -18,35 +18,35 @@ func NewEnvProxy() *EnvProxy {
 		envMap[tmp[0]] = tmp[1]
 	}
 	return &EnvProxy{
-		DefaultEnv: envMap,
+		defaultEnv: envMap,
 	}
 }
 
-func (s *EnvProxy) SetProxy(prefix, pattern string) {
-	s.varPrefix = prefix
-	s.varPattern = pattern
+func (s *EnvProxy) SetProxy(fromPrefix, toPrefix string) {
+	s.fromPrefix = fromPrefix
+	s.toPrefix = toPrefix
 }
 
 func (s *EnvProxy) Apply() {
-	if s.varPrefix == "" || s.varPattern == "" {
+	if s.fromPrefix == "" || s.toPrefix == "" {
 		return
 	}
-	for key, value := range s.DefaultEnv {
-		if strings.HasPrefix(key, s.varPrefix) {
-			key = strings.Replace(key, s.varPrefix, s.varPattern, 1)
+	for key, value := range s.defaultEnv {
+		if strings.HasPrefix(key, s.fromPrefix) {
+			key = strings.Replace(key, s.fromPrefix, s.toPrefix, 1)
 			os.Setenv(key, value)
 		}
 	}
 }
 
 func (s *EnvProxy) Restore() {
-	if s.varPrefix == "" || s.varPattern == "" {
+	if s.fromPrefix == "" || s.toPrefix == "" {
 		return
 	}
-	for key, value := range s.DefaultEnv {
-		if strings.HasPrefix(key, s.varPrefix) {
-			key = strings.Replace(key, s.varPrefix, s.varPattern, 1)
-			value = s.DefaultEnv[key]
+	for key, value := range s.defaultEnv {
+		if strings.HasPrefix(key, s.fromPrefix) {
+			key = strings.Replace(key, s.fromPrefix, s.toPrefix, 1)
+			value = s.defaultEnv[key]
 		}
 		os.Setenv(key, value)
 	}

--- a/pkg/envproxy/env_proxy.go
+++ b/pkg/envproxy/env_proxy.go
@@ -11,20 +11,17 @@ type EnvProxy struct {
 	defaultEnv map[string]string
 }
 
-func NewEnvProxy() *EnvProxy {
+func NewEnvProxy(fromPrefix, toPrefix string) *EnvProxy {
 	envMap := map[string]string{}
 	for _, variable := range os.Environ() {
 		tmp := strings.SplitN(variable, "=", 2)
 		envMap[tmp[0]] = tmp[1]
 	}
 	return &EnvProxy{
+		fromPrefix: fromPrefix,
+		toPrefix:   toPrefix,
 		defaultEnv: envMap,
 	}
-}
-
-func (s *EnvProxy) SetProxy(fromPrefix, toPrefix string) {
-	s.fromPrefix = fromPrefix
-	s.toPrefix = toPrefix
 }
 
 func (s *EnvProxy) Apply() {

--- a/pkg/envproxy/env_proxy.go
+++ b/pkg/envproxy/env_proxy.go
@@ -1,0 +1,53 @@
+package envproxy
+
+import (
+	"os"
+	"strings"
+)
+
+type EnvProxy struct {
+	varPrefix  string
+	varPattern string
+	DefaultEnv map[string]string
+}
+
+func NewEnvProxy() *EnvProxy {
+	envMap := map[string]string{}
+	for _, variable := range os.Environ() {
+		tmp := strings.SplitN(variable, "=", 2)
+		envMap[tmp[0]] = tmp[1]
+	}
+	return &EnvProxy{
+		DefaultEnv: envMap,
+	}
+}
+
+func (s *EnvProxy) SetProxy(prefix, pattern string) {
+	s.varPrefix = prefix
+	s.varPattern = pattern
+}
+
+func (s *EnvProxy) Apply() {
+	if s.varPrefix == "" || s.varPattern == "" {
+		return
+	}
+	for key, value := range s.DefaultEnv {
+		if strings.HasPrefix(key, s.varPrefix) {
+			key = strings.Replace(key, s.varPrefix, s.varPattern, 1)
+			os.Setenv(key, value)
+		}
+	}
+}
+
+func (s *EnvProxy) Restore() {
+	if s.varPrefix == "" || s.varPattern == "" {
+		return
+	}
+	for key, value := range s.DefaultEnv {
+		if strings.HasPrefix(key, s.varPrefix) {
+			key = strings.Replace(key, s.varPrefix, s.varPattern, 1)
+			value = s.DefaultEnv[key]
+		}
+		os.Setenv(key, value)
+	}
+}

--- a/pkg/envproxy/env_proxy_test.go
+++ b/pkg/envproxy/env_proxy_test.go
@@ -37,6 +37,12 @@ func TestEnvProxy(t *testing.T) {
 			initialEnv:  []string{"TEST_DCTL_S3_PROFILE=test_dctl_s3_profile", "TEST_AWS_PROFILE=test_aws_profile"},
 			modifiedEnv: []string{"TEST_DCTL_S3_PROFILE=test_dctl_s3_profile", "TEST_AWS_PROFILE=test_aws_profile"},
 		},
+        {
+            name:        "Without initialEnv",
+            proxyArgs:   []string{"TEST_DCTL_S3_", "TEST_AWS_"},
+            initialEnv:  []string{},
+            modifiedEnv: []string{},
+        },
 	}
 
 	for _, tt := range tests {

--- a/pkg/envproxy/env_proxy_test.go
+++ b/pkg/envproxy/env_proxy_test.go
@@ -37,12 +37,12 @@ func TestEnvProxy(t *testing.T) {
 			initialEnv:  []string{"TEST_DCTL_S3_PROFILE=test_dctl_s3_profile", "TEST_AWS_PROFILE=test_aws_profile"},
 			modifiedEnv: []string{"TEST_DCTL_S3_PROFILE=test_dctl_s3_profile", "TEST_AWS_PROFILE=test_aws_profile"},
 		},
-        {
-            name:        "Without initialEnv",
-            proxyArgs:   []string{"TEST_DCTL_S3_", "TEST_AWS_"},
-            initialEnv:  []string{},
-            modifiedEnv: []string{},
-        },
+		{
+			name:        "Without initialEnv",
+			proxyArgs:   []string{"TEST_DCTL_S3_", "TEST_AWS_"},
+			initialEnv:  []string{},
+			modifiedEnv: []string{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -53,8 +53,7 @@ func TestEnvProxy(t *testing.T) {
 				os.Setenv(tmp[0], tmp[1])
 			}
 
-			envProxy := NewEnvProxy()
-			envProxy.SetProxy(tt.proxyArgs[0], tt.proxyArgs[1])
+			envProxy := NewEnvProxy(tt.proxyArgs[0], tt.proxyArgs[1])
 
 			envProxy.Apply()
 

--- a/pkg/envproxy/env_proxy_test.go
+++ b/pkg/envproxy/env_proxy_test.go
@@ -1,0 +1,98 @@
+package envproxy
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvProxy_Apply(t *testing.T) {
+	tests := []struct {
+		name      string
+		proxyArgs []string
+		modifier  bool
+	}{
+		{
+			name:      "Without args on SetProxy",
+			proxyArgs: []string{"", ""},
+			modifier:  false,
+		},
+		{
+			name:      "With args on SetProxy",
+			proxyArgs: []string{"TEST_DCTL_S3_", "TEST_AWS_"},
+			modifier:  true,
+		},
+		{
+			name:      "With no pattern on SetProxy",
+			proxyArgs: []string{"TEST_DCTL_S3_", ""},
+			modifier:  false,
+		},
+		{
+			name:      "With no prefix on SetProxy",
+			proxyArgs: []string{"", "TEST_AWS_"},
+			modifier:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("TEST_DCTL_S3_PROFILE", "dctl_env")
+			os.Setenv("TEST_AWS_PROFILE", "aws_env")
+			expectedEnv := os.Environ()
+
+			envProxy := NewEnvProxy()
+			envProxy.SetProxy(tt.proxyArgs[0], tt.proxyArgs[1])
+
+			envProxy.Apply()
+
+			newEnv := os.Environ()
+			for index, value := range expectedEnv {
+				if tt.modifier && value == "TEST_AWS_PROFILE=aws_env" {
+					expectedEnv[index] = strings.Replace(
+						value,
+						"TEST_AWS_PROFILE=aws_env",
+						"TEST_AWS_PROFILE=dctl_env",
+						1,
+					)
+				}
+			}
+
+			if !assert.Equal(t, newEnv, expectedEnv) {
+				t.Errorf("Expected %v, got %v", expectedEnv, newEnv)
+			}
+		})
+	}
+}
+
+func TestEnvProxy_Restore(t *testing.T) {
+	tests := []struct {
+		name      string
+		proxyArgs []string
+	}{
+		{
+			name:      "With args on SetProxy",
+			proxyArgs: []string{"TEST_DCTL_S3_", "TEST_AWS_"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("TEST_DCTL_S3_PROFILE", "dctl_env")
+			os.Setenv("TEST_AWS_PROFILE", "aws_env")
+			expectedEnv := os.Environ()
+
+			envProxy := NewEnvProxy()
+			envProxy.SetProxy(tt.proxyArgs[0], tt.proxyArgs[1])
+			os.Setenv("TEST_AWS_PROFILE", "new_aws_env")
+
+			envProxy.Restore()
+
+			newEnv := os.Environ()
+			if !assert.Equal(t, newEnv, expectedEnv) {
+				t.Errorf("Expected %v, got %v", expectedEnv, newEnv)
+			}
+		})
+	}
+}

--- a/pkg/iac/terraform/state/backend/s3_reader.go
+++ b/pkg/iac/terraform/state/backend/s3_reader.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/cloudskiff/driftctl/pkg/envproxy"
 	"github.com/pkg/errors"
 
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -33,9 +34,12 @@ func NewS3Reader(path string) (*S3Backend, error) {
 		Key:    &key,
 		Bucket: &bucket,
 	}
+	envProxy := envproxy.NewEnvProxy("DCTL_S3_", "AWS_")
+	envProxy.Apply()
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
+	envProxy.Restore()
 	backend.S3Client = s3.New(sess)
 	return &backend, nil
 }

--- a/pkg/iac/terraform/state/backend/s3_reader_test.go
+++ b/pkg/iac/terraform/state/backend/s3_reader_test.go
@@ -67,6 +67,31 @@ func TestNewS3Reader(t *testing.T) {
 	)
 }
 
+func TestNewS3ReaderWithEnvProxy(t *testing.T) {
+	assert := assert.New(t)
+	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	os.Setenv("DCTL_S3_DEFAULT_REGION", "eu-west-3")
+	reader, err := NewS3Reader("sample_bucket/path/to/state.tfstate")
+
+	got := reader.S3Client.(*s3.S3).Config.Region
+	if aws.StringValue(got) != "eu-west-3" {
+		t.Errorf("NewS3Reader().S3Client.Config.Region got = %v, want %v", aws.StringValue(got), "eu-west-3")
+	}
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(
+		"path/to/state.tfstate",
+		*reader.input.Key,
+	)
+	assert.Equal(
+		"sample_bucket",
+		*reader.input.Bucket,
+	)
+}
+
 func TestS3Backend_ReadWithError(t *testing.T) {
 	assert := assert.New(t)
 	fakeS3 := &awstest.MockFakeS3{}

--- a/pkg/iac/terraform/state/enumerator/s3.go
+++ b/pkg/iac/terraform/state/enumerator/s3.go
@@ -21,8 +21,7 @@ type S3Enumerator struct {
 }
 
 func NewS3Enumerator(config config.SupplierConfig) *S3Enumerator {
-	envProxy := envproxy.NewEnvProxy()
-	envProxy.SetProxy("DCTL_S3_", "AWS_")
+	envProxy := envproxy.NewEnvProxy("DCTL_S3_", "AWS_")
 	envProxy.Apply()
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,

--- a/pkg/iac/terraform/state/enumerator/s3.go
+++ b/pkg/iac/terraform/state/enumerator/s3.go
@@ -8,16 +8,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/cloudskiff/driftctl/pkg/envproxy"
 	"github.com/pkg/errors"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/cloudskiff/driftctl/pkg/iac/config"
 )
-
-type S3EnumeratorConfig struct {
-	Bucket *string
-	Prefix *string
-}
 
 type S3Enumerator struct {
 	config config.SupplierConfig
@@ -25,9 +21,13 @@ type S3Enumerator struct {
 }
 
 func NewS3Enumerator(config config.SupplierConfig) *S3Enumerator {
+	envProxy := envproxy.NewEnvProxy()
+	envProxy.SetProxy("DCTL_S3_", "AWS_")
+	envProxy.Apply()
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
+	envProxy.Restore()
 	return &S3Enumerator{
 		config,
 		s3.New(sess),


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #615 
| ❓ Documentation  | yes - https://github.com/cloudskiff/driftctl-docs/pull/83

## Description

Creation of a struct to allow override of env var for state enumerator.
I'm not sure with this implementation, feel free to discuss about it.