### PR TITLE
Fix dupplicate resource when expanding managed_policy fields

### DIFF
--- a/pkg/driftctl_test.go
+++ b/pkg/driftctl_test.go
@@ -1560,6 +1560,14 @@ func TestDriftctlRun_Middlewares(t *testing.T) {
 					},
 				},
 				&resource.AbstractResource{
+					Id:   "role_with_managed_policy_attr-arn2",
+					Type: aws.AwsIamPolicyAttachmentResourceType,
+					Attrs: &resource.Attributes{
+						"policy_arn": "arn2",
+						"roles":      []interface{}{"role_with_managed_policy_attr"},
+					},
+				},
+				&resource.AbstractResource{
 					Id:   "role_with_empty_managed_policy_attribute",
 					Type: aws.AwsIamRoleResourceType,
 					Attrs: &resource.Attributes{


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #675 
| ❓ Documentation  | no