### PR TITLE
Ignore tags_all field on all resources

### DIFF
--- a/pkg/driftctl.go
+++ b/pkg/driftctl.go
@@ -97,6 +97,8 @@ func (d DriftCTL) Run() (*analyser.Analysis, error) {
 		middlewares.NewAwsDefaultSqsQueuePolicy(),
 		middlewares.NewAwsSNSTopicPolicyExpander(d.resourceFactory, d.resourceSchemaRepository),
 		middlewares.NewAwsRoleManagedPolicyExpander(d.resourceFactory),
+		// should always be last
+		middlewares.NewAwsTagsAllField(),
 	)
 
 	if !d.opts.StrictMode {

--- a/pkg/middlewares/aws_tags_all_field.go
+++ b/pkg/middlewares/aws_tags_all_field.go
@@ -1,0 +1,35 @@
+package middlewares
+
+import (
+	"github.com/cloudskiff/driftctl/pkg/resource"
+	"github.com/sirupsen/logrus"
+)
+
+// AwsTagsAllField middleware ignore tags_all field on all resources to avoid unexpected noise.
+type AwsTagsAllField struct{}
+
+func NewAwsTagsAllField() AwsTagsAllField {
+	return AwsTagsAllField{}
+}
+
+func (m AwsTagsAllField) Execute(remoteResources, _ *[]resource.Resource) error {
+
+	newRemoteResources := make([]resource.Resource, 0)
+
+	for _, remoteResource := range *remoteResources {
+		if (*remoteResource.Attributes())["tags_all"] != nil {
+			(*remoteResource.Attributes())["tags_all"] = nil
+
+			logrus.WithFields(logrus.Fields{
+				"id":   remoteResource.TerraformId(),
+				"type": remoteResource.TerraformType(),
+			}).Debug("Ignoring tags_all field on resource")
+		}
+
+		newRemoteResources = append(newRemoteResources, remoteResource)
+	}
+
+	*remoteResources = newRemoteResources
+
+	return nil
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #635
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

This PR ignores the field `tags_all` for all resources.