### PR TITLE
Display elapsed time at end of scan

### DIFF
--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/cloudskiff/driftctl/pkg/telemetry"
 	"github.com/fatih/color"
@@ -229,6 +230,8 @@ func scanRun(opts *pkg.ScanOptions) error {
 	if err != nil {
 		return err
 	}
+
+	globaloutput.Printf(color.WhiteString("Done in %s\n", analysis.Duration.Round(time.Second)))
 
 	if !opts.DisableTelemetry {
 		telemetry.SendTelemetry(analysis)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #550
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

This PR adds a simple message at the end of the scan to tell the user how much time it took to scan their entire infrastructure.

```shell
Scanned states (1) 
Found 3 resource(s)    
 - 100% coverage
Congrats! Your infrastructure is fully in sync.
Done in 8s
Provider version used to scan: 3.19.0. Use --tf-provider-version to use another version.
```