### PR TITLE
Fix duplicate ebs volume in state

### DIFF
--- a/pkg/middlewares/aws_instance_block_device_test.go
+++ b/pkg/middlewares/aws_instance_block_device_test.go
@@ -295,6 +295,53 @@ func TestAwsInstanceBlockDeviceResourceMapper_Execute(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"Should not create ebs volume if there is already one (e.g. inline ebs_block_device)",
+			struct {
+				expectedResource   *[]resource.Resource
+				resourcesFromState *[]resource.Resource
+			}{
+				expectedResource: &[]resource.Resource{
+					&resource.AbstractResource{
+						Id:   "dummy-instance",
+						Type: "aws_instance",
+						Attrs: &resource.Attributes{
+							"availability_zone": "eu-west-3",
+						},
+					},
+					&resource.AbstractResource{
+						Id:   "vol-02862d9b39045a3a4",
+						Type: "aws_ebs_volume",
+						Attrs: &resource.Attributes{
+							"id": "vol-02862d9b39045a3a4",
+						},
+					},
+				},
+				resourcesFromState: &[]resource.Resource{
+					&resource.AbstractResource{
+						Id:   "vol-02862d9b39045a3a4",
+						Type: "aws_ebs_volume",
+						Attrs: &resource.Attributes{
+							"id": "vol-02862d9b39045a3a4",
+						},
+					},
+					&resource.AbstractResource{
+						Id:   "dummy-instance",
+						Type: "aws_instance",
+						Attrs: &resource.Attributes{
+							"availability_zone": "eu-west-3",
+							"ebs_block_device": []interface{}{
+								map[string]interface{}{
+									"volume_id": "vol-02862d9b39045a3a4",
+								},
+							},
+						},
+					},
+				},
+			},
+			func(factory *terraform.MockResourceFactory) {},
+			false,
+		},
 	}
 	for _, c := range tests {
 		t.Run(c.name, func(tt *testing.T) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #562
| ❓ Documentation  | no

## Description

We should not create a new ebs_volume if the one inlined in `instance.ebs_block_device` was created using `ebs_volume`.