### PR TITLE
Add need-triage label to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: 🐛 Bug Report
 about: Report errors and problems
-labels: kind/bug
+labels: kind/bug, need-triage
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,7 +1,7 @@
 ---
 name: 🚀 Feature
 about: RFC and ideas for new features and improvements
-labels: kind/enhancement
+labels: kind/enhancement, need-triage
 
 ---
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #686
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Add need-triage label to new issues so we can easily filter them and process them.