### PR TITLE
Improve scan duration message at end of scan

### DIFF
--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -231,7 +231,7 @@ func scanRun(opts *pkg.ScanOptions) error {
 		return err
 	}
 
-	globaloutput.Printf(color.WhiteString("Done in %s\n", analysis.Duration.Round(time.Second)))
+	globaloutput.Printf(color.WhiteString("Scan duration: %s\n", analysis.Duration.Round(time.Second)))
 
 	if !opts.DisableTelemetry {
 		telemetry.SendTelemetry(analysis)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | https://github.com/cloudskiff/driftctl/issues/550#issuecomment-866643830
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

According to @sjourdan , this message wasn't clear enough for the user.