### PR TITLE
Check provider directory installation before downloading

### DIFF
--- a/pkg/terraform/provider_installer.go
+++ b/pkg/terraform/provider_installer.go
@@ -44,7 +44,7 @@ func (p *ProviderInstaller) Install() (string, error) {
 			"path": providerDir,
 		}).Debug("Provider directory destination not found, creating ...")
 		if err := os.MkdirAll(providerDir, 0755); err != nil {
-			return "", err
+			return "", errors.Wrap(err, "can't create configuration directory")
 		}
 	}
 
@@ -54,7 +54,7 @@ func (p *ProviderInstaller) Install() (string, error) {
 		logrus.WithFields(logrus.Fields{
 			"path": providerDir,
 		}).Debug("Provider directory destination is not writable")
-		return "", err
+		return "", errors.Wrap(err, "can't write in configuration directory")
 	}
 	defer isDirectoryWritable.Close()
 	defer os.Remove(isDirectoryWritablePath)

--- a/pkg/terraform/provider_installer.go
+++ b/pkg/terraform/provider_installer.go
@@ -38,6 +38,27 @@ func (p *ProviderInstaller) Install() (string, error) {
 	providerDir := p.getProviderDirectory()
 	providerPath := p.getBinaryPath()
 
+	_, err := os.Stat(providerDir)
+	if os.IsNotExist(err) {
+		logrus.WithFields(logrus.Fields{
+			"path": providerDir,
+		}).Debug("Provider directory destination not found, creating ...")
+		if err := os.MkdirAll(providerDir, 0755); err != nil {
+			return "", err
+		}
+	}
+
+	isDirectoryWritablePath := path.Join(providerDir, ".is_directory_writable")
+	isDirectoryWritable, err := os.OpenFile(isDirectoryWritablePath, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"path": providerDir,
+		}).Debug("Provider directory destination is not writable")
+		return "", err
+	}
+	defer isDirectoryWritable.Close()
+	defer os.Remove(isDirectoryWritablePath)
+
 	info, err := os.Stat(providerPath)
 
 	if err != nil && os.IsNotExist(err) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #669 
| ❓ Documentation  | no

## Description

check for the config-dir availability and writability before going further and download a provider.
Create a file inside provider directory to check the writability.