### PR TITLE
Ignore source_code_size in aws_lambda_function

### DIFF
--- a/pkg/iac/terraform/state/test/lambda_function/result.golden.json
+++ b/pkg/iac/terraform/state/test/lambda_function/result.golden.json
@@ -16,7 +16,6 @@
    "role": "arn:aws:iam::047081014315:role/iam_for_lambda",
    "runtime": "nodejs12.x",
    "source_code_hash": "PoaAEeOCmEFZojnrhEJvNzs+jg7/w1lL9GiFYvlM6aw=",
-   "source_code_size": 352,
    "timeout": 3,
    "tracing_config": [
     {
@@ -43,7 +42,6 @@
    "role": "arn:aws:iam::047081014315:role/iam_for_lambda",
    "runtime": "nodejs12.x",
    "source_code_hash": "PoaAEeOCmEFZojnrhEJvNzs+jg7/w1lL9GiFYvlM6aw=",
-   "source_code_size": 352,
    "timeout": 3,
    "tracing_config": [
     {

--- a/pkg/resource/aws/aws_lambda_function.go
+++ b/pkg/resource/aws/aws_lambda_function.go
@@ -18,5 +18,6 @@ func initAwsLambdaFunctionMetaData(resourceSchemaRepository resource.SchemaRepos
 		val.DeleteIfDefault("package_type")
 		val.DeleteIfDefault("signing_job_arn")
 		val.DeleteIfDefault("signing_profile_version_arn")
+		val.SafeDelete([]string{"source_code_size"})
 	})
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #673
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

We remove `source_code_size` from driftctl as it's a necessary duplicate of `source_code_hash`, and let the user decide to ignore this one or not, using the driftignore.