### PR TITLE
Use proper provider version in ACC tests

### DIFF
--- a/pkg/iac/terraform/state/testdata/acc/multiple_states/route53/terraform.tf
+++ b/pkg/iac/terraform/state/testdata/acc/multiple_states/route53/terraform.tf
@@ -5,7 +5,7 @@ provider "aws" {
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.19.0"
+      version = "3.19.0"
     }
   }
 

--- a/pkg/iac/terraform/state/testdata/acc/multiple_states/s3/terraform.tf
+++ b/pkg/iac/terraform/state/testdata/acc/multiple_states/s3/terraform.tf
@@ -5,7 +5,7 @@ provider "aws" {
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.19.0"
+      version = "3.19.0"
     }
   }
 

--- a/pkg/iac/terraform/state/testdata/acc/multiple_states_local/route53/terraform.tf
+++ b/pkg/iac/terraform/state/testdata/acc/multiple_states_local/route53/terraform.tf
@@ -5,7 +5,7 @@ provider "aws" {
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.19.0"
+      version = "3.19.0"
     }
   }
 

--- a/pkg/iac/terraform/state/testdata/acc/multiple_states_local/s3/terraform.tf
+++ b/pkg/iac/terraform/state/testdata/acc/multiple_states_local/s3/terraform.tf
@@ -5,7 +5,7 @@ provider "aws" {
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.19.0"
+      version = "3.19.0"
     }
   }
 

--- a/pkg/resource/aws/aws_eip_association_test.go
+++ b/pkg/resource/aws/aws_eip_association_test.go
@@ -11,7 +11,7 @@ func TestAcc_Aws_EipAssociation(t *testing.T) {
 	acceptance.Run(t, acceptance.AccTestCase{
 		TerraformVersion: "0.14.9",
 		Paths:            []string{"./testdata/acc/aws_eip_association"},
-		Args:             []string{"scan", "--filter", "Type=='aws_eip' || Type=='aws_eip_association'"},
+		Args:             []string{"scan", "--filter", "Type=='aws_eip' || Type=='aws_eip_association'", "--tf-provider-version", "3.44.0"},
 		Checks: []acceptance.AccCheck{
 			{
 				Env: map[string]string{

--- a/pkg/resource/aws/aws_eip_test.go
+++ b/pkg/resource/aws/aws_eip_test.go
@@ -11,7 +11,7 @@ func TestAcc_Aws_Eip(t *testing.T) {
 	acceptance.Run(t, acceptance.AccTestCase{
 		TerraformVersion: "0.14.9",
 		Paths:            []string{"./testdata/acc/aws_eip"},
-		Args:             []string{"scan", "--filter", "Type=='aws_eip' || Type=='aws_eip_association'"},
+		Args:             []string{"scan", "--filter", "Type=='aws_eip' || Type=='aws_eip_association'", "--tf-provider-version", "3.44.0"},
 		Checks: []acceptance.AccCheck{
 			{
 				Env: map[string]string{

--- a/pkg/resource/aws/aws_iam_role_test.go
+++ b/pkg/resource/aws/aws_iam_role_test.go
@@ -11,7 +11,7 @@ func TestAcc_Aws_IamRole(t *testing.T) {
 	acceptance.Run(t, acceptance.AccTestCase{
 		TerraformVersion: "0.14.9",
 		Paths:            []string{"./testdata/acc/aws_iam_role"},
-		Args:             []string{"scan", "--filter", "Type=='aws_iam_role'"},
+		Args:             []string{"scan", "--filter", "Type=='aws_iam_role'", "--tf-provider-version", "3.45.0"},
 		Checks: []acceptance.AccCheck{
 			{
 				Env: map[string]string{

--- a/pkg/resource/aws/aws_route_test.go
+++ b/pkg/resource/aws/aws_route_test.go
@@ -11,7 +11,7 @@ func TestAcc_AwsRoute(t *testing.T) {
 	acceptance.Run(t, acceptance.AccTestCase{
 		TerraformVersion: "0.14.9",
 		Paths:            []string{"./testdata/acc/aws_route"},
-		Args:             []string{"scan", "--filter", "Type=='aws_route'"},
+		Args:             []string{"scan", "--filter", "Type=='aws_route'", "--tf-provider-version", "3.44.0"},
 		Checks: []acceptance.AccCheck{
 			{
 				Env: map[string]string{

--- a/pkg/resource/aws/testdata/acc/aws_eip/terraform.tf
+++ b/pkg/resource/aws/testdata/acc/aws_eip/terraform.tf
@@ -4,7 +4,7 @@ provider "aws" {
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.44.0"
+      version = "3.44.0"
     }
   }
 }

--- a/pkg/resource/aws/testdata/acc/aws_eip_association/mainf.tf
+++ b/pkg/resource/aws/testdata/acc/aws_eip_association/mainf.tf
@@ -4,7 +4,7 @@ provider "aws" {
 terraform {
     required_providers {
         aws = {
-            version = "~> 3.44.0"
+            version = "3.44.0"
         }
     }
 }

--- a/pkg/resource/aws/testdata/acc/aws_iam_access_key/terraform.tf
+++ b/pkg/resource/aws/testdata/acc/aws_iam_access_key/terraform.tf
@@ -4,7 +4,7 @@ provider "aws" {
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.19.0"
+      version = "3.19.0"
     }
   }
 }

--- a/pkg/resource/aws/testdata/acc/aws_iam_policy_attachment/providers.tf
+++ b/pkg/resource/aws/testdata/acc/aws_iam_policy_attachment/providers.tf
@@ -4,7 +4,7 @@ provider "aws" {
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.19.0"
+      version = "3.19.0"
     }
   }
 }

--- a/pkg/resource/aws/testdata/acc/aws_instance/providers.tf
+++ b/pkg/resource/aws/testdata/acc/aws_instance/providers.tf
@@ -4,7 +4,7 @@ provider "aws" {
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.19.0"
+      version = "3.19.0"
     }
   }
 }

--- a/pkg/resource/aws/testdata/acc/aws_route53_record/providers.tf
+++ b/pkg/resource/aws/testdata/acc/aws_route53_record/providers.tf
@@ -4,7 +4,7 @@ provider "aws" {
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.19.0"
+      version = "3.19.0"
     }
   }
 }

--- a/pkg/resource/aws/testdata/acc/aws_route53_record_with_alias/providers.tf
+++ b/pkg/resource/aws/testdata/acc/aws_route53_record_with_alias/providers.tf
@@ -4,7 +4,7 @@ provider "aws" {
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.19.0"
+      version = "3.19.0"
     }
   }
 }

--- a/pkg/resource/aws/testdata/acc/aws_s3_bucket/providers.tf
+++ b/pkg/resource/aws/testdata/acc/aws_s3_bucket/providers.tf
@@ -4,7 +4,7 @@ provider "aws" {
 terraform {
   required_providers {
     aws = {
-      version = "~> 3.19.0"
+      version = "3.19.0"
     }
   }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

This PR attempt to fix resource serialization issues in acceptance tests ([example](https://app.circleci.com/pipelines/github/cloudskiff/driftctl/2515/workflows/ff81f09f-c834-4366-bf8c-7618114ebe9e/jobs/4963)). I also pinned provider versions in the `required_providers` directive.

```
DEBU[2902] Reading resources from state backend= path=testdata/acc/aws_route/terraform.tfstate
DEBU[2902] Found module in state module= resourceCount=7
DEBU[2902] Got a cty path error when deserializing state err=unsupported attribute "tags_all" name=vpc type=aws_vpc
DEBU[2902] Successfully converted resource
DEBU[2902] Got a cty path error when deserializing state err=unsupported attribute "arn" name=default type=aws_default_route_table
DEBU[2902] Successfully converted resource
DEBU[2902] Got a cty path error when deserializing state err=unsupported attribute "tags_all" name=main type=aws_internet_gateway
DEBU[2902] Successfully converted resource
DEBU[2902] Got a cty path error when deserializing state err=unsupported attribute "carrier_gateway_id" name=route1 type=aws_route
DEBU[2902] Successfully converted resource
DEBU[2902] Got a cty path error when deserializing state err=unsupported attribute "carrier_gateway_id" name=route_v6 type=aws_route
DEBU[2902] Successfully converted resource
DEBU[2902] Got a cty path error when deserializing state err=unsupported attribute "arn" name=r type=aws_route_table
DEBU[2902] Successfully converted resource
DEBU[2902] Got a cty path error when deserializing state err=unsupported attribute "arn" name=rr type=aws_route_table
DEBU[2902] Successfully converted resource
```