### PR TITLE
Fix goldenfile update

### DIFF
--- a/test/test_diff.go
+++ b/test/test_diff.go
@@ -29,7 +29,11 @@ func TestAgainstGoldenFile(
 
 	// update golden file
 	if shouldUpdate {
-		ctVal, err := gocty.ToCtyValue(got, ctyType)
+		attributes := make([]*resource.Attributes, 0, len(got))
+		for _, res := range got {
+			attributes = append(attributes, res.Attributes())
+		}
+		ctVal, err := gocty.ToCtyValue(attributes, ctyType)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
## Description

Goldenfile update were broken due to new test methods. We try to convert to `cty.Value` complete resource object but it fail with nil value for each field of the schema. We should only serialize resource attributes.