### PR TITLE
Allow multiple output flags for a single scan

### DIFF
--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -259,7 +259,7 @@ func scanRun(opts *pkg.ScanOptions) error {
 	validOutput := false
 	for _, o := range opts.Output {
 		if err = output.GetOutput(o, opts.Quiet).Write(analysis); err != nil {
-			logrus.Errorf("Computing output %s://%s failed: %v", o.Key, o.Options["path"], err.Error())
+			logrus.Errorf("Error writing to output %s: %v", o.String(), err.Error())
 			continue
 		}
 		validOutput = true
@@ -267,7 +267,7 @@ func scanRun(opts *pkg.ScanOptions) error {
 
 	// Fallback to console output if all output failed
 	if !validOutput {
-		logrus.Debug("All outputs failed to compute, fallback to console output")
+		logrus.Debug("All outputs failed, fallback to console output")
 		if err = output.NewConsole().Write(analysis); err != nil {
 			return err
 		}

--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -62,9 +62,6 @@ func NewScanCmd() *cobra.Command {
 			}
 
 			outputFlag, _ := cmd.Flags().GetStringSlice("output")
-			if len(outputFlag) == 0 {
-				outputFlag = append(outputFlag, output.Example(output.ConsoleOutputType))
-			}
 
 			out, err := parseOutputFlags(outputFlag)
 			if err != nil {
@@ -124,7 +121,7 @@ func NewScanCmd() *cobra.Command {
 	fl.StringSliceP(
 		"output",
 		"o",
-		[]string{},
+		[]string{output.Example(output.ConsoleOutputType)},
 		"Output format, by default it will write to the console\n"+
 			"Accepted formats are: "+strings.Join(output.SupportedOutputsExample(), ",")+"\n",
 	)

--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -261,9 +261,7 @@ func scanRun(opts *pkg.ScanOptions) error {
 
 	validOutput := false
 	for _, o := range opts.Output {
-		selectedOutput := output.GetOutput(o, opts.Quiet)
-		err = selectedOutput.Write(analysis)
-		if err != nil {
+		if err = output.GetOutput(o, opts.Quiet).Write(analysis); err != nil {
 			logrus.Errorf("Computing output %s://%s failed: %v", o.Key, o.Options["path"], err.Error())
 			continue
 		}
@@ -273,8 +271,7 @@ func scanRun(opts *pkg.ScanOptions) error {
 	// Fallback to console output if all output failed
 	if !validOutput {
 		logrus.Debug("All outputs failed to compute, fallback to console output")
-		err = output.NewConsole().Write(analysis)
-		if err != nil {
+		if err = output.NewConsole().Write(analysis); err != nil {
 			return err
 		}
 	}

--- a/pkg/cmd/scan/output/config.go
+++ b/pkg/cmd/scan/output/config.go
@@ -8,5 +8,5 @@ type OutputConfig struct {
 }
 
 func (o *OutputConfig) String() string {
-	return fmt.Sprintf("%s://%s", o.Key, o.Options["path"])
+	return fmt.Sprintf("%s://%s", o.Key, o.Path)
 }

--- a/pkg/cmd/scan/output/config.go
+++ b/pkg/cmd/scan/output/config.go
@@ -1,6 +1,12 @@
 package output
 
+import "fmt"
+
 type OutputConfig struct {
 	Key  string
 	Path string
+}
+
+func (o *OutputConfig) String() string {
+	return fmt.Sprintf("%s://%s", o.Key, o.Options["path"])
 }

--- a/pkg/cmd/scan/output/output.go
+++ b/pkg/cmd/scan/output/output.go
@@ -25,10 +25,6 @@ var supportedOutputExample = map[string]string{
 	PlanOutputType:    PlanOutputExample,
 }
 
-func SupportedOutputs() []string {
-	return supportedOutputTypes
-}
-
 func SupportedOutputsExample() []string {
 	examples := make([]string, 0, len(supportedOutputExample))
 	for _, ex := range supportedOutputExample {

--- a/pkg/cmd/scan_test.go
+++ b/pkg/cmd/scan_test.go
@@ -302,22 +302,16 @@ func Test_parseOutputFlag(t *testing.T) {
 			},
 			want: []output.OutputConfig{
 				{
-					Key: "json",
-					Options: map[string]string{
-						"path": "result1.json",
-					},
+					Key:  "json",
+					Path: "result1.json",
 				},
 				{
-					Key: "json",
-					Options: map[string]string{
-						"path": "result2.json",
-					},
+					Key:  "json",
+					Path: "result2.json",
 				},
 				{
-					Key: "json",
-					Options: map[string]string{
-						"path": "result3.json",
-					},
+					Key:  "json",
+					Path: "result3.json",
 				},
 			},
 			err: nil,

--- a/pkg/cmd/scan_test.go
+++ b/pkg/cmd/scan_test.go
@@ -295,6 +295,33 @@ func Test_parseOutputFlag(t *testing.T) {
 			},
 			err: fmt.Errorf("Unsupported output 'invalid': \nValid formats are: console://,html://PATH/TO/FILE.html,json://PATH/TO/FILE.json,plan://PATH/TO/FILE.json"),
 		},
+		{
+			name: "test multiple valid output values",
+			args: args{
+				out: []string{"json://result1.json", "json://result2.json", "json://result3.json"},
+			},
+			want: []output.OutputConfig{
+				{
+					Key: "json",
+					Options: map[string]string{
+						"path": "result1.json",
+					},
+				},
+				{
+					Key: "json",
+					Options: map[string]string{
+						"path": "result2.json",
+					},
+				},
+				{
+					Key: "json",
+					Options: map[string]string{
+						"path": "result3.json",
+					},
+				},
+			},
+			err: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/scan_test.go
+++ b/pkg/cmd/scan_test.go
@@ -48,6 +48,7 @@ func TestScanCmd_Valid(t *testing.T) {
 		{args: []string{"scan", "--tf-provider-version", "3.30.2"}},
 		{args: []string{"scan", "--driftignore", "./path/to/driftignore.s3"}},
 		{args: []string{"scan", "--driftignore", ".driftignore"}},
+		{args: []string{"scan", "-o", "html://result.html", "-o", "json://result.json"}},
 	}
 
 	for _, tt := range cases {
@@ -164,98 +165,140 @@ func Test_parseFromFlag(t *testing.T) {
 
 func Test_parseOutputFlag(t *testing.T) {
 	type args struct {
-		out string
+		out []string
 	}
 	tests := []struct {
 		name string
 		args args
-		want *output.OutputConfig
+		want []output.OutputConfig
 		err  error
 	}{
 		{
-			name: "test empty",
+			name: "test empty output",
 			args: args{
-				out: "",
+				out: []string{""},
 			},
-			want: nil,
+			want: []output.OutputConfig{},
 			err:  fmt.Errorf("Unable to parse output flag '': \nAccepted formats are: console://,html://PATH/TO/FILE.html,json://PATH/TO/FILE.json,plan://PATH/TO/FILE.json"),
+		},
+		{
+			name: "test empty array",
+			args: args{
+				out: []string{},
+			},
+			want: []output.OutputConfig{},
+			err:  nil,
 		},
 		{
 			name: "test invalid",
 			args: args{
-				out: "sdgjsdgjsdg",
+				out: []string{"sdgjsdgjsdg"},
 			},
-			want: nil,
+			want: []output.OutputConfig{},
 			err:  fmt.Errorf("Unable to parse output flag 'sdgjsdgjsdg': \nAccepted formats are: console://,html://PATH/TO/FILE.html,json://PATH/TO/FILE.json,plan://PATH/TO/FILE.json"),
 		},
 		{
 			name: "test invalid",
 			args: args{
-				out: "://",
+				out: []string{"://"},
 			},
-			want: nil,
+			want: []output.OutputConfig{},
 			err:  fmt.Errorf("Unable to parse output flag '://': \nAccepted formats are: console://,html://PATH/TO/FILE.html,json://PATH/TO/FILE.json,plan://PATH/TO/FILE.json"),
 		},
 		{
 			name: "test unsupported",
 			args: args{
-				out: "foobar://",
+				out: []string{"foobar://"},
 			},
-			want: nil,
+			want: []output.OutputConfig{},
 			err:  fmt.Errorf("Unsupported output 'foobar': \nValid formats are: console://,html://PATH/TO/FILE.html,json://PATH/TO/FILE.json,plan://PATH/TO/FILE.json"),
 		},
 		{
 			name: "test empty json",
 			args: args{
-				out: "json://",
+				out: []string{"json://"},
 			},
-			want: nil,
+			want: []output.OutputConfig{},
 			err:  fmt.Errorf("Invalid json output 'json://': \nMust be of kind: json://PATH/TO/FILE.json"),
 		},
 		{
 			name: "test valid console",
 			args: args{
-				out: "console://",
+				out: []string{"console://"},
 			},
-			want: &output.OutputConfig{
-				Key: "console",
+			want: []output.OutputConfig{
+				{
+					Key: "console",
+				},
 			},
 			err: nil,
 		},
 		{
 			name: "test valid json",
 			args: args{
-				out: "json:///tmp/foobar.json",
+				out: []string{"json:///tmp/foobar.json"},
 			},
-			want: &output.OutputConfig{
-				Key:  "json",
-				Path: "/tmp/foobar.json",
+			want: []output.OutputConfig{
+				{
+					Key:  "json",
+					Path: "/tmp/foobar.json",
+				},
 			},
 			err: nil,
 		},
 		{
 			name: "test empty jsonplan",
 			args: args{
-				out: "plan://",
+				out: []string{"plan://"},
 			},
-			want: nil,
+			want: []output.OutputConfig{},
 			err:  fmt.Errorf("Invalid plan output 'plan://': \nMust be of kind: plan://PATH/TO/FILE.json"),
 		},
 		{
 			name: "test valid jsonplan",
 			args: args{
-				out: "plan:///tmp/foobar.json",
+				out: []string{"plan:///tmp/foobar.json"},
 			},
-			want: &output.OutputConfig{
-				Key:  "plan",
-				Path: "/tmp/foobar.json",
+			want: []output.OutputConfig{
+				{
+					Key:  "plan",
+					Path: "/tmp/foobar.json",
+				},
 			},
 			err: nil,
+		},
+		{
+			name: "test multiple output values",
+			args: args{
+				out: []string{"console:///dev/stdout", "json://result.json"},
+			},
+			want: []output.OutputConfig{
+				{
+					Key: "console",
+				},
+				{
+					Key:  "json",
+					Path: "result.json",
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "test multiple output values with invalid value",
+			args: args{
+				out: []string{"console:///dev/stdout", "invalid://result.json"},
+			},
+			want: []output.OutputConfig{
+				{
+					Key: "console",
+				},
+			},
+			err: fmt.Errorf("Unsupported output 'invalid': \nValid formats are: console://,html://PATH/TO/FILE.html,json://PATH/TO/FILE.json,plan://PATH/TO/FILE.json"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseOutputFlag(tt.args.out)
+			got, err := parseOutputFlags(tt.args.out)
 			if err != nil && err.Error() != tt.err.Error() {
 				t.Fatalf("got error = '%v', expected '%v'", err, tt.err)
 			}

--- a/pkg/driftctl.go
+++ b/pkg/driftctl.go
@@ -24,7 +24,7 @@ type ScanOptions struct {
 	Detect           bool
 	From             []config.SupplierConfig
 	To               string
-	Output           output.OutputConfig
+	Output           []output.OutputConfig
 	Filter           *jmespath.JMESPath
 	Quiet            bool
 	BackendOptions   *backend.Options


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #831
| ❓ Documentation  | yes https://github.com/cloudskiff/driftctl-docs/pull/86 <!-- does this require documentation update ? -->

## Description

```bash
# Example
$ driftctl scan -o console://stdout -o html://reports/001/result.html -o json://reports/001/result.json
```