### PR TITLE
Fix defaults sgrule middleware to be deep mode compliant

### DIFF
--- a/pkg/middlewares/aws_default_security_group_rule.go
+++ b/pkg/middlewares/aws_default_security_group_rule.go
@@ -79,9 +79,11 @@ func isDefaultIngress(rule *resource.AbstractResource, remoteResources *[]resour
 	if _, exist := rule.Attrs.Get("prefix_list_ids"); exist {
 		return false
 	}
+	if self := rule.Attrs.GetBool("self"); self == nil || !*self {
+		return false
+	}
 	sgId := rule.Attrs.GetString("security_group_id")
-	sourceSgId := rule.Attrs.GetString("source_security_group_id")
-	if sgId == nil || sourceSgId == nil || *sgId != *sourceSgId {
+	if sgId == nil {
 		return false
 	}
 	return isFromDefaultSecurityGroup(sgId, remoteResources)

--- a/pkg/middlewares/aws_default_security_group_rule_test.go
+++ b/pkg/middlewares/aws_default_security_group_rule_test.go
@@ -34,6 +34,7 @@ func TestAwsDefaultSecurityGroupRule_Execute(t *testing.T) {
 						"protocol":                 "-1",
 						"security_group_id":        "default-sg",
 						"source_security_group_id": "default-sg",
+						"self":                     true,
 					},
 				},
 				&resource.AbstractResource{
@@ -133,6 +134,7 @@ func TestAwsDefaultSecurityGroupRule_Execute(t *testing.T) {
 						"protocol":                 "-1",
 						"security_group_id":        "default-sg",
 						"source_security_group_id": "default-sg",
+						"self":                     true,
 					},
 				},
 				&resource.AbstractResource{
@@ -203,6 +205,7 @@ func TestAwsDefaultSecurityGroupRule_Execute(t *testing.T) {
 						"protocol":                 "-1",
 						"security_group_id":        "default-sg",
 						"source_security_group_id": "default-sg",
+						"self":                     true,
 					},
 				},
 				&resource.AbstractResource{
@@ -240,6 +243,7 @@ func TestAwsDefaultSecurityGroupRule_Execute(t *testing.T) {
 						"protocol":                 "-1",
 						"security_group_id":        "default-sg",
 						"source_security_group_id": "default-sg",
+						"self":                     true,
 					},
 				},
 				&resource.AbstractResource{


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Default ingress security group rules should be ignored when deep mode is not enabled.

The problem was that, in non deep mode, rules don't have the `source_security_group` attribute but have the `self` attribute.

Because in the deep mode the `ReadResource` add to the resource both the `source_security_group` attribute and the `self` attribute, let's only rely on the `self` attribute to check default ingress rule.