### PR TITLE
Dereference vpc_id

### DIFF
--- a/pkg/remote/aws/ec2_internet_gateway_enumerator.go
+++ b/pkg/remote/aws/ec2_internet_gateway_enumerator.go
@@ -34,7 +34,7 @@ func (e *EC2InternetGatewayEnumerator) Enumerate() ([]resource.Resource, error) 
 	for _, internetGateway := range internetGateways {
 		data := map[string]interface{}{}
 		if len(internetGateway.Attachments) > 0 && internetGateway.Attachments[0].VpcId != nil {
-			data["vpc_id"] = internetGateway.Attachments[0].VpcId
+			data["vpc_id"] = *internetGateway.Attachments[0].VpcId
 		}
 		results = append(
 			results,


### PR DESCRIPTION
Needed to dereference the vpc_id to compare similar strings in `aws_default_internet_gateway` middleware.