### PR TITLE
Fix SQS queue policy crash

### DIFF
--- a/pkg/remote/aws/sqs_queue_policy_enumerator.go
+++ b/pkg/remote/aws/sqs_queue_policy_enumerator.go
@@ -32,21 +32,25 @@ func (e *SQSQueuePolicyEnumerator) Enumerate() ([]resource.Resource, error) {
 		return nil, remoteerror.NewResourceEnumerationErrorWithType(err, string(e.SupportedType()), aws.AwsSqsQueueResourceType)
 	}
 
-	results := make([]resource.Resource, len(queues))
+	results := make([]resource.Resource, 0, len(queues))
 
 	for _, queue := range queues {
+		attrs := map[string]interface{}{
+			"policy": "",
+		}
 		attributes, err := e.repository.GetQueueAttributes(*queue)
 		if err != nil {
 			return nil, remoteerror.NewResourceEnumerationError(err, string(e.SupportedType()))
+		}
+		if attributes.Attributes != nil {
+			attrs["policy"] = *attributes.Attributes[sqs.QueueAttributeNamePolicy]
 		}
 		results = append(
 			results,
 			e.factory.CreateAbstractResource(
 				string(e.SupportedType()),
 				awssdk.StringValue(queue),
-				map[string]interface{}{
-					"policy": *attributes.Attributes[sqs.QueueAttributeNamePolicy],
-				},
+				attrs,
 			),
 		)
 	}

--- a/pkg/remote/sqs_scanner_test.go
+++ b/pkg/remote/sqs_scanner_test.go
@@ -153,6 +153,23 @@ func TestSQSQueuePolicy(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			test:    "multiple sqs queue policies (with nil attributes)",
+			dirName: "sqs_queue_policy_multiple",
+			mocks: func(client *repository.MockSQSRepository) {
+				client.On("ListAllQueues").Return([]*string{
+					awssdk.String("https://sqs.eu-west-3.amazonaws.com/047081014315/bar.fifo"),
+					awssdk.String("https://sqs.eu-west-3.amazonaws.com/047081014315/foo"),
+					awssdk.String("https://sqs.eu-west-3.amazonaws.com/047081014315/baz"),
+				}, nil)
+
+				client.On("GetQueueAttributes", mock.Anything).Return(
+					&sqs.GetQueueAttributesOutput{},
+					nil,
+				)
+			},
+			wantErr: nil,
+		},
+		{
 			test:    "cannot list sqs queues, thus sqs queue policies",
 			dirName: "sqs_queue_policy_empty",
 			mocks: func(client *repository.MockSQSRepository) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Fix a weakness in sqs queue policy enumerator, sometimes attributes can be `nil`