### PR TITLE
Fix aws_instance acc test

### DIFF
--- a/pkg/resource/aws/aws_instance_test.go
+++ b/pkg/resource/aws/aws_instance_test.go
@@ -48,7 +48,14 @@ func TestAcc_AwsInstance_WithBlockDevices(t *testing.T) {
 	acceptance.Run(t, acceptance.AccTestCase{
 		TerraformVersion: "0.14.9",
 		Paths:            []string{"./testdata/acc/aws_instance"},
-		Args:             []string{"scan", "--filter", "Type=='aws_instance'"},
+		Args: []string{
+			"scan",
+			"--filter",
+			"Type=='aws_instance'",
+			"--tf-provider-version",
+			"3.19.0",
+			"--deep",
+		},
 		Checks: []acceptance.AccCheck{
 			{
 				Env: map[string]string{


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Fix aws_instance acc test by running driftctl in deep mode.