### PR TITLE
Handle `destination_prefix_list_id` in `aws_route`

### DIFF
--- a/pkg/remote/aws/ec2_route_enumerator.go
+++ b/pkg/remote/aws/ec2_route_enumerator.go
@@ -33,7 +33,7 @@ func (e *EC2RouteEnumerator) Enumerate() ([]resource.Resource, error) {
 
 	for _, routeTable := range routeTables {
 		for _, route := range routeTable.Routes {
-			routeId, _ := aws.CalculateRouteID(routeTable.RouteTableId, route.DestinationCidrBlock, route.DestinationIpv6CidrBlock)
+			routeId := aws.CalculateRouteID(routeTable.RouteTableId, route.DestinationCidrBlock, route.DestinationIpv6CidrBlock, route.DestinationPrefixListId)
 			data := map[string]interface{}{
 				"route_table_id": *routeTable.RouteTableId,
 				"origin":         *route.Origin,
@@ -43,6 +43,9 @@ func (e *EC2RouteEnumerator) Enumerate() ([]resource.Resource, error) {
 			}
 			if route.DestinationIpv6CidrBlock != nil && *route.DestinationIpv6CidrBlock != "" {
 				data["destination_ipv6_cidr_block"] = *route.DestinationIpv6CidrBlock
+			}
+			if route.DestinationPrefixListId != nil && *route.DestinationPrefixListId != "" {
+				data["destination_prefix_list_id"] = *route.DestinationPrefixListId
 			}
 			if route.GatewayId != nil && *route.GatewayId != "" {
 				data["gateway_id"] = *route.GatewayId

--- a/pkg/resource/aws/aws_route.go
+++ b/pkg/resource/aws/aws_route.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	"github.com/hashicorp/terraform/helper/hashcode"
-	"github.com/pkg/errors"
 )
 
 const AwsRouteResourceType = "aws_route"
@@ -41,18 +40,25 @@ func initAwsRouteMetaData(resourceSchemaRepository resource.SchemaRepositoryInte
 		if ipv6 := val.GetString("destination_ipv6_cidr_block"); ipv6 != nil && *ipv6 != "" {
 			attrs["Destination"] = *ipv6
 		}
+		if prefix := val.GetString("destination_prefix_list_id"); prefix != nil && *prefix != "" {
+			attrs["Destination"] = *prefix
+		}
 		return attrs
 	})
 }
 
-func CalculateRouteID(tableId, CidrBlock, Ipv6CidrBlock *string) (string, error) {
+func CalculateRouteID(tableId, CidrBlock, Ipv6CidrBlock, PrefixListId *string) string {
 	if CidrBlock != nil && *CidrBlock != "" {
-		return fmt.Sprintf("r-%s%d", *tableId, hashcode.String(*CidrBlock)), nil
+		return fmt.Sprintf("r-%s%d", *tableId, hashcode.String(*CidrBlock))
 	}
 
 	if Ipv6CidrBlock != nil && *Ipv6CidrBlock != "" {
-		return fmt.Sprintf("r-%s%d", *tableId, hashcode.String(*Ipv6CidrBlock)), nil
+		return fmt.Sprintf("r-%s%d", *tableId, hashcode.String(*Ipv6CidrBlock))
 	}
 
-	return "", errors.Errorf("invalid route detected for table %s", *tableId)
+	if PrefixListId != nil && *PrefixListId != "" {
+		return fmt.Sprintf("r-%s%d", *tableId, hashcode.String(*PrefixListId))
+	}
+
+	return ""
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Complete the route creation ID function to handle all the cases. Previously it was sending an unexpected alert for theses cases but this is a nonsense.