### PR TITLE
Include resource ID in scanning errors to ignore a particular resource

### DIFF
--- a/pkg/cmd/scan/output/console.go
+++ b/pkg/cmd/scan/output/console.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/cloudskiff/driftctl/pkg/remote/alerts"
 	"github.com/fatih/color"
 	"github.com/mattn/go-isatty"
 	"github.com/r3labs/diff/v2"
@@ -16,7 +17,6 @@ import (
 	"github.com/yudai/gojsondiff/formatter"
 
 	"github.com/cloudskiff/driftctl/pkg/analyser"
-	"github.com/cloudskiff/driftctl/pkg/remote"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 )
 
@@ -117,10 +117,10 @@ func (c *Console) Write(analysis *analyser.Analysis) error {
 	c.writeSummary(analysis)
 
 	enumerationErrorMessage := ""
-	for _, alerts := range analysis.Alerts() {
-		for _, alert := range alerts {
+	for _, a := range analysis.Alerts() {
+		for _, alert := range a {
 			fmt.Println(color.YellowString(alert.Message()))
-			if alert, ok := alert.(*remote.RemoteAccessDeniedAlert); ok && enumerationErrorMessage == "" {
+			if alert, ok := alert.(*alerts.RemoteAccessDeniedAlert); ok && enumerationErrorMessage == "" {
 				enumerationErrorMessage = alert.GetProviderMessage()
 			}
 		}

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -8,9 +8,8 @@ import (
 	"github.com/cloudskiff/driftctl/pkg/alerter"
 	"github.com/cloudskiff/driftctl/pkg/analyser"
 	"github.com/cloudskiff/driftctl/pkg/output"
-	"github.com/cloudskiff/driftctl/pkg/remote"
-	"github.com/cloudskiff/driftctl/pkg/remote/aws"
-	"github.com/cloudskiff/driftctl/pkg/remote/github"
+	"github.com/cloudskiff/driftctl/pkg/remote/alerts"
+	"github.com/cloudskiff/driftctl/pkg/remote/common"
 	"github.com/cloudskiff/driftctl/pkg/resource"
 	testresource "github.com/cloudskiff/driftctl/test/resource"
 	"github.com/r3labs/diff/v2"
@@ -91,9 +90,9 @@ func fakeAnalysisWithAlerts() *analyser.Analysis {
 	a := fakeAnalysis()
 	a.SetAlerts(alerter.Alerts{
 		"": []alerter.Alert{
-			remote.NewRemoteAccessDeniedAlert(aws.RemoteAWSTerraform, "aws_vpc", "aws_vpc", remote.EnumerationPhase),
-			remote.NewRemoteAccessDeniedAlert(aws.RemoteAWSTerraform, "aws_sqs", "aws_sqs", remote.EnumerationPhase),
-			remote.NewRemoteAccessDeniedAlert(aws.RemoteAWSTerraform, "aws_sns", "aws_sns", remote.EnumerationPhase),
+			alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, "aws_vpc", "aws_vpc", alerts.EnumerationPhase),
+			alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, "aws_sqs", "aws_sqs", alerts.EnumerationPhase),
+			alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, "aws_sns", "aws_sns", alerts.EnumerationPhase),
 		},
 	})
 	a.ProviderVersion = "3.19.0"
@@ -349,9 +348,9 @@ func fakeAnalysisWithAWSEnumerationError() *analyser.Analysis {
 	a := analyser.Analysis{}
 	a.SetAlerts(alerter.Alerts{
 		"": []alerter.Alert{
-			remote.NewRemoteAccessDeniedAlert(aws.RemoteAWSTerraform, "aws_vpc", "aws_vpc", remote.EnumerationPhase),
-			remote.NewRemoteAccessDeniedAlert(aws.RemoteAWSTerraform, "aws_sqs", "aws_sqs", remote.EnumerationPhase),
-			remote.NewRemoteAccessDeniedAlert(aws.RemoteAWSTerraform, "aws_sns", "aws_sns", remote.EnumerationPhase),
+			alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, "aws_vpc", "aws_vpc", alerts.EnumerationPhase),
+			alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, "aws_sqs", "aws_sqs", alerts.EnumerationPhase),
+			alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, "aws_sns", "aws_sns", alerts.EnumerationPhase),
 		},
 	})
 	a.ProviderName = "AWS"
@@ -363,8 +362,8 @@ func fakeAnalysisWithGithubEnumerationError() *analyser.Analysis {
 	a := analyser.Analysis{}
 	a.SetAlerts(alerter.Alerts{
 		"": []alerter.Alert{
-			remote.NewRemoteAccessDeniedAlert(github.RemoteGithubTerraform, "github_team", "github_team", remote.EnumerationPhase),
-			remote.NewRemoteAccessDeniedAlert(github.RemoteGithubTerraform, "github_team_membership", "github_team", remote.EnumerationPhase),
+			alerts.NewRemoteAccessDeniedAlert(common.RemoteGithubTerraform, "github_team", "github_team", alerts.EnumerationPhase),
+			alerts.NewRemoteAccessDeniedAlert(common.RemoteGithubTerraform, "github_team_membership", "github_team", alerts.EnumerationPhase),
 		},
 	})
 	a.ProviderName = "AWS"

--- a/pkg/remote/alerts/alerts.go
+++ b/pkg/remote/alerts/alerts.go
@@ -1,0 +1,80 @@
+package alerts
+
+import (
+	"fmt"
+
+	"github.com/cloudskiff/driftctl/pkg/alerter"
+	"github.com/cloudskiff/driftctl/pkg/remote/common"
+	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
+	"github.com/sirupsen/logrus"
+)
+
+type ScanningPhase int
+
+const (
+	EnumerationPhase ScanningPhase = iota
+	DetailsFetchingPhase
+)
+
+type RemoteAccessDeniedAlert struct {
+	message       string
+	provider      string
+	scanningPhase ScanningPhase
+}
+
+func NewRemoteAccessDeniedAlert(provider, resource, listedTypeError string, scanningPhase ScanningPhase) *RemoteAccessDeniedAlert {
+	var message string
+	switch scanningPhase {
+	case EnumerationPhase:
+		message = fmt.Sprintf("Ignoring %s from drift calculation: Listing %s is forbidden.", resource, listedTypeError)
+	case DetailsFetchingPhase:
+		message = fmt.Sprintf("Ignoring %s from drift calculation: Reading details of %s is forbidden.", resource, listedTypeError)
+	default:
+		message = fmt.Sprintf("Ignoring %s from drift calculation: %s", resource, listedTypeError)
+	}
+	return &RemoteAccessDeniedAlert{message, provider, scanningPhase}
+}
+
+func (e *RemoteAccessDeniedAlert) Message() string {
+	return e.message
+}
+
+func (e *RemoteAccessDeniedAlert) ShouldIgnoreResource() bool {
+	return true
+}
+
+func (e *RemoteAccessDeniedAlert) GetProviderMessage() string {
+	var message string
+	if e.scanningPhase == DetailsFetchingPhase {
+		message = "It seems that we got access denied exceptions while reading details of resources.\n"
+	}
+	if e.scanningPhase == EnumerationPhase {
+		message = "It seems that we got access denied exceptions while listing resources.\n"
+	}
+
+	switch e.provider {
+	case common.RemoteGithubTerraform:
+		message += "Please be sure that your Github token has the right permissions, check the last up-to-date documentation there: https://docs.driftctl.com/github/policy"
+	case common.RemoteAWSTerraform:
+		message += "The latest minimal read-only IAM policy for driftctl is always available here, please update yours: https://docs.driftctl.com/aws/policy"
+	default:
+		return ""
+	}
+	return message
+}
+
+func sendRemoteAccessDeniedAlert(provider string, alerter alerter.AlerterInterface, listError *remoteerror.ResourceScanningError, p ScanningPhase) {
+	logrus.WithFields(logrus.Fields{
+		"resource":    listError.Resource(),
+		"listed_type": listError.ListedTypeError(),
+	}).Debugf("Got an access denied error: %+v", listError.String())
+	alerter.SendAlert(listError.Resource(), NewRemoteAccessDeniedAlert(provider, listError.Resource(), listError.ListedTypeError(), p))
+}
+
+func SendEnumerationAlert(provider string, alerter alerter.AlerterInterface, listError *remoteerror.ResourceScanningError) {
+	sendRemoteAccessDeniedAlert(provider, alerter, listError, EnumerationPhase)
+}
+
+func SendDetailsFetchingAlert(provider string, alerter alerter.AlerterInterface, listError *remoteerror.ResourceScanningError) {
+	sendRemoteAccessDeniedAlert(provider, alerter, listError, DetailsFetchingPhase)
+}

--- a/pkg/remote/aws/cloudfront_distribution_enumerator.go
+++ b/pkg/remote/aws/cloudfront_distribution_enumerator.go
@@ -26,7 +26,7 @@ func (e *CloudfrontDistributionEnumerator) SupportedType() resource.ResourceType
 func (e *CloudfrontDistributionEnumerator) Enumerate() ([]resource.Resource, error) {
 	distributions, err := e.repository.ListAllDistributions()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(distributions))

--- a/pkg/remote/aws/default_vpc_enumerator.go
+++ b/pkg/remote/aws/default_vpc_enumerator.go
@@ -28,7 +28,7 @@ func (e *DefaultVPCEnumerator) SupportedType() resource.ResourceType {
 func (e *DefaultVPCEnumerator) Enumerate() ([]resource.Resource, error) {
 	_, defaultVPCs, err := e.repo.ListAllVPCs()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, aws.AwsDefaultVpcResourceType)
+		return nil, remoteerror.NewResourceListingError(err, aws.AwsDefaultVpcResourceType)
 	}
 
 	results := make([]resource.Resource, 0, len(defaultVPCs))

--- a/pkg/remote/aws/default_vpc_enumerator.go
+++ b/pkg/remote/aws/default_vpc_enumerator.go
@@ -28,7 +28,7 @@ func (e *DefaultVPCEnumerator) SupportedType() resource.ResourceType {
 func (e *DefaultVPCEnumerator) Enumerate() ([]resource.Resource, error) {
 	_, defaultVPCs, err := e.repo.ListAllVPCs()
 	if err != nil {
-		return nil, remoteerror.NewResourceListingError(err, aws.AwsDefaultVpcResourceType)
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, 0, len(defaultVPCs))

--- a/pkg/remote/aws/dynamodb_table_details_fetcher.go
+++ b/pkg/remote/aws/dynamodb_table_details_fetcher.go
@@ -28,7 +28,7 @@ func (r *DynamoDBTableDetailsFetcher) ReadDetails(res resource.Resource) (resour
 		},
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsDynamodbTableResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/dynamodb_table_enumerator.go
+++ b/pkg/remote/aws/dynamodb_table_enumerator.go
@@ -26,7 +26,7 @@ func (e *DynamoDBTableEnumerator) SupportedType() resource.ResourceType {
 func (e *DynamoDBTableEnumerator) Enumerate() ([]resource.Resource, error) {
 	tables, err := e.repository.ListAllTables()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(tables))

--- a/pkg/remote/aws/ec2_ami_enumerator.go
+++ b/pkg/remote/aws/ec2_ami_enumerator.go
@@ -26,7 +26,7 @@ func (e *EC2AmiEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2AmiEnumerator) Enumerate() ([]resource.Resource, error) {
 	images, err := e.repository.ListAllImages()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(images))

--- a/pkg/remote/aws/ec2_default_route_table_details_fetcher.go
+++ b/pkg/remote/aws/ec2_default_route_table_details_fetcher.go
@@ -28,7 +28,7 @@ func (r *EC2DefaultRouteTableDetailsFetcher) ReadDetails(res resource.Resource) 
 		},
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsDefaultRouteTableResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/ec2_default_route_table_enumerator.go
+++ b/pkg/remote/aws/ec2_default_route_table_enumerator.go
@@ -26,7 +26,7 @@ func (e *EC2DefaultRouteTableEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2DefaultRouteTableEnumerator) Enumerate() ([]resource.Resource, error) {
 	routeTables, err := e.repository.ListAllRouteTables()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	var results []resource.Resource

--- a/pkg/remote/aws/ec2_default_subnet_enumerator.go
+++ b/pkg/remote/aws/ec2_default_subnet_enumerator.go
@@ -26,7 +26,7 @@ func (e *EC2DefaultSubnetEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2DefaultSubnetEnumerator) Enumerate() ([]resource.Resource, error) {
 	_, defaultSubnets, err := e.repository.ListAllSubnets()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(defaultSubnets))

--- a/pkg/remote/aws/ec2_ebs_snapshot_enumerator.go
+++ b/pkg/remote/aws/ec2_ebs_snapshot_enumerator.go
@@ -26,7 +26,7 @@ func (e *EC2EbsSnapshotEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2EbsSnapshotEnumerator) Enumerate() ([]resource.Resource, error) {
 	snapshots, err := e.repository.ListAllSnapshots()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(snapshots))

--- a/pkg/remote/aws/ec2_ebs_volume_enumerator.go
+++ b/pkg/remote/aws/ec2_ebs_volume_enumerator.go
@@ -26,7 +26,7 @@ func (e *EC2EbsVolumeEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2EbsVolumeEnumerator) Enumerate() ([]resource.Resource, error) {
 	volumes, err := e.repository.ListAllVolumes()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(volumes))

--- a/pkg/remote/aws/ec2_eip_association_enumerator.go
+++ b/pkg/remote/aws/ec2_eip_association_enumerator.go
@@ -26,7 +26,7 @@ func (e *EC2EipAssociationEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2EipAssociationEnumerator) Enumerate() ([]resource.Resource, error) {
 	addresses, err := e.repository.ListAllAddressesAssociation()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, 0, len(addresses))

--- a/pkg/remote/aws/ec2_eip_enumerator.go
+++ b/pkg/remote/aws/ec2_eip_enumerator.go
@@ -26,7 +26,7 @@ func (e *EC2EipEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2EipEnumerator) Enumerate() ([]resource.Resource, error) {
 	addresses, err := e.repository.ListAllAddresses()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(addresses))

--- a/pkg/remote/aws/ec2_instance_enumerator.go
+++ b/pkg/remote/aws/ec2_instance_enumerator.go
@@ -26,7 +26,7 @@ func (e *EC2InstanceEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2InstanceEnumerator) Enumerate() ([]resource.Resource, error) {
 	instances, err := e.repository.ListAllInstances()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(instances))

--- a/pkg/remote/aws/ec2_internet_gateway_enumerator.go
+++ b/pkg/remote/aws/ec2_internet_gateway_enumerator.go
@@ -26,7 +26,7 @@ func (e *EC2InternetGatewayEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2InternetGatewayEnumerator) Enumerate() ([]resource.Resource, error) {
 	internetGateways, err := e.repository.ListAllInternetGateways()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(internetGateways))

--- a/pkg/remote/aws/ec2_key_pair_enumerator.go
+++ b/pkg/remote/aws/ec2_key_pair_enumerator.go
@@ -26,7 +26,7 @@ func (e *EC2KeyPairEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2KeyPairEnumerator) Enumerate() ([]resource.Resource, error) {
 	keyPairs, err := e.repository.ListAllKeyPairs()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(keyPairs))

--- a/pkg/remote/aws/ec2_nat_gateway_enumerator.go
+++ b/pkg/remote/aws/ec2_nat_gateway_enumerator.go
@@ -26,7 +26,7 @@ func (e *EC2NatGatewayEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2NatGatewayEnumerator) Enumerate() ([]resource.Resource, error) {
 	natGateways, err := e.repository.ListAllNatGateways()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(natGateways))

--- a/pkg/remote/aws/ec2_route_details_fetcher.go
+++ b/pkg/remote/aws/ec2_route_details_fetcher.go
@@ -35,7 +35,7 @@ func (r *EC2RouteDetailsFetcher) ReadDetails(res resource.Resource) (resource.Re
 		Attributes: attributes,
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsRouteResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/ec2_route_enumerator.go
+++ b/pkg/remote/aws/ec2_route_enumerator.go
@@ -26,7 +26,7 @@ func (e *EC2RouteEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2RouteEnumerator) Enumerate() ([]resource.Resource, error) {
 	routeTables, err := e.repository.ListAllRouteTables()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), aws.AwsRouteTableResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsRouteTableResourceType)
 	}
 
 	var results []resource.Resource

--- a/pkg/remote/aws/ec2_route_table_association_details_fetcher.go
+++ b/pkg/remote/aws/ec2_route_table_association_details_fetcher.go
@@ -28,7 +28,7 @@ func (r *EC2RouteTableAssociationDetailsFetcher) ReadDetails(res resource.Resour
 		},
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsRouteTableAssociationResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/ec2_route_table_association_enumerator.go
+++ b/pkg/remote/aws/ec2_route_table_association_enumerator.go
@@ -27,7 +27,7 @@ func (e *EC2RouteTableAssociationEnumerator) SupportedType() resource.ResourceTy
 func (e *EC2RouteTableAssociationEnumerator) Enumerate() ([]resource.Resource, error) {
 	routeTables, err := e.repository.ListAllRouteTables()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), aws.AwsRouteTableResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsRouteTableResourceType)
 	}
 
 	var results []resource.Resource

--- a/pkg/remote/aws/ec2_route_table_enumerator.go
+++ b/pkg/remote/aws/ec2_route_table_enumerator.go
@@ -27,7 +27,7 @@ func (e *EC2RouteTableEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2RouteTableEnumerator) Enumerate() ([]resource.Resource, error) {
 	routeTables, err := e.repository.ListAllRouteTables()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	var results []resource.Resource

--- a/pkg/remote/aws/ec2_subnet_enumerator.go
+++ b/pkg/remote/aws/ec2_subnet_enumerator.go
@@ -26,7 +26,7 @@ func (e *EC2SubnetEnumerator) SupportedType() resource.ResourceType {
 func (e *EC2SubnetEnumerator) Enumerate() ([]resource.Resource, error) {
 	subnets, _, err := e.repository.ListAllSubnets()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(subnets))

--- a/pkg/remote/aws/ecr_repository_enumerator.go
+++ b/pkg/remote/aws/ecr_repository_enumerator.go
@@ -26,7 +26,7 @@ func (e *ECRRepositoryEnumerator) SupportedType() resource.ResourceType {
 func (e *ECRRepositoryEnumerator) Enumerate() ([]resource.Resource, error) {
 	repos, err := e.repository.ListAllRepositories()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(repos))

--- a/pkg/remote/aws/iam_access_key_details_fetcher.go
+++ b/pkg/remote/aws/iam_access_key_details_fetcher.go
@@ -28,7 +28,7 @@ func (r *IamAccessKeyDetailsFetcher) ReadDetails(res resource.Resource) (resourc
 		},
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsIamAccessKeyResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/iam_access_key_enumerator.go
+++ b/pkg/remote/aws/iam_access_key_enumerator.go
@@ -26,12 +26,12 @@ func (e *IamAccessKeyEnumerator) SupportedType() resource.ResourceType {
 func (e *IamAccessKeyEnumerator) Enumerate() ([]resource.Resource, error) {
 	users, err := e.repository.ListAllUsers()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), resourceaws.AwsIamUserResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), resourceaws.AwsIamUserResourceType)
 	}
 
 	keys, err := e.repository.ListAllAccessKeys(users)
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, resourceaws.AwsIamAccessKeyResourceType)
+		return nil, remoteerror.NewResourceListingError(err, resourceaws.AwsIamAccessKeyResourceType)
 	}
 
 	results := make([]resource.Resource, 0)

--- a/pkg/remote/aws/iam_access_key_enumerator.go
+++ b/pkg/remote/aws/iam_access_key_enumerator.go
@@ -31,7 +31,7 @@ func (e *IamAccessKeyEnumerator) Enumerate() ([]resource.Resource, error) {
 
 	keys, err := e.repository.ListAllAccessKeys(users)
 	if err != nil {
-		return nil, remoteerror.NewResourceListingError(err, resourceaws.AwsIamAccessKeyResourceType)
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, 0)

--- a/pkg/remote/aws/iam_policy_enumerator.go
+++ b/pkg/remote/aws/iam_policy_enumerator.go
@@ -27,7 +27,7 @@ func (e *IamPolicyEnumerator) SupportedType() resource.ResourceType {
 func (e *IamPolicyEnumerator) Enumerate() ([]resource.Resource, error) {
 	policies, err := e.repository.ListAllPolicies()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(policies))

--- a/pkg/remote/aws/iam_role_enumerator.go
+++ b/pkg/remote/aws/iam_role_enumerator.go
@@ -40,7 +40,7 @@ func awsIamRoleShouldBeIgnored(roleName string) bool {
 func (e *IamRoleEnumerator) Enumerate() ([]resource.Resource, error) {
 	roles, err := e.repository.ListAllRoles()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, 0)

--- a/pkg/remote/aws/iam_role_policy_attachment_details_fetcher.go
+++ b/pkg/remote/aws/iam_role_policy_attachment_details_fetcher.go
@@ -29,7 +29,7 @@ func (r *IamRolePolicyAttachmentDetailsFetcher) ReadDetails(res resource.Resourc
 		},
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsIamRolePolicyAttachmentResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/iam_role_policy_attachment_enumerator.go
+++ b/pkg/remote/aws/iam_role_policy_attachment_enumerator.go
@@ -29,7 +29,7 @@ func (e *IamRolePolicyAttachmentEnumerator) SupportedType() resource.ResourceTyp
 func (e *IamRolePolicyAttachmentEnumerator) Enumerate() ([]resource.Resource, error) {
 	roles, err := e.repository.ListAllRoles()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), resourceaws.AwsIamRoleResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), resourceaws.AwsIamRoleResourceType)
 	}
 
 	results := make([]resource.Resource, 0)
@@ -48,7 +48,7 @@ func (e *IamRolePolicyAttachmentEnumerator) Enumerate() ([]resource.Resource, er
 
 	policyAttachments, err := e.repository.ListAllRolePolicyAttachments(rolesNotIgnored)
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	for _, attachedPol := range policyAttachments {

--- a/pkg/remote/aws/iam_role_policy_enumerator.go
+++ b/pkg/remote/aws/iam_role_policy_enumerator.go
@@ -29,12 +29,12 @@ func (e *IamRolePolicyEnumerator) SupportedType() resource.ResourceType {
 func (e *IamRolePolicyEnumerator) Enumerate() ([]resource.Resource, error) {
 	roles, err := e.repository.ListAllRoles()
 	if err != nil {
-		return nil, remoteerror.NewResourceListingErrorWithType(err, resourceaws.AwsIamRolePolicyResourceType, resourceaws.AwsIamRoleResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), resourceaws.AwsIamRoleResourceType)
 	}
 
 	policies, err := e.repository.ListAllRolePolicies(roles)
 	if err != nil {
-		return nil, remoteerror.NewResourceListingError(err, resourceaws.AwsIamRolePolicyResourceType)
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(policies))

--- a/pkg/remote/aws/iam_role_policy_enumerator.go
+++ b/pkg/remote/aws/iam_role_policy_enumerator.go
@@ -29,12 +29,12 @@ func (e *IamRolePolicyEnumerator) SupportedType() resource.ResourceType {
 func (e *IamRolePolicyEnumerator) Enumerate() ([]resource.Resource, error) {
 	roles, err := e.repository.ListAllRoles()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, resourceaws.AwsIamRolePolicyResourceType, resourceaws.AwsIamRoleResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, resourceaws.AwsIamRolePolicyResourceType, resourceaws.AwsIamRoleResourceType)
 	}
 
 	policies, err := e.repository.ListAllRolePolicies(roles)
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, resourceaws.AwsIamRolePolicyResourceType)
+		return nil, remoteerror.NewResourceListingError(err, resourceaws.AwsIamRolePolicyResourceType)
 	}
 
 	results := make([]resource.Resource, len(policies))

--- a/pkg/remote/aws/iam_user_enumerator.go
+++ b/pkg/remote/aws/iam_user_enumerator.go
@@ -27,7 +27,7 @@ func (e *IamUserEnumerator) SupportedType() resource.ResourceType {
 func (e *IamUserEnumerator) Enumerate() ([]resource.Resource, error) {
 	users, err := e.repository.ListAllUsers()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(users))

--- a/pkg/remote/aws/iam_user_policy_attachment_details_fetcher.go
+++ b/pkg/remote/aws/iam_user_policy_attachment_details_fetcher.go
@@ -29,7 +29,7 @@ func (r *IamUserPolicyAttachmentDetailsFetcher) ReadDetails(res resource.Resourc
 		},
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsIamUserPolicyAttachmentResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/iam_user_policy_attachment_enumerator.go
+++ b/pkg/remote/aws/iam_user_policy_attachment_enumerator.go
@@ -28,13 +28,13 @@ func (e *IamUserPolicyAttachmentEnumerator) SupportedType() resource.ResourceTyp
 func (e *IamUserPolicyAttachmentEnumerator) Enumerate() ([]resource.Resource, error) {
 	users, err := e.repository.ListAllUsers()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), resourceaws.AwsIamUserResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), resourceaws.AwsIamUserResourceType)
 	}
 
 	results := make([]resource.Resource, 0)
 	policyAttachments, err := e.repository.ListAllUserPolicyAttachments(users)
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	for _, attachedPol := range policyAttachments {

--- a/pkg/remote/aws/iam_user_policy_enumerator.go
+++ b/pkg/remote/aws/iam_user_policy_enumerator.go
@@ -26,11 +26,11 @@ func (e *IamUserPolicyEnumerator) SupportedType() resource.ResourceType {
 func (e *IamUserPolicyEnumerator) Enumerate() ([]resource.Resource, error) {
 	users, err := e.repository.ListAllUsers()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), aws.AwsIamUserResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsIamUserResourceType)
 	}
 	userPolicies, err := e.repository.ListAllUserPolicies(users)
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(userPolicies))

--- a/pkg/remote/aws/init.go
+++ b/pkg/remote/aws/init.go
@@ -12,8 +12,6 @@ import (
 	"github.com/cloudskiff/driftctl/pkg/terraform"
 )
 
-const RemoteAWSTerraform = "aws+tf"
-
 /**
  * Initialize remote (configure credentials, launch tf providers and start gRPC clients)
  * Required to use Scanner
@@ -57,17 +55,17 @@ func Init(version string, alerter *alerter.Alerter,
 	deserializer := resource.NewDeserializer(factory)
 	providerLibrary.AddProvider(terraform.AWS, provider)
 
-	remoteLibrary.AddEnumerator(NewS3BucketEnumerator(s3Repository, factory, provider.Config))
+	remoteLibrary.AddEnumerator(NewS3BucketEnumerator(s3Repository, factory, provider.Config, alerter))
 	remoteLibrary.AddDetailsFetcher(aws.AwsS3BucketResourceType, NewS3BucketDetailsFetcher(provider, deserializer))
-	remoteLibrary.AddEnumerator(NewS3BucketInventoryEnumerator(s3Repository, factory, provider.Config))
+	remoteLibrary.AddEnumerator(NewS3BucketInventoryEnumerator(s3Repository, factory, provider.Config, alerter))
 	remoteLibrary.AddDetailsFetcher(aws.AwsS3BucketInventoryResourceType, NewS3BucketInventoryDetailsFetcher(provider, deserializer))
-	remoteLibrary.AddEnumerator(NewS3BucketNotificationEnumerator(s3Repository, factory, provider.Config))
+	remoteLibrary.AddEnumerator(NewS3BucketNotificationEnumerator(s3Repository, factory, provider.Config, alerter))
 	remoteLibrary.AddDetailsFetcher(aws.AwsS3BucketNotificationResourceType, NewS3BucketNotificationDetailsFetcher(provider, deserializer))
-	remoteLibrary.AddEnumerator(NewS3BucketMetricsEnumerator(s3Repository, factory, provider.Config))
+	remoteLibrary.AddEnumerator(NewS3BucketMetricsEnumerator(s3Repository, factory, provider.Config, alerter))
 	remoteLibrary.AddDetailsFetcher(aws.AwsS3BucketMetricResourceType, NewS3BucketMetricsDetailsFetcher(provider, deserializer))
-	remoteLibrary.AddEnumerator(NewS3BucketPolicyEnumerator(s3Repository, factory, provider.Config))
+	remoteLibrary.AddEnumerator(NewS3BucketPolicyEnumerator(s3Repository, factory, provider.Config, alerter))
 	remoteLibrary.AddDetailsFetcher(aws.AwsS3BucketPolicyResourceType, NewS3BucketPolicyDetailsFetcher(provider, deserializer))
-	remoteLibrary.AddEnumerator(NewS3BucketAnalyticEnumerator(s3Repository, factory, provider.Config))
+	remoteLibrary.AddEnumerator(NewS3BucketAnalyticEnumerator(s3Repository, factory, provider.Config, alerter))
 	remoteLibrary.AddDetailsFetcher(aws.AwsS3BucketAnalyticsConfigurationResourceType, NewS3BucketAnalyticDetailsFetcher(provider, deserializer))
 
 	remoteLibrary.AddEnumerator(NewEC2EbsVolumeEnumerator(ec2repository, factory))

--- a/pkg/remote/aws/kms_alias_enumerator.go
+++ b/pkg/remote/aws/kms_alias_enumerator.go
@@ -26,7 +26,7 @@ func (e *KMSAliasEnumerator) SupportedType() resource.ResourceType {
 func (e *KMSAliasEnumerator) Enumerate() ([]resource.Resource, error) {
 	aliases, err := e.repository.ListAllAliases()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(aliases))

--- a/pkg/remote/aws/kms_key_enumerator.go
+++ b/pkg/remote/aws/kms_key_enumerator.go
@@ -26,7 +26,7 @@ func (e *KMSKeyEnumerator) SupportedType() resource.ResourceType {
 func (e *KMSKeyEnumerator) Enumerate() ([]resource.Resource, error) {
 	keys, err := e.repository.ListAllKeys()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(keys))

--- a/pkg/remote/aws/lambda_event_source_mapping_enumerator.go
+++ b/pkg/remote/aws/lambda_event_source_mapping_enumerator.go
@@ -26,7 +26,7 @@ func (e *LambdaEventSourceMappingEnumerator) SupportedType() resource.ResourceTy
 func (e *LambdaEventSourceMappingEnumerator) Enumerate() ([]resource.Resource, error) {
 	eventSourceMappings, err := e.repository.ListAllLambdaEventSourceMappings()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(eventSourceMappings))

--- a/pkg/remote/aws/lambda_function_details_fetcher.go
+++ b/pkg/remote/aws/lambda_function_details_fetcher.go
@@ -31,7 +31,7 @@ func (r *LambdaFunctionDetailsFetcher) ReadDetails(topic resource.Resource) (res
 	})
 	if err != nil {
 		logrus.Error(err)
-		return nil, remoteerror.NewResourceScanningError(err, resourceaws.AwsLambdaFunctionResourceType)
+		return nil, remoteerror.NewResourceScanningError(err, resourceaws.AwsLambdaFunctionResourceType, topic.TerraformId())
 	}
 	return r.deserializer.DeserializeOne(resourceaws.AwsLambdaFunctionResourceType, *val)
 }

--- a/pkg/remote/aws/lambda_function_details_fetcher.go
+++ b/pkg/remote/aws/lambda_function_details_fetcher.go
@@ -21,17 +21,17 @@ func NewLambdaFunctionDetailsFetcher(provider terraform.ResourceReader, deserial
 	}
 }
 
-func (r *LambdaFunctionDetailsFetcher) ReadDetails(topic resource.Resource) (resource.Resource, error) {
+func (r *LambdaFunctionDetailsFetcher) ReadDetails(res resource.Resource) (resource.Resource, error) {
 	val, err := r.reader.ReadResource(terraform.ReadResourceArgs{
-		ID: topic.TerraformId(),
+		ID: res.TerraformId(),
 		Ty: resourceaws.AwsLambdaFunctionResourceType,
 		Attributes: map[string]string{
-			"function_name": topic.TerraformId(),
+			"function_name": res.TerraformId(),
 		},
 	})
 	if err != nil {
 		logrus.Error(err)
-		return nil, remoteerror.NewResourceScanningError(err, resourceaws.AwsLambdaFunctionResourceType, topic.TerraformId())
+		return nil, remoteerror.NewResourceScanningError(err, resourceaws.AwsLambdaFunctionResourceType, res.TerraformId())
 	}
 	return r.deserializer.DeserializeOne(resourceaws.AwsLambdaFunctionResourceType, *val)
 }

--- a/pkg/remote/aws/lambda_function_enumerator.go
+++ b/pkg/remote/aws/lambda_function_enumerator.go
@@ -26,7 +26,7 @@ func (e *LambdaFunctionEnumerator) SupportedType() resource.ResourceType {
 func (e *LambdaFunctionEnumerator) Enumerate() ([]resource.Resource, error) {
 	functions, err := e.repository.ListAllLambdaFunctions()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(functions))

--- a/pkg/remote/aws/rds_db_instance_enumerator.go
+++ b/pkg/remote/aws/rds_db_instance_enumerator.go
@@ -26,7 +26,7 @@ func (e *RDSDBInstanceEnumerator) SupportedType() resource.ResourceType {
 func (e *RDSDBInstanceEnumerator) Enumerate() ([]resource.Resource, error) {
 	instances, err := e.repository.ListAllDBInstances()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(instances))

--- a/pkg/remote/aws/rds_db_subnet_group_enumerator.go
+++ b/pkg/remote/aws/rds_db_subnet_group_enumerator.go
@@ -26,7 +26,7 @@ func (e *RDSDBSubnetGroupEnumerator) SupportedType() resource.ResourceType {
 func (e *RDSDBSubnetGroupEnumerator) Enumerate() ([]resource.Resource, error) {
 	subnetGroups, err := e.repository.ListAllDBSubnetGroups()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(subnetGroups))

--- a/pkg/remote/aws/route53_health_check_enumerator.go
+++ b/pkg/remote/aws/route53_health_check_enumerator.go
@@ -26,7 +26,7 @@ func (e *Route53HealthCheckEnumerator) SupportedType() resource.ResourceType {
 func (e *Route53HealthCheckEnumerator) Enumerate() ([]resource.Resource, error) {
 	healthChecks, err := e.repository.ListAllHealthChecks()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(healthChecks))

--- a/pkg/remote/aws/route53_record_enumerator.go
+++ b/pkg/remote/aws/route53_record_enumerator.go
@@ -31,7 +31,7 @@ func (e *Route53RecordEnumerator) Enumerate() ([]resource.Resource, error) {
 
 	zones, err := e.client.ListAllZones()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), resourceaws.AwsRoute53ZoneResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), resourceaws.AwsRoute53ZoneResourceType)
 	}
 
 	results := make([]resource.Resource, len(zones))
@@ -39,7 +39,7 @@ func (e *Route53RecordEnumerator) Enumerate() ([]resource.Resource, error) {
 	for _, hostedZone := range zones {
 		records, err := e.listRecordsForZone(strings.TrimPrefix(*hostedZone.Id, "/hostedzone/"))
 		if err != nil {
-			return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+			return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 		}
 
 		results = append(results, records...)

--- a/pkg/remote/aws/route53_zone_enumerator.go
+++ b/pkg/remote/aws/route53_zone_enumerator.go
@@ -30,7 +30,7 @@ func (e *Route53ZoneSupplier) SupportedType() resource.ResourceType {
 func (e *Route53ZoneSupplier) Enumerate() ([]resource.Resource, error) {
 	zones, err := e.client.ListAllZones()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(zones))

--- a/pkg/remote/aws/s3_bucket_analytic_detail_fetcher.go
+++ b/pkg/remote/aws/s3_bucket_analytic_detail_fetcher.go
@@ -28,7 +28,7 @@ func (r *S3BucketAnalyticDetailsFetcher) ReadDetails(res resource.Resource) (res
 		},
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsS3BucketAnalyticsConfigurationResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/s3_bucket_analytic_enumerator.go
+++ b/pkg/remote/aws/s3_bucket_analytic_enumerator.go
@@ -3,7 +3,10 @@ package aws
 import (
 	"fmt"
 
+	"github.com/cloudskiff/driftctl/pkg/alerter"
+	"github.com/cloudskiff/driftctl/pkg/remote/alerts"
 	"github.com/cloudskiff/driftctl/pkg/remote/aws/repository"
+	"github.com/cloudskiff/driftctl/pkg/remote/common"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 	tf "github.com/cloudskiff/driftctl/pkg/remote/terraform"
 	"github.com/cloudskiff/driftctl/pkg/resource"
@@ -15,13 +18,15 @@ type S3BucketAnalyticEnumerator struct {
 	repository     repository.S3Repository
 	factory        resource.ResourceFactory
 	providerConfig tf.TerraformProviderConfig
+	alerter        alerter.AlerterInterface
 }
 
-func NewS3BucketAnalyticEnumerator(repo repository.S3Repository, factory resource.ResourceFactory, providerConfig tf.TerraformProviderConfig) *S3BucketAnalyticEnumerator {
+func NewS3BucketAnalyticEnumerator(repo repository.S3Repository, factory resource.ResourceFactory, providerConfig tf.TerraformProviderConfig, alerter alerter.AlerterInterface) *S3BucketAnalyticEnumerator {
 	return &S3BucketAnalyticEnumerator{
 		repository:     repo,
 		factory:        factory,
 		providerConfig: providerConfig,
+		alerter:        alerter,
 	}
 }
 
@@ -32,7 +37,7 @@ func (e *S3BucketAnalyticEnumerator) SupportedType() resource.ResourceType {
 func (e *S3BucketAnalyticEnumerator) Enumerate() ([]resource.Resource, error) {
 	buckets, err := e.repository.ListAllBuckets()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
 	}
 
 	results := make([]resource.Resource, len(buckets))
@@ -40,7 +45,8 @@ func (e *S3BucketAnalyticEnumerator) Enumerate() ([]resource.Resource, error) {
 	for _, bucket := range buckets {
 		region, err := e.repository.GetBucketLocation(*bucket.Name)
 		if err != nil {
-			return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
+			alerts.SendEnumerationAlert(common.RemoteAWSTerraform, e.alerter, remoteerror.NewResourceScanningError(err, string(e.SupportedType()), *bucket.Name))
+			continue
 		}
 		if region == "" || region != e.providerConfig.DefaultAlias {
 			logrus.WithFields(logrus.Fields{
@@ -52,7 +58,7 @@ func (e *S3BucketAnalyticEnumerator) Enumerate() ([]resource.Resource, error) {
 
 		analyticsConfigurationList, err := e.repository.ListBucketAnalyticsConfigurations(bucket, region)
 		if err != nil {
-			return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+			return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 		}
 
 		for _, analytics := range analyticsConfigurationList {

--- a/pkg/remote/aws/s3_bucket_details_fetcher.go
+++ b/pkg/remote/aws/s3_bucket_details_fetcher.go
@@ -28,7 +28,7 @@ func (r *S3BucketDetailsFetcher) ReadDetails(res resource.Resource) (resource.Re
 		},
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsS3BucketResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/s3_bucket_enumerator.go
+++ b/pkg/remote/aws/s3_bucket_enumerator.go
@@ -1,7 +1,10 @@
 package aws
 
 import (
+	"github.com/cloudskiff/driftctl/pkg/alerter"
+	"github.com/cloudskiff/driftctl/pkg/remote/alerts"
 	"github.com/cloudskiff/driftctl/pkg/remote/aws/repository"
+	"github.com/cloudskiff/driftctl/pkg/remote/common"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 	tf "github.com/cloudskiff/driftctl/pkg/remote/terraform"
 	"github.com/cloudskiff/driftctl/pkg/resource"
@@ -13,13 +16,15 @@ type S3BucketEnumerator struct {
 	repository     repository.S3Repository
 	factory        resource.ResourceFactory
 	providerConfig tf.TerraformProviderConfig
+	alerter        alerter.AlerterInterface
 }
 
-func NewS3BucketEnumerator(repo repository.S3Repository, factory resource.ResourceFactory, providerConfig tf.TerraformProviderConfig) *S3BucketEnumerator {
+func NewS3BucketEnumerator(repo repository.S3Repository, factory resource.ResourceFactory, providerConfig tf.TerraformProviderConfig, alerter alerter.AlerterInterface) *S3BucketEnumerator {
 	return &S3BucketEnumerator{
 		repository:     repo,
 		factory:        factory,
 		providerConfig: providerConfig,
+		alerter:        alerter,
 	}
 }
 
@@ -30,7 +35,7 @@ func (e *S3BucketEnumerator) SupportedType() resource.ResourceType {
 func (e *S3BucketEnumerator) Enumerate() ([]resource.Resource, error) {
 	buckets, err := e.repository.ListAllBuckets()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(buckets))
@@ -38,7 +43,8 @@ func (e *S3BucketEnumerator) Enumerate() ([]resource.Resource, error) {
 	for _, bucket := range buckets {
 		region, err := e.repository.GetBucketLocation(*bucket.Name)
 		if err != nil {
-			return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+			alerts.SendEnumerationAlert(common.RemoteAWSTerraform, e.alerter, remoteerror.NewResourceScanningError(err, string(e.SupportedType()), *bucket.Name))
+			continue
 		}
 		if region == "" || region != e.providerConfig.DefaultAlias {
 			logrus.WithFields(logrus.Fields{

--- a/pkg/remote/aws/s3_bucket_inventory_details_fetcher.go
+++ b/pkg/remote/aws/s3_bucket_inventory_details_fetcher.go
@@ -28,7 +28,7 @@ func (r *S3BucketInventoryDetailsFetcher) ReadDetails(res resource.Resource) (re
 		},
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsS3BucketInventoryResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/s3_bucket_inventory_enumerator.go
+++ b/pkg/remote/aws/s3_bucket_inventory_enumerator.go
@@ -3,7 +3,10 @@ package aws
 import (
 	"fmt"
 
+	"github.com/cloudskiff/driftctl/pkg/alerter"
+	"github.com/cloudskiff/driftctl/pkg/remote/alerts"
 	"github.com/cloudskiff/driftctl/pkg/remote/aws/repository"
+	"github.com/cloudskiff/driftctl/pkg/remote/common"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 	tf "github.com/cloudskiff/driftctl/pkg/remote/terraform"
 	"github.com/cloudskiff/driftctl/pkg/resource"
@@ -15,13 +18,15 @@ type S3BucketInventoryEnumerator struct {
 	repository     repository.S3Repository
 	factory        resource.ResourceFactory
 	providerConfig tf.TerraformProviderConfig
+	alerter        alerter.AlerterInterface
 }
 
-func NewS3BucketInventoryEnumerator(repo repository.S3Repository, factory resource.ResourceFactory, providerConfig tf.TerraformProviderConfig) *S3BucketInventoryEnumerator {
+func NewS3BucketInventoryEnumerator(repo repository.S3Repository, factory resource.ResourceFactory, providerConfig tf.TerraformProviderConfig, alerter alerter.AlerterInterface) *S3BucketInventoryEnumerator {
 	return &S3BucketInventoryEnumerator{
 		repository:     repo,
 		factory:        factory,
 		providerConfig: providerConfig,
+		alerter:        alerter,
 	}
 }
 
@@ -32,7 +37,7 @@ func (e *S3BucketInventoryEnumerator) SupportedType() resource.ResourceType {
 func (e *S3BucketInventoryEnumerator) Enumerate() ([]resource.Resource, error) {
 	buckets, err := e.repository.ListAllBuckets()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
 	}
 
 	results := make([]resource.Resource, len(buckets))
@@ -40,7 +45,8 @@ func (e *S3BucketInventoryEnumerator) Enumerate() ([]resource.Resource, error) {
 	for _, bucket := range buckets {
 		region, err := e.repository.GetBucketLocation(*bucket.Name)
 		if err != nil {
-			return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
+			alerts.SendEnumerationAlert(common.RemoteAWSTerraform, e.alerter, remoteerror.NewResourceScanningError(err, string(e.SupportedType()), *bucket.Name))
+			continue
 		}
 		if region == "" || region != e.providerConfig.DefaultAlias {
 			logrus.WithFields(logrus.Fields{
@@ -52,7 +58,8 @@ func (e *S3BucketInventoryEnumerator) Enumerate() ([]resource.Resource, error) {
 
 		inventoryConfigurations, err := e.repository.ListBucketInventoryConfigurations(bucket, region)
 		if err != nil {
-			return nil, remoteerror.NewResourceScanningError(err, aws.AwsS3BucketInventoryResourceType)
+			// TODO: we should think about a way to ignore just one bucket inventory listing
+			return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 		}
 
 		for _, config := range inventoryConfigurations {

--- a/pkg/remote/aws/s3_bucket_metrics_details_fetcher.go
+++ b/pkg/remote/aws/s3_bucket_metrics_details_fetcher.go
@@ -28,7 +28,7 @@ func (r *S3BucketMetricsDetailsFetcher) ReadDetails(res resource.Resource) (reso
 		},
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsS3BucketMetricResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/s3_bucket_metrics_enumerator.go
+++ b/pkg/remote/aws/s3_bucket_metrics_enumerator.go
@@ -3,7 +3,10 @@ package aws
 import (
 	"fmt"
 
+	"github.com/cloudskiff/driftctl/pkg/alerter"
+	"github.com/cloudskiff/driftctl/pkg/remote/alerts"
 	"github.com/cloudskiff/driftctl/pkg/remote/aws/repository"
+	"github.com/cloudskiff/driftctl/pkg/remote/common"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 	tf "github.com/cloudskiff/driftctl/pkg/remote/terraform"
 	"github.com/cloudskiff/driftctl/pkg/resource"
@@ -15,13 +18,15 @@ type S3BucketMetricsEnumerator struct {
 	repository     repository.S3Repository
 	factory        resource.ResourceFactory
 	providerConfig tf.TerraformProviderConfig
+	alerter        alerter.AlerterInterface
 }
 
-func NewS3BucketMetricsEnumerator(repo repository.S3Repository, factory resource.ResourceFactory, providerConfig tf.TerraformProviderConfig) *S3BucketMetricsEnumerator {
+func NewS3BucketMetricsEnumerator(repo repository.S3Repository, factory resource.ResourceFactory, providerConfig tf.TerraformProviderConfig, alerter alerter.AlerterInterface) *S3BucketMetricsEnumerator {
 	return &S3BucketMetricsEnumerator{
 		repository:     repo,
 		factory:        factory,
 		providerConfig: providerConfig,
+		alerter:        alerter,
 	}
 }
 
@@ -32,7 +37,7 @@ func (e *S3BucketMetricsEnumerator) SupportedType() resource.ResourceType {
 func (e *S3BucketMetricsEnumerator) Enumerate() ([]resource.Resource, error) {
 	buckets, err := e.repository.ListAllBuckets()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, aws.AwsS3BucketMetricResourceType, aws.AwsS3BucketResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, aws.AwsS3BucketMetricResourceType, aws.AwsS3BucketResourceType)
 	}
 
 	results := make([]resource.Resource, len(buckets))
@@ -40,7 +45,8 @@ func (e *S3BucketMetricsEnumerator) Enumerate() ([]resource.Resource, error) {
 	for _, bucket := range buckets {
 		region, err := e.repository.GetBucketLocation(*bucket.Name)
 		if err != nil {
-			return nil, remoteerror.NewResourceScanningErrorWithType(err, aws.AwsS3BucketMetricResourceType, aws.AwsS3BucketResourceType)
+			alerts.SendEnumerationAlert(common.RemoteAWSTerraform, e.alerter, remoteerror.NewResourceScanningError(err, string(e.SupportedType()), *bucket.Name))
+			continue
 		}
 		if region == "" || region != e.providerConfig.DefaultAlias {
 			logrus.WithFields(logrus.Fields{
@@ -52,7 +58,7 @@ func (e *S3BucketMetricsEnumerator) Enumerate() ([]resource.Resource, error) {
 
 		metricsConfigurationList, err := e.repository.ListBucketMetricsConfigurations(bucket, region)
 		if err != nil {
-			return nil, remoteerror.NewResourceScanningError(err, aws.AwsS3BucketMetricResourceType)
+			return nil, remoteerror.NewResourceListingError(err, aws.AwsS3BucketMetricResourceType)
 		}
 
 		for _, metric := range metricsConfigurationList {

--- a/pkg/remote/aws/s3_bucket_metrics_enumerator.go
+++ b/pkg/remote/aws/s3_bucket_metrics_enumerator.go
@@ -37,7 +37,7 @@ func (e *S3BucketMetricsEnumerator) SupportedType() resource.ResourceType {
 func (e *S3BucketMetricsEnumerator) Enumerate() ([]resource.Resource, error) {
 	buckets, err := e.repository.ListAllBuckets()
 	if err != nil {
-		return nil, remoteerror.NewResourceListingErrorWithType(err, aws.AwsS3BucketMetricResourceType, aws.AwsS3BucketResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
 	}
 
 	results := make([]resource.Resource, len(buckets))
@@ -58,7 +58,7 @@ func (e *S3BucketMetricsEnumerator) Enumerate() ([]resource.Resource, error) {
 
 		metricsConfigurationList, err := e.repository.ListBucketMetricsConfigurations(bucket, region)
 		if err != nil {
-			return nil, remoteerror.NewResourceListingError(err, aws.AwsS3BucketMetricResourceType)
+			return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 		}
 
 		for _, metric := range metricsConfigurationList {

--- a/pkg/remote/aws/s3_bucket_notification_details_fetcher.go
+++ b/pkg/remote/aws/s3_bucket_notification_details_fetcher.go
@@ -28,7 +28,7 @@ func (r *S3BucketNotificationDetailsFetcher) ReadDetails(res resource.Resource) 
 		},
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsS3BucketNotificationResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/s3_bucket_policy_detail_fetcher.go
+++ b/pkg/remote/aws/s3_bucket_policy_detail_fetcher.go
@@ -28,7 +28,7 @@ func (r *S3BucketPolicyDetailsFetcher) ReadDetails(res resource.Resource) (resou
 		},
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsS3BucketPolicyResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/s3_bucket_policy_enumerator.go
+++ b/pkg/remote/aws/s3_bucket_policy_enumerator.go
@@ -1,7 +1,10 @@
 package aws
 
 import (
+	"github.com/cloudskiff/driftctl/pkg/alerter"
+	"github.com/cloudskiff/driftctl/pkg/remote/alerts"
 	"github.com/cloudskiff/driftctl/pkg/remote/aws/repository"
+	"github.com/cloudskiff/driftctl/pkg/remote/common"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
 	tf "github.com/cloudskiff/driftctl/pkg/remote/terraform"
 	"github.com/cloudskiff/driftctl/pkg/resource"
@@ -13,13 +16,15 @@ type S3BucketPolicyEnumerator struct {
 	repository     repository.S3Repository
 	factory        resource.ResourceFactory
 	providerConfig tf.TerraformProviderConfig
+	alerter        alerter.AlerterInterface
 }
 
-func NewS3BucketPolicyEnumerator(repo repository.S3Repository, factory resource.ResourceFactory, providerConfig tf.TerraformProviderConfig) *S3BucketPolicyEnumerator {
+func NewS3BucketPolicyEnumerator(repo repository.S3Repository, factory resource.ResourceFactory, providerConfig tf.TerraformProviderConfig, alerter alerter.AlerterInterface) *S3BucketPolicyEnumerator {
 	return &S3BucketPolicyEnumerator{
 		repository:     repo,
 		factory:        factory,
 		providerConfig: providerConfig,
+		alerter:        alerter,
 	}
 }
 
@@ -30,7 +35,7 @@ func (e *S3BucketPolicyEnumerator) SupportedType() resource.ResourceType {
 func (e *S3BucketPolicyEnumerator) Enumerate() ([]resource.Resource, error) {
 	buckets, err := e.repository.ListAllBuckets()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
 	}
 
 	results := make([]resource.Resource, len(buckets))
@@ -38,7 +43,8 @@ func (e *S3BucketPolicyEnumerator) Enumerate() ([]resource.Resource, error) {
 	for _, bucket := range buckets {
 		region, err := e.repository.GetBucketLocation(*bucket.Name)
 		if err != nil {
-			return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
+			alerts.SendEnumerationAlert(common.RemoteAWSTerraform, e.alerter, remoteerror.NewResourceScanningError(err, string(e.SupportedType()), *bucket.Name))
+			continue
 		}
 		if region == "" || region != e.providerConfig.DefaultAlias {
 			logrus.WithFields(logrus.Fields{
@@ -50,7 +56,8 @@ func (e *S3BucketPolicyEnumerator) Enumerate() ([]resource.Resource, error) {
 
 		policy, err := e.repository.GetBucketPolicy(*bucket.Name, region)
 		if err != nil {
-			return nil, remoteerror.NewResourceScanningError(err, aws.AwsS3BucketPolicyResourceType)
+			alerts.SendEnumerationAlert(common.RemoteAWSTerraform, e.alerter, remoteerror.NewResourceScanningError(err, string(e.SupportedType()), *bucket.Name))
+			continue
 		}
 
 		if policy != nil {

--- a/pkg/remote/aws/sns_topic_details_fetcher.go
+++ b/pkg/remote/aws/sns_topic_details_fetcher.go
@@ -31,7 +31,7 @@ func (r *SNSTopicDetailsFetcher) ReadDetails(topic resource.Resource) (resource.
 	})
 	if err != nil {
 		logrus.Error(err)
-		return nil, remoteerror.NewResourceScanningError(err, topic.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, topic.TerraformType(), topic.TerraformId())
 	}
 	return r.deserializer.DeserializeOne(aws.AwsSnsTopicResourceType, *val)
 }

--- a/pkg/remote/aws/sns_topic_enumerator.go
+++ b/pkg/remote/aws/sns_topic_enumerator.go
@@ -26,7 +26,7 @@ func (e *SNSTopicEnumerator) SupportedType() resource.ResourceType {
 func (e *SNSTopicEnumerator) Enumerate() ([]resource.Resource, error) {
 	topics, err := e.repository.ListAllTopics()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(topics))

--- a/pkg/remote/aws/sns_topic_policy_details_fetcher.go
+++ b/pkg/remote/aws/sns_topic_policy_details_fetcher.go
@@ -31,7 +31,7 @@ func (r *SNSTopicPolicyDetailsFetcher) ReadDetails(topic resource.Resource) (res
 	})
 	if err != nil {
 		logrus.Error(err)
-		return nil, remoteerror.NewResourceScanningError(err, topic.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, topic.TerraformType(), topic.TerraformId())
 	}
 	return r.deserializer.DeserializeOne(aws.AwsSnsTopicPolicyResourceType, *val)
 }

--- a/pkg/remote/aws/sns_topic_policy_enumerator.go
+++ b/pkg/remote/aws/sns_topic_policy_enumerator.go
@@ -26,7 +26,7 @@ func (e *SNSTopicPolicyEnumerator) SupportedType() resource.ResourceType {
 func (e *SNSTopicPolicyEnumerator) Enumerate() ([]resource.Resource, error) {
 	topics, err := e.repository.ListAllTopics()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), aws.AwsSnsTopicResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsSnsTopicResourceType)
 	}
 
 	results := make([]resource.Resource, len(topics))

--- a/pkg/remote/aws/sns_topic_subscription_details_fetcher.go
+++ b/pkg/remote/aws/sns_topic_subscription_details_fetcher.go
@@ -31,7 +31,7 @@ func (r *SNSTopicSubscriptionDetailsFetcher) ReadDetails(res resource.Resource) 
 	})
 	if err != nil {
 		logrus.Error(err)
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsSnsTopicSubscriptionResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/sns_topic_subscription_enumerator.go
+++ b/pkg/remote/aws/sns_topic_subscription_enumerator.go
@@ -58,7 +58,7 @@ func (e *SNSTopicSubscriptionEnumerator) SupportedType() resource.ResourceType {
 func (e *SNSTopicSubscriptionEnumerator) Enumerate() ([]resource.Resource, error) {
 	allSubscriptions, err := e.repository.ListAllSubscriptions()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(allSubscriptions))

--- a/pkg/remote/aws/sqs_queue_details_fetcher.go
+++ b/pkg/remote/aws/sqs_queue_details_fetcher.go
@@ -36,7 +36,7 @@ func (r *SQSQueueDetailsFetcher) ReadDetails(res resource.Resource) (resource.Re
 			return nil, nil
 		}
 		logrus.Error(err)
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsSqsQueueResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/sqs_queue_enumerator.go
+++ b/pkg/remote/aws/sqs_queue_enumerator.go
@@ -28,7 +28,7 @@ func (e *SQSQueueEnumerator) SupportedType() resource.ResourceType {
 func (e *SQSQueueEnumerator) Enumerate() ([]resource.Resource, error) {
 	queues, err := e.repository.ListAllQueues()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(queues))

--- a/pkg/remote/aws/sqs_queue_policy_enumerator.go
+++ b/pkg/remote/aws/sqs_queue_policy_enumerator.go
@@ -32,7 +32,7 @@ func (e *SQSQueuePolicyEnumerator) SupportedType() resource.ResourceType {
 func (e *SQSQueuePolicyEnumerator) Enumerate() ([]resource.Resource, error) {
 	queues, err := e.repository.ListAllQueues()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), aws.AwsSqsQueueResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsSqsQueueResourceType)
 	}
 
 	results := make([]resource.Resource, 0, len(queues))
@@ -50,7 +50,7 @@ func (e *SQSQueuePolicyEnumerator) Enumerate() ([]resource.Resource, error) {
 				}).Debugf("Ignoring queue that seems to be already deleted: %+v", err)
 				continue
 			}
-			return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+			return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 		}
 		if attributes.Attributes != nil {
 			attrs["policy"] = *attributes.Attributes[sqs.QueueAttributeNamePolicy]

--- a/pkg/remote/aws/vpc_default_security_group_enumerator.go
+++ b/pkg/remote/aws/vpc_default_security_group_enumerator.go
@@ -29,7 +29,7 @@ func (e *VPCDefaultSecurityGroupEnumerator) SupportedType() resource.ResourceTyp
 func (e *VPCDefaultSecurityGroupEnumerator) Enumerate() ([]resource.Resource, error) {
 	_, defaultSecurityGroups, err := e.repository.ListAllSecurityGroups()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, 0, len(defaultSecurityGroups))

--- a/pkg/remote/aws/vpc_enumerator.go
+++ b/pkg/remote/aws/vpc_enumerator.go
@@ -28,7 +28,7 @@ func (e *VPCEnumerator) SupportedType() resource.ResourceType {
 func (e *VPCEnumerator) Enumerate() ([]resource.Resource, error) {
 	VPCs, _, err := e.repo.ListAllVPCs()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, aws.AwsVpcResourceType)
+		return nil, remoteerror.NewResourceListingError(err, aws.AwsVpcResourceType)
 	}
 
 	results := make([]resource.Resource, 0, len(VPCs))

--- a/pkg/remote/aws/vpc_enumerator.go
+++ b/pkg/remote/aws/vpc_enumerator.go
@@ -28,7 +28,7 @@ func (e *VPCEnumerator) SupportedType() resource.ResourceType {
 func (e *VPCEnumerator) Enumerate() ([]resource.Resource, error) {
 	VPCs, _, err := e.repo.ListAllVPCs()
 	if err != nil {
-		return nil, remoteerror.NewResourceListingError(err, aws.AwsVpcResourceType)
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, 0, len(VPCs))

--- a/pkg/remote/aws/vpc_security_group_enumerator.go
+++ b/pkg/remote/aws/vpc_security_group_enumerator.go
@@ -29,7 +29,7 @@ func (e *VPCSecurityGroupEnumerator) SupportedType() resource.ResourceType {
 func (e *VPCSecurityGroupEnumerator) Enumerate() ([]resource.Resource, error) {
 	securityGroups, _, err := e.repository.ListAllSecurityGroups()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(e.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
 	results := make([]resource.Resource, 0, len(securityGroups))

--- a/pkg/remote/aws/vpc_security_group_rule_details_fetcher.go
+++ b/pkg/remote/aws/vpc_security_group_rule_details_fetcher.go
@@ -60,7 +60,7 @@ func (r *VPCSecurityGroupRuleDetailsFetcher) ReadDetails(res resource.Resource) 
 		Attributes: flatmap.Flatten(attrs),
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	deserializedRes, err := r.deserializer.DeserializeOne(aws.AwsSecurityGroupRuleResourceType, *ctyVal)
 	if err != nil {

--- a/pkg/remote/aws/vpc_security_group_rule_enumerator.go
+++ b/pkg/remote/aws/vpc_security_group_rule_enumerator.go
@@ -78,7 +78,7 @@ func (e *VPCSecurityGroupRuleEnumerator) SupportedType() resource.ResourceType {
 func (e *VPCSecurityGroupRuleEnumerator) Enumerate() ([]resource.Resource, error) {
 	securityGroups, defaultSecurityGroups, err := e.repository.ListAllSecurityGroups()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningErrorWithType(err, string(e.SupportedType()), resourceaws.AwsSecurityGroupResourceType)
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), resourceaws.AwsSecurityGroupResourceType)
 	}
 
 	secGroups := make([]*ec2.SecurityGroup, 0, len(securityGroups)+len(defaultSecurityGroups))

--- a/pkg/remote/common/details_fetcher.go
+++ b/pkg/remote/common/details_fetcher.go
@@ -31,7 +31,7 @@ func (f *GenericDetailsFetcher) ReadDetails(res resource.Resource) (resource.Res
 		ID: res.TerraformId(),
 	})
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType())
+		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())
 	}
 	if ctyVal.IsNull() {
 		logrus.WithFields(logrus.Fields{

--- a/pkg/remote/common/providers.go
+++ b/pkg/remote/common/providers.go
@@ -1,0 +1,6 @@
+package common
+
+const (
+	RemoteAWSTerraform    = "aws+tf"
+	RemoteGithubTerraform = "github+tf"
+)

--- a/pkg/remote/error/errors.go
+++ b/pkg/remote/error/errors.go
@@ -2,52 +2,64 @@ package error
 
 import "fmt"
 
-type SupplierError struct {
-	err          error
-	context      map[string]string
-	supplierType string
-}
-
-func NewSupplierError(err error, context map[string]string, supplierType string) *SupplierError {
-	context["SupplierType"] = supplierType
-	return &SupplierError{err: err, context: context, supplierType: supplierType}
-}
-
-func (b *SupplierError) Error() string {
-	return fmt.Sprintf("error in supplier %s: %s", b.supplierType, b.err)
-}
-
-func (b *SupplierError) RootCause() error {
-	return b.err
-}
-
-func (b *SupplierError) SupplierType() string {
-	return b.supplierType
-}
-
-func (b *SupplierError) Context() map[string]string {
-	return b.context
+type RemoteError interface {
+	ListedTypeError() string
 }
 
 type ResourceScanningError struct {
-	SupplierError
+	err             error
+	resourceType    string
+	resourceId      string
 	listedTypeError string
 }
 
-func NewResourceScanningErrorWithType(error error, supplierType string, listedTypeError string) *ResourceScanningError {
-	context := map[string]string{
-		"ListedTypeError": listedTypeError,
+func (b *ResourceScanningError) Error() string {
+	if b.resourceId != "" {
+		return fmt.Sprintf("error scanning resource %s: %s", b.Resource(), b.err)
 	}
+	return fmt.Sprintf("error scanning resource type %s: %s", b.Resource(), b.err)
+}
+
+func (b *ResourceScanningError) RootCause() error {
+	return b.err
+}
+
+func (b *ResourceScanningError) ResourceType() string {
+	return b.resourceType
+}
+
+func NewResourceScanningError(error error, resourceType string, resourceId string) *ResourceScanningError {
 	return &ResourceScanningError{
-		SupplierError:   *NewSupplierError(error, context, supplierType),
+		err:             error,
+		resourceType:    resourceType,
+		resourceId:      resourceId,
+		listedTypeError: resourceType,
+	}
+}
+
+func NewResourceListingError(error error, resourceType string) *ResourceScanningError {
+	return NewResourceListingErrorWithType(error, resourceType, resourceType)
+}
+
+func NewResourceListingErrorWithType(error error, resourceType, listedTypeError string) *ResourceScanningError {
+	return &ResourceScanningError{
+		err:             error,
+		resourceType:    resourceType,
 		listedTypeError: listedTypeError,
 	}
 }
 
-func NewResourceScanningError(error error, supplierType string) *ResourceScanningError {
-	return NewResourceScanningErrorWithType(error, supplierType, supplierType)
-}
-
 func (b *ResourceScanningError) ListedTypeError() string {
 	return b.listedTypeError
+}
+
+func (b *ResourceScanningError) Resource() string {
+	if b.resourceId != "" {
+		return fmt.Sprintf("%s.%s", b.resourceType, b.resourceId)
+	}
+	return b.resourceType
+}
+
+func (b *ResourceScanningError) String() string {
+	return fmt.Sprintf("%s.%s (%s)", b.resourceType, b.resourceId, b.listedTypeError)
 }

--- a/pkg/remote/github/github_branch_protection_enumerator.go
+++ b/pkg/remote/github/github_branch_protection_enumerator.go
@@ -25,7 +25,7 @@ func (g *GithubBranchProtectionEnumerator) SupportedType() resource.ResourceType
 func (g *GithubBranchProtectionEnumerator) Enumerate() ([]resource.Resource, error) {
 	ids, err := g.repository.ListBranchProtection()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(g.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(g.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(ids))

--- a/pkg/remote/github/github_membership_enumerator.go
+++ b/pkg/remote/github/github_membership_enumerator.go
@@ -25,7 +25,7 @@ func (g *GithubMembershipEnumerator) SupportedType() resource.ResourceType {
 func (g *GithubMembershipEnumerator) Enumerate() ([]resource.Resource, error) {
 	ids, err := g.Membership.ListMembership()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(g.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(g.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(ids))

--- a/pkg/remote/github/github_repository_enumerator.go
+++ b/pkg/remote/github/github_repository_enumerator.go
@@ -25,7 +25,7 @@ func (g *GithubRepositoryEnumerator) SupportedType() resource.ResourceType {
 func (g *GithubRepositoryEnumerator) Enumerate() ([]resource.Resource, error) {
 	ids, err := g.repository.ListRepositories()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(g.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(g.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(ids))

--- a/pkg/remote/github/github_team_enumerator.go
+++ b/pkg/remote/github/github_team_enumerator.go
@@ -27,7 +27,7 @@ func (g *GithubTeamEnumerator) SupportedType() resource.ResourceType {
 func (g *GithubTeamEnumerator) Enumerate() ([]resource.Resource, error) {
 	resourceList, err := g.repository.ListTeams()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(g.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(g.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(resourceList))

--- a/pkg/remote/github/github_team_membership_enumerator.go
+++ b/pkg/remote/github/github_team_membership_enumerator.go
@@ -25,7 +25,7 @@ func (g *GithubTeamMembershipEnumerator) SupportedType() resource.ResourceType {
 func (g *GithubTeamMembershipEnumerator) Enumerate() ([]resource.Resource, error) {
 	ids, err := g.repository.ListTeamMemberships()
 	if err != nil {
-		return nil, remoteerror.NewResourceScanningError(err, string(g.SupportedType()))
+		return nil, remoteerror.NewResourceListingError(err, string(g.SupportedType()))
 	}
 
 	results := make([]resource.Resource, len(ids))

--- a/pkg/remote/github/init.go
+++ b/pkg/remote/github/init.go
@@ -10,8 +10,6 @@ import (
 	"github.com/cloudskiff/driftctl/pkg/terraform"
 )
 
-const RemoteGithubTerraform = "github+tf"
-
 /**
  * Initialize remote (configure credentials, launch tf providers and start gRPC clients)
  * Required to use Scanner

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -12,8 +12,8 @@ import (
 )
 
 var supportedRemotes = []string{
-	aws.RemoteAWSTerraform,
-	github.RemoteGithubTerraform,
+	common.RemoteAWSTerraform,
+	common.RemoteGithubTerraform,
 }
 
 func IsSupported(remote string) bool {
@@ -33,9 +33,9 @@ func Activate(remote, version string, alerter *alerter.Alerter,
 	factory resource.ResourceFactory,
 	configDir string) error {
 	switch remote {
-	case aws.RemoteAWSTerraform:
+	case common.RemoteAWSTerraform:
 		return aws.Init(version, alerter, providerLibrary, remoteLibrary, progress, resourceSchemaRepository, factory, configDir)
-	case github.RemoteGithubTerraform:
+	case common.RemoteGithubTerraform:
 		return github.Init(version, alerter, providerLibrary, remoteLibrary, progress, resourceSchemaRepository, factory, configDir)
 	default:
 		return errors.Errorf("unsupported remote '%s'", remote)

--- a/pkg/remote/resource_enumeration_error_handler.go
+++ b/pkg/remote/resource_enumeration_error_handler.go
@@ -1,70 +1,14 @@
 package remote
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/cloudskiff/driftctl/pkg/alerter"
-	"github.com/cloudskiff/driftctl/pkg/remote/aws"
+	"github.com/cloudskiff/driftctl/pkg/remote/alerts"
+	"github.com/cloudskiff/driftctl/pkg/remote/common"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
-	"github.com/cloudskiff/driftctl/pkg/remote/github"
-	"github.com/sirupsen/logrus"
 )
-
-type ScanningPhase int
-
-const (
-	EnumerationPhase ScanningPhase = iota
-	DetailsFetchingPhase
-)
-
-type RemoteAccessDeniedAlert struct {
-	message       string
-	provider      string
-	scanningPhase ScanningPhase
-}
-
-func NewRemoteAccessDeniedAlert(provider, supplierType, listedTypeError string, scanningPhase ScanningPhase) *RemoteAccessDeniedAlert {
-	var message string
-	switch scanningPhase {
-	case EnumerationPhase:
-		message = fmt.Sprintf("Ignoring %s from drift calculation: Listing %s is forbidden.", supplierType, listedTypeError)
-	case DetailsFetchingPhase:
-		message = fmt.Sprintf("Ignoring %s from drift calculation: Reading details of %s is forbidden.", supplierType, listedTypeError)
-	default:
-		message = fmt.Sprintf("Ignoring %s from drift calculation: %s", supplierType, listedTypeError)
-	}
-	return &RemoteAccessDeniedAlert{message, provider, scanningPhase}
-}
-
-func (e *RemoteAccessDeniedAlert) Message() string {
-	return e.message
-}
-
-func (e *RemoteAccessDeniedAlert) ShouldIgnoreResource() bool {
-	return true
-}
-
-func (e *RemoteAccessDeniedAlert) GetProviderMessage() string {
-	var message string
-	if e.scanningPhase == DetailsFetchingPhase {
-		message = "It seems that we got access denied exceptions while reading details of resources.\n"
-	}
-	if e.scanningPhase == EnumerationPhase {
-		message = "It seems that we got access denied exceptions while listing resources.\n"
-	}
-
-	switch e.provider {
-	case github.RemoteGithubTerraform:
-		message += "Please be sure that your Github token has the right permissions, check the last up-to-date documentation there: https://docs.driftctl.com/github/policy"
-	case aws.RemoteAWSTerraform:
-		message += "The latest minimal read-only IAM policy for driftctl is always available here, please update yours: https://docs.driftctl.com/aws/policy"
-	default:
-		return ""
-	}
-	return message
-}
 
 func HandleResourceEnumerationError(err error, alerter alerter.AlerterInterface) error {
 	listError, ok := err.(*remoteerror.ResourceScanningError)
@@ -82,7 +26,7 @@ func HandleResourceEnumerationError(err error, alerter alerter.AlerterInterface)
 	// This handles access denied errors like the following:
 	// aws_s3_bucket_policy: AccessDenied: Error listing bucket policy <policy_name>
 	if strings.Contains(rootCause.Error(), "AccessDenied") {
-		sendEnumerationAlert(aws.RemoteAWSTerraform, alerter, listError)
+		alerts.SendEnumerationAlert(common.RemoteAWSTerraform, alerter, listError)
 		return nil
 	}
 
@@ -90,7 +34,7 @@ func HandleResourceEnumerationError(err error, alerter alerter.AlerterInterface)
 		rootCause.Error(),
 		"Your token has not been granted the required scopes to execute this query.",
 	) {
-		sendEnumerationAlert(github.RemoteGithubTerraform, alerter, listError)
+		alerts.SendEnumerationAlert(common.RemoteGithubTerraform, alerter, listError)
 		return nil
 	}
 
@@ -110,7 +54,7 @@ func HandleResourceDetailsFetchingError(err error, alerter alerter.AlerterInterf
 	if strings.HasPrefix(rootCause.Error(), "AccessDeniedException") ||
 		strings.Contains(rootCause.Error(), "AccessDenied") ||
 		strings.Contains(rootCause.Error(), "AuthorizationError") {
-		sendDetailsFetchingAlert(aws.RemoteAWSTerraform, alerter, listError)
+		alerts.SendDetailsFetchingAlert(common.RemoteAWSTerraform, alerter, listError)
 		return nil
 	}
 
@@ -119,25 +63,9 @@ func HandleResourceDetailsFetchingError(err error, alerter alerter.AlerterInterf
 
 func handleAWSError(alerter alerter.AlerterInterface, listError *remoteerror.ResourceScanningError, reqerr awserr.RequestFailure) error {
 	if reqerr.StatusCode() == 403 || (reqerr.StatusCode() == 400 && strings.Contains(reqerr.Code(), "AccessDenied")) {
-		sendEnumerationAlert(aws.RemoteAWSTerraform, alerter, listError)
+		alerts.SendEnumerationAlert(common.RemoteAWSTerraform, alerter, listError)
 		return nil
 	}
 
 	return reqerr
-}
-
-func sendRemoteAccessDeniedAlert(provider string, alerter alerter.AlerterInterface, listError *remoteerror.ResourceScanningError, p ScanningPhase) {
-	logrus.WithFields(logrus.Fields{
-		"supplier_type": listError.SupplierType(),
-		"listed_type":   listError.ListedTypeError(),
-	}).Debugf("Got an access denied error")
-	alerter.SendAlert(listError.SupplierType(), NewRemoteAccessDeniedAlert(provider, listError.SupplierType(), listError.ListedTypeError(), p))
-}
-
-func sendEnumerationAlert(provider string, alerter alerter.AlerterInterface, listError *remoteerror.ResourceScanningError) {
-	sendRemoteAccessDeniedAlert(provider, alerter, listError, EnumerationPhase)
-}
-
-func sendDetailsFetchingAlert(provider string, alerter alerter.AlerterInterface, listError *remoteerror.ResourceScanningError) {
-	sendRemoteAccessDeniedAlert(provider, alerter, listError, DetailsFetchingPhase)
 }

--- a/pkg/remote/resource_enumeration_error_handler_test.go
+++ b/pkg/remote/resource_enumeration_error_handler_test.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/cloudskiff/driftctl/pkg/remote/aws"
+	"github.com/cloudskiff/driftctl/pkg/remote/alerts"
+	"github.com/cloudskiff/driftctl/pkg/remote/common"
 	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
-	"github.com/cloudskiff/driftctl/pkg/remote/github"
 	resourcegithub "github.com/cloudskiff/driftctl/pkg/resource/github"
 
 	"github.com/stretchr/testify/assert"
@@ -27,25 +27,19 @@ func TestHandleAwsEnumerationErrors(t *testing.T) {
 	}{
 		{
 			name:       "Handled error 403",
-			err:        remoteerror.NewResourceScanningError(awserr.NewRequestFailure(awserr.New("", "", errors.New("")), 403, ""), resourceaws.AwsVpcResourceType),
-			wantAlerts: alerter.Alerts{"aws_vpc": []alerter.Alert{NewRemoteAccessDeniedAlert(aws.RemoteAWSTerraform, "aws_vpc", "aws_vpc", EnumerationPhase)}},
+			err:        remoteerror.NewResourceListingError(awserr.NewRequestFailure(awserr.New("", "", errors.New("")), 403, ""), resourceaws.AwsVpcResourceType),
+			wantAlerts: alerter.Alerts{"aws_vpc": []alerter.Alert{alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, "aws_vpc", "aws_vpc", alerts.EnumerationPhase)}},
 			wantErr:    false,
 		},
 		{
 			name:       "Handled error AccessDenied",
-			err:        remoteerror.NewResourceScanningError(awserr.NewRequestFailure(awserr.New("AccessDeniedException", "", errors.New("")), 403, ""), resourceaws.AwsDynamodbTableResourceType),
-			wantAlerts: alerter.Alerts{"aws_dynamodb_table": []alerter.Alert{NewRemoteAccessDeniedAlert(aws.RemoteAWSTerraform, "aws_dynamodb_table", "aws_dynamodb_table", EnumerationPhase)}},
+			err:        remoteerror.NewResourceListingError(awserr.NewRequestFailure(awserr.New("AccessDeniedException", "", errors.New("")), 403, ""), resourceaws.AwsDynamodbTableResourceType),
+			wantAlerts: alerter.Alerts{"aws_dynamodb_table": []alerter.Alert{alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, "aws_dynamodb_table", "aws_dynamodb_table", alerts.EnumerationPhase)}},
 			wantErr:    false,
 		},
 		{
 			name:       "Not Handled error code",
-			err:        remoteerror.NewResourceScanningError(awserr.NewRequestFailure(awserr.New("", "", errors.New("")), 404, ""), resourceaws.AwsVpcResourceType),
-			wantAlerts: map[string][]alerter.Alert{},
-			wantErr:    true,
-		},
-		{
-			name:       "Not Handled supplier error",
-			err:        remoteerror.NewSupplierError(awserr.NewRequestFailure(awserr.New("", "", errors.New("")), 403, ""), map[string]string{}, resourceaws.AwsVpcResourceType),
+			err:        remoteerror.NewResourceListingError(awserr.NewRequestFailure(awserr.New("", "", errors.New("")), 404, ""), resourceaws.AwsVpcResourceType),
 			wantAlerts: map[string][]alerter.Alert{},
 			wantErr:    true,
 		},
@@ -57,14 +51,20 @@ func TestHandleAwsEnumerationErrors(t *testing.T) {
 		},
 		{
 			name:       "Not Handled root error type",
-			err:        remoteerror.NewResourceScanningError(errors.New("error"), resourceaws.AwsVpcResourceType),
+			err:        remoteerror.NewResourceListingError(errors.New("error"), resourceaws.AwsVpcResourceType),
 			wantAlerts: map[string][]alerter.Alert{},
 			wantErr:    true,
 		},
 		{
 			name:       "Handle AccessDenied error",
-			err:        remoteerror.NewResourceScanningError(errors.New("an error occured: AccessDenied: 403"), resourceaws.AwsVpcResourceType),
-			wantAlerts: alerter.Alerts{"aws_vpc": []alerter.Alert{NewRemoteAccessDeniedAlert(aws.RemoteAWSTerraform, "aws_vpc", "aws_vpc", EnumerationPhase)}},
+			err:        remoteerror.NewResourceListingError(errors.New("an error occured: AccessDenied: 403"), resourceaws.AwsVpcResourceType),
+			wantAlerts: alerter.Alerts{"aws_vpc": []alerter.Alert{alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, "aws_vpc", "aws_vpc", alerts.EnumerationPhase)}},
+			wantErr:    false,
+		},
+		{
+			name:       "Access denied error on a single resource",
+			err:        remoteerror.NewResourceScanningError(errors.New("Error: AccessDenied: 403 ..."), resourceaws.AwsS3BucketResourceType, "my-bucket"),
+			wantAlerts: alerter.Alerts{"aws_s3_bucket.my-bucket": []alerter.Alert{alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, "aws_s3_bucket.my-bucket", "aws_s3_bucket", alerts.EnumerationPhase)}},
 			wantErr:    false,
 		},
 	}
@@ -91,19 +91,13 @@ func TestHandleGithubEnumerationErrors(t *testing.T) {
 	}{
 		{
 			name:       "Handled graphql error",
-			err:        remoteerror.NewResourceScanningError(errors.New("Your token has not been granted the required scopes to execute this query."), resourcegithub.GithubTeamResourceType),
-			wantAlerts: alerter.Alerts{"github_team": []alerter.Alert{NewRemoteAccessDeniedAlert(github.RemoteGithubTerraform, "github_team", "github_team", EnumerationPhase)}},
+			err:        remoteerror.NewResourceListingError(errors.New("Your token has not been granted the required scopes to execute this query."), resourcegithub.GithubTeamResourceType),
+			wantAlerts: alerter.Alerts{"github_team": []alerter.Alert{alerts.NewRemoteAccessDeniedAlert(common.RemoteGithubTerraform, "github_team", "github_team", alerts.EnumerationPhase)}},
 			wantErr:    false,
 		},
 		{
 			name:       "Not handled graphql error",
-			err:        remoteerror.NewResourceScanningError(errors.New("This is a not handler graphql error"), resourcegithub.GithubTeamResourceType),
-			wantAlerts: map[string][]alerter.Alert{},
-			wantErr:    true,
-		},
-		{
-			name:       "Not Handled supplier error",
-			err:        remoteerror.NewSupplierError(errors.New("An error from the supplier"), map[string]string{}, resourcegithub.GithubTeamResourceType),
+			err:        remoteerror.NewResourceListingError(errors.New("This is a not handler graphql error"), resourcegithub.GithubTeamResourceType),
 			wantAlerts: map[string][]alerter.Alert{},
 			wantErr:    true,
 		},
@@ -137,26 +131,32 @@ func TestHandleAwsDetailsFetchingErrors(t *testing.T) {
 	}{
 		{
 			name:       "Handle AccessDeniedException error",
-			err:        remoteerror.NewResourceScanningError(awserr.NewRequestFailure(awserr.New("AccessDeniedException", "test", errors.New("")), 403, ""), resourceaws.AwsVpcResourceType),
-			wantAlerts: alerter.Alerts{"aws_vpc": []alerter.Alert{NewRemoteAccessDeniedAlert(aws.RemoteAWSTerraform, "aws_vpc", "aws_vpc", DetailsFetchingPhase)}},
+			err:        remoteerror.NewResourceListingError(awserr.NewRequestFailure(awserr.New("AccessDeniedException", "test", errors.New("")), 403, ""), resourceaws.AwsVpcResourceType),
+			wantAlerts: alerter.Alerts{"aws_vpc": []alerter.Alert{alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, "aws_vpc", "aws_vpc", alerts.DetailsFetchingPhase)}},
 			wantErr:    false,
 		},
 		{
 			name:       "Handle AccessDenied error",
-			err:        remoteerror.NewResourceScanningError(awserr.NewRequestFailure(awserr.New("test", "error: AccessDenied", errors.New("")), 403, ""), resourceaws.AwsVpcResourceType),
-			wantAlerts: alerter.Alerts{"aws_vpc": []alerter.Alert{NewRemoteAccessDeniedAlert(aws.RemoteAWSTerraform, "aws_vpc", "aws_vpc", DetailsFetchingPhase)}},
+			err:        remoteerror.NewResourceListingError(awserr.NewRequestFailure(awserr.New("test", "error: AccessDenied", errors.New("")), 403, ""), resourceaws.AwsVpcResourceType),
+			wantAlerts: alerter.Alerts{"aws_vpc": []alerter.Alert{alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, "aws_vpc", "aws_vpc", alerts.DetailsFetchingPhase)}},
 			wantErr:    false,
 		},
 		{
 			name:       "Handle AuthorizationError error",
-			err:        remoteerror.NewResourceScanningError(awserr.NewRequestFailure(awserr.New("test", "error: AuthorizationError", errors.New("")), 403, ""), resourceaws.AwsVpcResourceType),
-			wantAlerts: alerter.Alerts{"aws_vpc": []alerter.Alert{NewRemoteAccessDeniedAlert(aws.RemoteAWSTerraform, "aws_vpc", "aws_vpc", DetailsFetchingPhase)}},
+			err:        remoteerror.NewResourceListingError(awserr.NewRequestFailure(awserr.New("test", "error: AuthorizationError", errors.New("")), 403, ""), resourceaws.AwsVpcResourceType),
+			wantAlerts: alerter.Alerts{"aws_vpc": []alerter.Alert{alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, "aws_vpc", "aws_vpc", alerts.DetailsFetchingPhase)}},
 			wantErr:    false,
 		},
 		{
 			name:       "Unhandled error",
-			err:        remoteerror.NewResourceScanningError(awserr.NewRequestFailure(awserr.New("test", "error: dummy error", errors.New("")), 403, ""), resourceaws.AwsVpcResourceType),
+			err:        remoteerror.NewResourceListingError(awserr.NewRequestFailure(awserr.New("test", "error: dummy error", errors.New("")), 403, ""), resourceaws.AwsVpcResourceType),
 			wantAlerts: alerter.Alerts{},
+			wantErr:    true,
+		},
+		{
+			name:       "Not Handled error type",
+			err:        errors.New("error"),
+			wantAlerts: map[string][]alerter.Alert{},
 			wantErr:    true,
 		},
 	}
@@ -186,18 +186,18 @@ func TestEnumerationAccessDeniedAlert_GetProviderMessage(t *testing.T) {
 		},
 		{
 			name:     "test for AWS",
-			provider: aws.RemoteAWSTerraform,
+			provider: common.RemoteAWSTerraform,
 			want:     "It seems that we got access denied exceptions while listing resources.\nThe latest minimal read-only IAM policy for driftctl is always available here, please update yours: https://docs.driftctl.com/aws/policy",
 		},
 		{
 			name:     "test for github",
-			provider: github.RemoteGithubTerraform,
+			provider: common.RemoteGithubTerraform,
 			want:     "It seems that we got access denied exceptions while listing resources.\nPlease be sure that your Github token has the right permissions, check the last up-to-date documentation there: https://docs.driftctl.com/github/policy",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := NewRemoteAccessDeniedAlert(tt.provider, "supplier_type", "listed_type_error", EnumerationPhase)
+			e := alerts.NewRemoteAccessDeniedAlert(tt.provider, "supplier_type", "listed_type_error", alerts.EnumerationPhase)
 			if got := e.GetProviderMessage(); got != tt.want {
 				t.Errorf("GetProviderMessage() = %v, want %v", got, tt.want)
 			}
@@ -218,21 +218,56 @@ func TestDetailsFetchingAccessDeniedAlert_GetProviderMessage(t *testing.T) {
 		},
 		{
 			name:     "test for AWS",
-			provider: aws.RemoteAWSTerraform,
+			provider: common.RemoteAWSTerraform,
 			want:     "It seems that we got access denied exceptions while reading details of resources.\nThe latest minimal read-only IAM policy for driftctl is always available here, please update yours: https://docs.driftctl.com/aws/policy",
 		},
 		{
 			name:     "test for github",
-			provider: github.RemoteGithubTerraform,
+			provider: common.RemoteGithubTerraform,
 			want:     "It seems that we got access denied exceptions while reading details of resources.\nPlease be sure that your Github token has the right permissions, check the last up-to-date documentation there: https://docs.driftctl.com/github/policy",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := NewRemoteAccessDeniedAlert(tt.provider, "supplier_type", "listed_type_error", DetailsFetchingPhase)
+			e := alerts.NewRemoteAccessDeniedAlert(tt.provider, "supplier_type", "listed_type_error", alerts.DetailsFetchingPhase)
 			if got := e.GetProviderMessage(); got != tt.want {
 				t.Errorf("GetProviderMessage() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestResourceScanningErrorMethods(t *testing.T) {
+
+	tests := []struct {
+		name                 string
+		err                  *remoteerror.ResourceScanningError
+		expectedError        string
+		expectedResourceType string
+	}{
+		{
+			name:                 "Handled error AccessDenied",
+			err:                  remoteerror.NewResourceListingError(awserr.NewRequestFailure(awserr.New("AccessDeniedException", "", errors.New("")), 403, ""), resourceaws.AwsDynamodbTableResourceType),
+			expectedError:        "error scanning resource type aws_dynamodb_table: AccessDeniedException: \n\tstatus code: 403, request id: \ncaused by: ",
+			expectedResourceType: resourceaws.AwsDynamodbTableResourceType,
+		},
+		{
+			name:                 "Handle AccessDenied error",
+			err:                  remoteerror.NewResourceListingError(errors.New("an error occured: AccessDenied: 403"), resourceaws.AwsVpcResourceType),
+			expectedError:        "error scanning resource type aws_vpc: an error occured: AccessDenied: 403",
+			expectedResourceType: resourceaws.AwsVpcResourceType,
+		},
+		{
+			name:                 "Access denied error on a single resource",
+			err:                  remoteerror.NewResourceScanningError(errors.New("Error: AccessDenied: 403 ..."), resourceaws.AwsS3BucketResourceType, "my-bucket"),
+			expectedError:        "error scanning resource aws_s3_bucket.my-bucket: Error: AccessDenied: 403 ...",
+			expectedResourceType: resourceaws.AwsS3BucketResourceType,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedError, tt.err.Error())
+			assert.Equal(t, tt.expectedResourceType, tt.err.ResourceType())
 		})
 	}
 }

--- a/pkg/remote/s3_scanner_test.go
+++ b/pkg/remote/s3_scanner_test.go
@@ -125,7 +125,7 @@ func TestS3Bucket(t *testing.T) {
 			remoteLibrary.AddEnumerator(aws.NewS3BucketEnumerator(repo, factory, tf.TerraformProviderConfig{
 				Name:         "test",
 				DefaultAlias: "eu-west-3",
-			}))
+			}, alerter))
 			remoteLibrary.AddDetailsFetcher(resourceaws.AwsS3BucketResourceType, aws.NewS3BucketDetailsFetcher(provider, deserializer))
 
 			testFilter := &filter.MockFilter{}
@@ -278,7 +278,7 @@ func TestS3BucketInventory(t *testing.T) {
 			remoteLibrary.AddEnumerator(aws.NewS3BucketInventoryEnumerator(repo, factory, tf.TerraformProviderConfig{
 				Name:         "test",
 				DefaultAlias: "eu-west-3",
-			}))
+			}, alerter))
 			remoteLibrary.AddDetailsFetcher(resourceaws.AwsS3BucketInventoryResourceType, aws.NewS3BucketInventoryDetailsFetcher(provider, deserializer))
 
 			testFilter := &filter.MockFilter{}
@@ -457,7 +457,7 @@ func TestS3BucketNotification(t *testing.T) {
 			remoteLibrary.AddEnumerator(aws.NewS3BucketNotificationEnumerator(repo, factory, tf.TerraformProviderConfig{
 				Name:         "test",
 				DefaultAlias: "eu-west-3",
-			}))
+			}, alerter))
 			remoteLibrary.AddDetailsFetcher(resourceaws.AwsS3BucketNotificationResourceType, aws.NewS3BucketNotificationDetailsFetcher(provider, deserializer))
 
 			testFilter := &filter.MockFilter{}
@@ -612,7 +612,7 @@ func TestS3BucketMetrics(t *testing.T) {
 			remoteLibrary.AddEnumerator(aws.NewS3BucketMetricsEnumerator(repo, factory, tf.TerraformProviderConfig{
 				Name:         "test",
 				DefaultAlias: "eu-west-3",
-			}))
+			}, alerter))
 			remoteLibrary.AddDetailsFetcher(resourceaws.AwsS3BucketMetricResourceType, aws.NewS3BucketMetricsDetailsFetcher(provider, deserializer))
 
 			testFilter := &filter.MockFilter{}
@@ -766,7 +766,7 @@ func TestS3BucketPolicy(t *testing.T) {
 			remoteLibrary.AddEnumerator(aws.NewS3BucketPolicyEnumerator(repo, factory, tf.TerraformProviderConfig{
 				Name:         "test",
 				DefaultAlias: "eu-west-3",
-			}))
+			}, alerter))
 			remoteLibrary.AddDetailsFetcher(resourceaws.AwsS3BucketPolicyResourceType, aws.NewS3BucketPolicyDetailsFetcher(provider, deserializer))
 
 			testFilter := &filter.MockFilter{}
@@ -923,7 +923,7 @@ func TestS3BucketAnalytic(t *testing.T) {
 			remoteLibrary.AddEnumerator(aws.NewS3BucketAnalyticEnumerator(repo, factory, tf.TerraformProviderConfig{
 				Name:         "test",
 				DefaultAlias: "eu-west-3",
-			}))
+			}, alerter))
 			remoteLibrary.AddDetailsFetcher(resourceaws.AwsS3BucketAnalyticsConfigurationResourceType, aws.NewS3BucketAnalyticDetailsFetcher(provider, deserializer))
 
 			testFilter := &filter.MockFilter{}

--- a/pkg/remote/sns_scanner_test.go
+++ b/pkg/remote/sns_scanner_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cloudskiff/driftctl/mocks"
 	"github.com/cloudskiff/driftctl/pkg/alerter"
 	"github.com/cloudskiff/driftctl/pkg/filter"
+	"github.com/cloudskiff/driftctl/pkg/remote/alerts"
 	"github.com/cloudskiff/driftctl/pkg/remote/aws"
 	"github.com/cloudskiff/driftctl/pkg/remote/cache"
 	"github.com/cloudskiff/driftctl/pkg/remote/common"
@@ -279,7 +280,7 @@ func TestSNSTopicSubscriptionScan(t *testing.T) {
 			},
 			alerts: map[string][]alerter.Alert{
 				resourceaws.AwsSnsTopicSubscriptionResourceType: {
-					NewRemoteAccessDeniedAlert("aws+tf", resourceaws.AwsSnsTopicSubscriptionResourceType, resourceaws.AwsSnsTopicSubscriptionResourceType, EnumerationPhase),
+					alerts.NewRemoteAccessDeniedAlert("aws+tf", resourceaws.AwsSnsTopicSubscriptionResourceType, resourceaws.AwsSnsTopicSubscriptionResourceType, alerts.EnumerationPhase),
 				},
 			},
 			err: nil,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #666 
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

When we encounter a Access Denied error on a particular resource, it creates an alert and ignore all resources of the same type. With this fix, we create an alert including the resource type & ID so we can only ignore that one.

### What changed

- Moved `RemoteAccessDeniedAlert` into new `pkg/remote/alerts` package
- Moved `RemoteAWSTerraform` & `RemoteGithubTerraform` into `pkg/remote/common/providers.go`
- Deleted `SupplierError` and moved its methods into `ResourceScanningError`
- Added fields `resourceType` & `resourceName` in `ResourceScanningError`
- Added few unit tests to avoid regression and increase coverage