### PR TITLE
Allow to customize read attributes in detail fetcher

### DIFF
--- a/pkg/remote/common/details_fetcher.go
+++ b/pkg/remote/common/details_fetcher.go
@@ -26,9 +26,15 @@ func NewGenericDetailsFetcher(resType resource.ResourceType, provider terraform.
 }
 
 func (f *GenericDetailsFetcher) ReadDetails(res resource.Resource) (resource.Resource, error) {
+	attributes := map[string]string{}
+	if res.Schema().ResolveReadAttributesFunc != nil {
+		abstractResource := res.(*resource.AbstractResource)
+		attributes = res.Schema().ResolveReadAttributesFunc(abstractResource)
+	}
 	ctyVal, err := f.reader.ReadResource(terraform.ReadResourceArgs{
-		Ty: f.resType,
-		ID: res.TerraformId(),
+		Ty:         f.resType,
+		ID:         res.TerraformId(),
+		Attributes: attributes,
 	})
 	if err != nil {
 		return nil, remoteerror.NewResourceScanningError(err, res.TerraformType(), res.TerraformId())

--- a/pkg/resource/schemas.go
+++ b/pkg/resource/schemas.go
@@ -20,6 +20,7 @@ type Schema struct {
 	Attributes                  map[string]AttributeSchema
 	NormalizeFunc               func(res *AbstractResource)
 	HumanReadableAttributesFunc func(res *AbstractResource) map[string]string
+	ResolveReadAttributesFunc   func(res *AbstractResource) map[string]string
 }
 
 func (s *Schema) IsComputedField(path []string) bool {
@@ -43,6 +44,7 @@ type SchemaRepositoryInterface interface {
 	UpdateSchema(typ string, schemasMutators map[string]func(attributeSchema *AttributeSchema))
 	SetNormalizeFunc(typ string, normalizeFunc func(res *AbstractResource))
 	SetHumanReadableAttributesFunc(typ string, humanReadableAttributesFunc func(res *AbstractResource) map[string]string)
+	SetResolveReadAttributesFunc(typ string, resolveReadAttributesFunc func(res *AbstractResource) map[string]string)
 }
 
 type SchemaRepository struct {
@@ -133,4 +135,13 @@ func (r *SchemaRepository) SetHumanReadableAttributesFunc(typ string, humanReada
 		return
 	}
 	(*metadata).HumanReadableAttributesFunc = humanReadableAttributesFunc
+}
+
+func (r *SchemaRepository) SetResolveReadAttributesFunc(typ string, resolveReadAttributesFunc func(res *AbstractResource) map[string]string) {
+	metadata, exist := r.GetSchema(typ)
+	if !exist {
+		logrus.WithFields(logrus.Fields{"type": typ}).Warning("Unable to add read resource attributes, no schema found")
+		return
+	}
+	(*metadata).ResolveReadAttributesFunc = resolveReadAttributesFunc
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | contribution doc

## Description

With this new approach we can use remove all boilerplate of custom details fetcher bu setting the resolve func in the schema.
For example for a new resource we'll end with the code below instead of creating a custom detail fetcher:

```go
package gcp

import "github.com/cloudskiff/driftctl/pkg/resource"

const GoogleStorageBucketResourceType = "google_storage_bucket"

func initGoogleStorageBucketMetadata(resourceSchemaRepository resource.SchemaRepositoryInterface) {
	resourceSchemaRepository.SetResolveReadAttributesFunc(GoogleStorageBucketResourceType, func(res *resource.AbstractResource) map[string]string {
		return map[string]string{
			"name": res.TerraformId(),
		}
	})
}

```

