### PR TITLE
Add schema creation helper

### DIFF
--- a/test/schemas/schemas_test.go
+++ b/test/schemas/schemas_test.go
@@ -1,0 +1,36 @@
+package schemas
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cloudskiff/driftctl/pkg/terraform"
+	terraformtest "github.com/cloudskiff/driftctl/test/terraform"
+)
+
+// You can use this test function to create a schema file for a given provider in a given version
+// You may want to update part of this code to change provider and version to generate desired schema
+// To use this test you should run this command from the repository root
+// DCTL_UPDATE_TEST_SCHEMA=true go test ./test/schemas
+// You may need to setup proper environment variable to make the terraform provider work
+// DCTL_UPDATE_TEST_SCHEMA=true AWS_PROFILE=myprofile go test ./test/schemas
+func TestCreateNewSchema(t *testing.T) {
+
+	if os.Getenv("DCTL_UPDATE_TEST_SCHEMA") != "true" {
+		t.SkipNow()
+	}
+
+	providerLibrary := terraform.NewProviderLibrary()
+
+	// Replace this with provider you want to create schema
+	realProvider, _ := terraformtest.InitTestAwsProvider(providerLibrary, "3.19.0")
+
+	err := realProvider.Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = writeTestSchema(realProvider.Schema(), realProvider.Name(), realProvider.Version())
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/schemas/shemas.go
+++ b/test/schemas/shemas.go
@@ -3,11 +3,28 @@ package schemas
 import (
 	gojson "encoding/json"
 	"io/ioutil"
+	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 
 	"github.com/hashicorp/terraform/providers"
 )
+
+func writeTestSchema(schema map[string]providers.Schema, provider, version string) error {
+	_, relativeFilePath, _, _ := runtime.Caller(0)
+	fileName := path.Join(path.Dir(relativeFilePath), provider, version, "schema.json")
+	content, _ := gojson.Marshal(schema)
+	err := os.MkdirAll(filepath.Dir(fileName), os.ModePerm)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(fileName, content, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
 func ReadTestSchema(provider, version string) (map[string]providers.Schema, error) {
 	_, filename, _, _ := runtime.Caller(0)

--- a/test/terraform/fake_terraform_provider.go
+++ b/test/terraform/fake_terraform_provider.go
@@ -29,11 +29,6 @@ func (p *FakeTerraformProvider) ShouldUpdate() {
 }
 
 func (p *FakeTerraformProvider) Schema() map[string]providers.Schema {
-	if p.shouldUpdate {
-		schema := p.realProvider.Schema()
-		p.writeSchema(schema)
-		return schema
-	}
 	return p.readSchema()
 }
 
@@ -55,19 +50,8 @@ func (p *FakeTerraformProvider) ReadResource(args terraform.ReadResourceArgs) (*
 	return p.readResource(args)
 }
 
-func (p *FakeTerraformProvider) writeSchema(schema map[string]providers.Schema) {
-	marshal, err := gojson.Marshal(schema)
-	if err != nil {
-		panic(err)
-	}
-	err = test.WriteTestFile(fmt.Sprintf("schemas/%s/%s.json", p.realProvider.Name(), p.realProvider.Version()), marshal)
-	if err != nil {
-		panic(err)
-	}
-}
-
 func (p *FakeTerraformProvider) readSchema() map[string]providers.Schema {
-	content, err := test.ReadTestFile(fmt.Sprintf("schemas/%s/%s.json", p.realProvider.Name(), p.realProvider.Version()))
+	content, err := test.ReadTestFile(fmt.Sprintf("../schemas/%s/%s/schema.json", p.realProvider.Name(), p.realProvider.Version()))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | contrib doc

## Description

This add an helper to generate fake schemas for new provider or new provider version.
It also redirect schemas from fake terraform provider to theses ones. 
It mean that Schema handling is manual and not handled by the `-update` flag in tests.

Ping @moadibfr contribution doc need to be updated according