### PR TITLE
Fix build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,7 +18,6 @@ goreleaser check
 
 FLAGS=""
 FLAGS+="--rm-dist "
-FLAGS+="--snapshot "
 FLAGS+="--parallelism 2 "
 
 CMD="release"
@@ -34,6 +33,7 @@ if [ "$CI" != true ] && [ "$CMD" == "release" ]; then
     FLAGS+="--skip-announce "
     FLAGS+="--skip-publish "
     FLAGS+="--skip-sign "
+    FLAGS+="--snapshot "
 fi
 
 CMD="goreleaser ${CMD} ${FLAGS}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -33,6 +33,9 @@ if [ "$CI" != true ] && [ "$CMD" == "release" ]; then
     FLAGS+="--skip-announce "
     FLAGS+="--skip-publish "
     FLAGS+="--skip-sign "
+fi
+
+if [ "$CI" != true ]; then
     FLAGS+="--snapshot "
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,7 +30,7 @@ fi
 
 # Only CI system should publish artifacts
 # We may not want to sign artifacts in dev environments
-if [ "$CI" == true ] && [ "$CMD" == "release" ]; then
+if [ "$CI" != true ] && [ "$CMD" == "release" ]; then
     FLAGS+="--skip-announce "
     FLAGS+="--skip-publish "
     FLAGS+="--skip-sign "


### PR DESCRIPTION
Reverts cloudskiff/driftctl#911

The snapshot flag prevents CI from publishing artifacts to GitHub.