### PR TITLE
Fix JSON diff formatting in HTML output

### DIFF
--- a/pkg/cmd/scan/output/console.go
+++ b/pkg/cmd/scan/output/console.go
@@ -98,7 +98,7 @@ func (c *Console) Write(analysis *analyser.Analysis) error {
 					if change.Type == diff.UPDATE {
 						if change.JsonString {
 							prefix := "           "
-							fmt.Printf("%s%s\n%s%s\n", whiteSpace, pref, prefix, jsonDiff(change.From, change.To, prefix))
+							fmt.Printf("%s%s\n%s%s\n", whiteSpace, pref, prefix, jsonDiff(change.From, change.To, isatty.IsTerminal(os.Stdout.Fd())))
 							continue
 						}
 					}
@@ -207,22 +207,22 @@ func groupByType(resources []*resource.Resource) (map[string][]*resource.Resourc
 	return result, keys
 }
 
-func jsonDiff(a, b interface{}, prefix string) string {
+func jsonDiff(a, b interface{}, coloring bool) string {
 	aStr := fmt.Sprintf("%s", a)
 	bStr := fmt.Sprintf("%s", b)
 	d := gojsondiff.New()
 	var aJson map[string]interface{}
 	_ = json.Unmarshal([]byte(aStr), &aJson)
-	diff, _ := d.Compare([]byte(aStr), []byte(bStr))
+	result, _ := d.Compare([]byte(aStr), []byte(bStr))
 	f := formatter.NewAsciiFormatter(aJson, formatter.AsciiFormatterConfig{
-		Coloring: isatty.IsTerminal(os.Stdout.Fd()),
+		Coloring: coloring,
 	})
 	// Set foreground green color for added lines and red color for deleted lines
 	formatter.AsciiStyles = map[string]string{
 		"+": "32",
 		"-": "31",
 	}
-	diffStr, _ := f.Format(diff)
+	diffStr, _ := f.Format(result)
 
 	return diffStr
 }

--- a/pkg/cmd/scan/output/html.go
+++ b/pkg/cmd/scan/output/html.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -123,7 +124,7 @@ func (c *HTML) Write(analysis *analyser.Analysis) error {
 				case diff.UPDATE:
 					prefix := fmt.Sprintf("%s %s:", "~", path)
 					if change.JsonString {
-						_, _ = fmt.Fprintf(&buf, "%s%s<br>%s%s<br>", whiteSpace, prefix, whiteSpace, jsonDiff(change.From, change.To, whiteSpace))
+						_, _ = fmt.Fprintf(&buf, "%s%s<br>%s%s<br>", whiteSpace, prefix, whiteSpace, jsonDiffHTML(change.From, change.To))
 						continue
 					}
 					_, _ = fmt.Fprintf(&buf, "%s%s <span class=\"code-box-line-delete\">%s</span> => <span class=\"code-box-line-create\">%s</span>", whiteSpace, prefix, htmlPrettify(change.From), htmlPrettify(change.To))
@@ -193,4 +194,16 @@ func htmlPrettify(resource interface{}) string {
 		return "null"
 	}
 	return awsutil.Prettify(resource)
+}
+
+func jsonDiffHTML(a, b interface{}) string {
+	diffStr := jsonDiff(a, b, false)
+
+	re := regexp.MustCompile(`(?m)^(?P<value>(\-)(.*))$`)
+	diffStr = re.ReplaceAllString(diffStr, `<span class="code-box-line-delete">$value</span>`)
+
+	re = regexp.MustCompile(`(?m)^(?P<value>(\+)(.*))$`)
+	diffStr = re.ReplaceAllString(diffStr, `<span class="code-box-line-create">$value</span>`)
+
+	return diffStr
 }

--- a/pkg/cmd/scan/output/html_test.go
+++ b/pkg/cmd/scan/output/html_test.go
@@ -127,11 +127,12 @@ func TestHTML_Write(t *testing.T) {
 							},
 						},
 						{
+							JsonString: true,
 							Change: diff.Change{
 								Type: diff.UPDATE,
-								Path: []string{"Policies", "0"},
-								From: resource.Resource{},
-								To:   resource.Resource{Id: "093cd6ba-cf6d-4800-b252-6a50ca8903cd", Type: "aws_iam_policy"},
+								Path: []string{"policy"},
+								From: `{"Statement":[{"Action":["s3:GetObjectVersion"],"Effect":"Allow","Principal":"*","Resource":"arn:aws:s3:::tmxxrn.foobar.driftctl-test.com/*","Sid":"PublicRead"}],"Version":"2012-10-17"}`,
+								To:   `{"Statement":[{"Action":["*"],"Effect":"Deny","Principal":"*","Resource":"arn:aws:s3:::tmxxrn.foobar.driftctl-test.com/b/*","Sid":"PublicReadWrite"},{"Effect":"Deny","Sid":"PublicReadWrite"}],"Version":"2021-10-17","Test":[]}`,
 							},
 						},
 						{

--- a/pkg/cmd/scan/output/testdata/output.html
+++ b/pkg/cmd/scan/output/testdata/output.html
@@ -518,15 +518,37 @@ input[type="search"], select {
                                     <span role="cell" data-type="resource-type">aws_diff_resource</span>
                                 </div>
                                 <pre class="code-box">
-                                    <code class="code-box-line">&emsp;- path.to.fields.[0]: <span class="code-box-line-delete">"value"</span><br>&emsp;~ path.to.fields.[1]: <span class="code-box-line-delete">12</span> => <span class="code-box-line-create">"12"</span><br>&emsp;- group_ids: <span class="code-box-line-delete">["a071314398026"]</span><br>&emsp;~ Policies.[0]: <span class="code-box-line-delete">{
-  Id: "",
-  Type: "",
-  Source: <nil>
-}</span> => <span class="code-box-line-create">{
-  Id: "093cd6ba-cf6d-4800-b252-6a50ca8903cd",
-  Type: "aws_iam_policy",
-  Source: <nil>
-}</span><br>&emsp;+ Tags.[0].Name: <span class="code-box-line-create">"test"</span><br>&emsp;~ InstanceInitiatedShutdownBehavior: <span class="code-box-line-delete">""</span> => <span class="code-box-line-create">null</span><br></code>
+                                    <code class="code-box-line">&emsp;- path.to.fields.[0]: <span class="code-box-line-delete">"value"</span><br>&emsp;~ path.to.fields.[1]: <span class="code-box-line-delete">12</span> => <span class="code-box-line-create">"12"</span><br>&emsp;- group_ids: <span class="code-box-line-delete">["a071314398026"]</span><br>&emsp;~ policy:<br>&emsp; {
+   "Statement": [
+     {
+       "Action": [
+<span class="code-box-line-delete">-        "s3:GetObjectVersion"</span>
+<span class="code-box-line-create">+        "*"</span>
+       ],
+<span class="code-box-line-delete">-      "Effect": "Allow",</span>
+<span class="code-box-line-create">+      "Effect": "Deny",</span>
+       "Principal": "*",
+<span class="code-box-line-delete">-      "Resource": "arn:aws:s3:::tmxxrn.foobar.driftctl-test.com/*",</span>
+<span class="code-box-line-create">+      "Resource": "arn:aws:s3:::tmxxrn.foobar.driftctl-test.com/b/*",</span>
+<span class="code-box-line-delete">-      "Sid": "PublicRead"</span>
+<span class="code-box-line-create">+      "Sid": "PublicReadWrite"</span>
+     }
+<span class="code-box-line-create">+    {</span>
+<span class="code-box-line-create">+      "Action": [</span>
+<span class="code-box-line-create">+        "*"</span>
+<span class="code-box-line-create">+      ],</span>
+<span class="code-box-line-create">+      "Effect": "Deny",</span>
+<span class="code-box-line-create">+      "Principal": "*",</span>
+<span class="code-box-line-create">+      "Resource": "arn:aws:s3:::tmxxrn.foobar.driftctl-test.com/b/*",</span>
+<span class="code-box-line-create">+      "Sid": "PublicReadWrite"</span>
+<span class="code-box-line-create">+    }</span>
+   ],
+<span class="code-box-line-delete">-  "Version": "2012-10-17"</span>
+<span class="code-box-line-create">+  "Version": "2021-10-17"</span>
+<span class="code-box-line-create">+  "Test": [</span>
+<span class="code-box-line-create">+  ]</span>
+ }
+<br>&emsp;+ Tags.[0].Name: <span class="code-box-line-create">"test"</span><br>&emsp;~ InstanceInitiatedShutdownBehavior: <span class="code-box-line-delete">""</span> => <span class="code-box-line-create">null</span><br></code>
                                 </pre>
                             </div>
                             


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #921
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

When we have a diff on a JSON field, the result in the HTML report is ugly. The reason is we use the same formatting function than console output. We should create a custom formatting function.

This PR disables TTY coloring and add missing html tags to the JSON diff.

## Example

![image](https://user-images.githubusercontent.com/16480203/129738075-d769e6c6-1bc9-4e43-8ee7-7a6425889942.png)