### PR TITLE
Revert "feat: add iac source to drift in console output"

### DIFF
--- a/pkg/cmd/scan/output/console.go
+++ b/pkg/cmd/scan/output/console.go
@@ -35,27 +35,13 @@ func NewConsole() *Console {
 
 func (c *Console) Write(analysis *analyser.Analysis) error {
 	if analysis.Summary().TotalDeleted > 0 {
-		groupedBySource := make(map[string][]*resource.Resource)
-
-		for _, deletedResource := range analysis.Deleted() {
-			key := deletedResource.Source.Source()
-
-			if _, exist := groupedBySource[key]; !exist {
-				groupedBySource[key] = []*resource.Resource{deletedResource}
-				continue
-			}
-
-			groupedBySource[key] = append(groupedBySource[key], deletedResource)
-		}
-
 		fmt.Println("Found missing resources:")
-
-		for source, deletedResources := range groupedBySource {
-			fmt.Print(color.BlueString("  From %s\n", source))
-			for _, deletedResource := range deletedResources {
-				humanString := fmt.Sprintf("    - %s (%s)", deletedResource.ResourceId(), deletedResource.SourceString())
-
-				if humanAttrs := formatResourceAttributes(deletedResource); humanAttrs != "" {
+		deletedByType, keys := groupByType(analysis.Deleted())
+		for _, ty := range keys {
+			fmt.Printf("  %s:\n", ty)
+			for _, res := range deletedByType[ty] {
+				humanString := fmt.Sprintf("    - %s", res.ResourceId())
+				if humanAttrs := formatResourceAttributes(res); humanAttrs != "" {
 					humanString += fmt.Sprintf("\n        %s", humanAttrs)
 				}
 				fmt.Println(humanString)

--- a/pkg/cmd/scan/output/console_test.go
+++ b/pkg/cmd/scan/output/console_test.go
@@ -36,20 +36,10 @@ func TestConsole_Write(t *testing.T) {
 					&resource.Resource{
 						Id:   "test-id-1",
 						Type: "aws_test_resource",
-						Source: &resource.TerraformStateSource{
-							State:  "tfstate://test_state.tfstate",
-							Module: "module",
-							Name:   "name",
-						},
 					},
 					&resource.Resource{
 						Id:   "test-id-2",
 						Type: "aws_test_resource",
-						Source: &resource.TerraformStateSource{
-							State:  "tfstate://test_state.tfstate",
-							Module: "module",
-							Name:   "name",
-						},
 					},
 				)
 				a.AddUnmanaged(

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -30,19 +30,9 @@ func fakeAnalysis() *analyser.Analysis {
 		&resource.Resource{
 			Id:   "deleted-id-1",
 			Type: "aws_deleted_resource",
-			Source: &resource.TerraformStateSource{
-				State:  "tfstate://delete_state.tfstate",
-				Module: "module",
-				Name:   "name",
-			},
 		}, &resource.Resource{
 			Id:   "deleted-id-2",
 			Type: "aws_deleted_resource",
-			Source: &resource.TerraformStateSource{
-				State:  "tfstate://delete_state.tfstate",
-				Module: "module",
-				Name:   "name",
-			},
 		},
 	)
 	a.AddManaged(
@@ -189,11 +179,6 @@ func fakeAnalysisWithoutAttrs() *analyser.Analysis {
 			Id:    "dfjkgnbsgj",
 			Type:  "FakeResourceStringer",
 			Attrs: &resource.Attributes{},
-			Source: &resource.TerraformStateSource{
-				State:  "tfstate://state.tfstate",
-				Module: "module",
-				Name:   "name",
-			},
 		},
 	)
 	a.AddManaged(
@@ -229,11 +214,6 @@ func fakeAnalysisWithStringerResources() *analyser.Analysis {
 			Sch:  schema,
 			Attrs: &resource.Attributes{
 				"name": "deleted resource",
-			},
-			Source: &resource.TerraformStateSource{
-				State:  "tfstate://state.tfstate",
-				Module: "module",
-				Name:   "name",
 			},
 		},
 	)

--- a/pkg/cmd/scan/output/testdata/output.json
+++ b/pkg/cmd/scan/output/testdata/output.json
@@ -29,21 +29,11 @@
 	"missing": [
 		{
 			"id": "deleted-id-1",
-			"type": "aws_deleted_resource",
-			"source": {
-				"source": "tfstate://delete_state.tfstate",
-				"namespace": "module",
-				"internal_name": "name"
-			}
+			"type": "aws_deleted_resource"
 		},
 		{
 			"id": "deleted-id-2",
-			"type": "aws_deleted_resource",
-			"source": {
-				"source": "tfstate://delete_state.tfstate",
-				"namespace": "module",
-				"internal_name": "name"
-			}
+			"type": "aws_deleted_resource"
 		}
 	],
 	"differences": [

--- a/pkg/cmd/scan/output/testdata/output.txt
+++ b/pkg/cmd/scan/output/testdata/output.txt
@@ -1,10 +1,10 @@
 Found missing resources:
-  From tfstate://delete_state.tfstate
-    - deleted-id-1 (module.aws_deleted_resource.name)
-    - deleted-id-2 (module.aws_deleted_resource.name)
-  From tfstate://test_state.tfstate
-    - test-id-1 (module.aws_test_resource.name)
-    - test-id-2 (module.aws_test_resource.name)
+  aws_deleted_resource:
+    - deleted-id-1
+    - deleted-id-2
+  aws_test_resource:
+    - test-id-1
+    - test-id-2
 Found resources not covered by IaC:
   aws_resource:
     - test-id-2

--- a/pkg/cmd/scan/output/testdata/output_empty_attributes.txt
+++ b/pkg/cmd/scan/output/testdata/output_empty_attributes.txt
@@ -1,6 +1,6 @@
 Found missing resources:
-  From tfstate://state.tfstate
-    - dfjkgnbsgj (module.FakeResourceStringer.name)
+  FakeResourceStringer:
+    - dfjkgnbsgj
 Found resources not covered by IaC:
   FakeResourceStringer:
     - duysgkfdjfdgfhd

--- a/pkg/cmd/scan/output/testdata/output_stringer_resources.txt
+++ b/pkg/cmd/scan/output/testdata/output_stringer_resources.txt
@@ -1,6 +1,6 @@
 Found missing resources:
-  From tfstate://state.tfstate
-    - dfjkgnbsgj (module.FakeResourceStringer.name)
+  FakeResourceStringer:
+    - dfjkgnbsgj
         Name: deleted resource
 Found resources not covered by IaC:
   FakeResourceStringer:


### PR DESCRIPTION
Reverts cloudskiff/driftctl#934


## Bug

`deletedResource.Source` == nil if it is deleted.

## Steps to reproduce:
- create ec2 through terraform
- delete ec2 through the console
- run it and `deletedResource.Source` is `nil`

## Steps to Resolve
- resource.Source needs to be declared even when it is a deleted resource


## relates to #901 