### PR TITLE
Remove options in output config

### DIFF
--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -367,8 +367,10 @@ func parseOutputFlag(out string) (*output.OutputConfig, error) {
 		)
 	}
 
-	o := schemeOpts[0]
-	if !output.IsSupported(o) {
+	o := &output.OutputConfig{
+		Key: schemeOpts[0],
+	}
+	if !output.IsSupported(o.Key) {
 		return nil, errors.Wrapf(
 			cmderrors.NewUsageError(
 				fmt.Sprintf(
@@ -377,14 +379,13 @@ func parseOutputFlag(out string) (*output.OutputConfig, error) {
 				),
 			),
 			"Unsupported output '%s'",
-			o,
+			o.Key,
 		)
 	}
 
 	opts := schemeOpts[1:]
-	options := map[string]string{}
 
-	switch o {
+	switch o.Key {
 	case output.JSONOutputType:
 		if len(opts) != 1 || opts[0] == "" {
 			return nil, errors.Wrapf(
@@ -398,7 +399,7 @@ func parseOutputFlag(out string) (*output.OutputConfig, error) {
 				out,
 			)
 		}
-		options["path"] = opts[0]
+		o.Path = opts[0]
 	case output.HTMLOutputType:
 		if len(opts) != 1 || opts[0] == "" {
 			return nil, errors.Wrapf(
@@ -412,7 +413,7 @@ func parseOutputFlag(out string) (*output.OutputConfig, error) {
 				out,
 			)
 		}
-		options["path"] = opts[0]
+		o.Path = opts[0]
 	case output.PlanOutputType:
 		if len(opts) != 1 || opts[0] == "" {
 			return nil, errors.Wrapf(
@@ -426,13 +427,10 @@ func parseOutputFlag(out string) (*output.OutputConfig, error) {
 				out,
 			)
 		}
-		options["path"] = opts[0]
+		o.Path = opts[0]
 	}
 
-	return &output.OutputConfig{
-		Key:     o,
-		Options: options,
-	}, nil
+	return o, nil
 }
 
 func validateTfProviderVersionString(version string) error {

--- a/pkg/cmd/scan/output/config.go
+++ b/pkg/cmd/scan/output/config.go
@@ -1,6 +1,6 @@
 package output
 
 type OutputConfig struct {
-	Key     string
-	Options map[string]string
+	Key  string
+	Path string
 }

--- a/pkg/cmd/scan/output/output.go
+++ b/pkg/cmd/scan/output/output.go
@@ -56,11 +56,11 @@ func GetOutput(config OutputConfig, quiet bool) Output {
 
 	switch config.Key {
 	case JSONOutputType:
-		return NewJSON(config.Options["path"])
+		return NewJSON(config.Path)
 	case HTMLOutputType:
-		return NewHTML(config.Options["path"])
+		return NewHTML(config.Path)
 	case PlanOutputType:
-		return NewPlan(config.Options["path"])
+		return NewPlan(config.Path)
 	case ConsoleOutputType:
 		fallthrough
 	default:
@@ -75,12 +75,12 @@ func GetPrinter(config OutputConfig, quiet bool) output.Printer {
 
 	switch config.Key {
 	case JSONOutputType:
-		if isStdOut(config.Options["path"]) {
+		if isStdOut(config.Path) {
 			return &output.VoidPrinter{}
 		}
 		fallthrough
 	case PlanOutputType:
-		if isStdOut(config.Options["path"]) {
+		if isStdOut(config.Path) {
 			return &output.VoidPrinter{}
 		}
 		fallthrough

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -500,10 +500,8 @@ func TestGetPrinter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := GetPrinter(OutputConfig{
-				Key: tt.key,
-				Options: map[string]string{
-					"path": tt.path,
-				},
+				Key:  tt.key,
+				Path: tt.path,
 			}, tt.quiet); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetPrinter() = %v, want %v", got, tt.want)
 			}

--- a/pkg/cmd/scan_test.go
+++ b/pkg/cmd/scan_test.go
@@ -218,8 +218,7 @@ func Test_parseOutputFlag(t *testing.T) {
 				out: "console://",
 			},
 			want: &output.OutputConfig{
-				Key:     "console",
-				Options: map[string]string{},
+				Key: "console",
 			},
 			err: nil,
 		},
@@ -229,10 +228,8 @@ func Test_parseOutputFlag(t *testing.T) {
 				out: "json:///tmp/foobar.json",
 			},
 			want: &output.OutputConfig{
-				Key: "json",
-				Options: map[string]string{
-					"path": "/tmp/foobar.json",
-				},
+				Key:  "json",
+				Path: "/tmp/foobar.json",
 			},
 			err: nil,
 		},
@@ -250,10 +247,8 @@ func Test_parseOutputFlag(t *testing.T) {
 				out: "plan:///tmp/foobar.json",
 			},
 			want: &output.OutputConfig{
-				Key: "plan",
-				Options: map[string]string{
-					"path": "/tmp/foobar.json",
-				},
+				Key:  "plan",
+				Path: "/tmp/foobar.json",
 			},
 			err: nil,
 		},


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Following a discussion with @eliecharra (https://github.com/cloudskiff/driftctl/pull/865#discussion_r698532633), the options field in the OutputConfig object is not really useful as we only use it for the path and it lacks of type safety. In this PR I removed it in favor of a dedicated `Path` field.