### PR TITLE
Read provider version from .terraform.lock.hcl lock file when possible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/armstorage v0.2.0
-	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.4
 	github.com/Azure/go-autorest/autorest v0.11.3
 	github.com/aws/aws-sdk-go v1.38.68
 	github.com/bmatcuk/doublestar/v4 v4.0.1
@@ -19,6 +18,7 @@ require (
 	github.com/hashicorp/go-hclog v0.9.2
 	github.com/hashicorp/go-plugin v1.3.0
 	github.com/hashicorp/go-version v1.3.0
+	github.com/hashicorp/hcl/v2 v2.7.2
 	github.com/hashicorp/terraform v0.14.0
 	github.com/hashicorp/terraform-exec v0.14.0
 	github.com/jarcoal/httpmock v1.0.6
@@ -40,6 +40,7 @@ require (
 	github.com/yudai/gojsondiff v1.0.0
 	github.com/zclconf/go-cty v1.8.4
 	go.uber.org/atomic v1.4.0
+	golang.org/x/net v0.0.0-20210913180222-943fd674d43e // indirect
 	golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/api v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,6 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0 h1:v9p9TfTbf7AwNb5NYQt7hI4
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
 github.com/Azure/azure-sdk-for-go/sdk/storage/armstorage v0.2.0 h1:LOq4ZG6rMgTAZTyGbYHyxL1EVfZdngpUDRY/KvBToMs=
 github.com/Azure/azure-sdk-for-go/sdk/storage/armstorage v0.2.0/go.mod h1:mIFJgQ93RCQPBsN2jBDzDOfwJpLacGwXIxmirNQMiq4=
-github.com/Azure/azure-sdk-for-go/sdk/to v0.1.4 h1:3w4gk+uYOwplGhID1fDP305/8bI5Aug3URoC1V493KU=
-github.com/Azure/azure-sdk-for-go/sdk/to v0.1.4/go.mod h1:UL/d4lvWAzSJUuX+19uKdN0ktyjoOyQhgY+HWNgtIYI=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.3 h1:fyYnmYujkIXUgv88D9/Wo2ybE4Zwd/TmQd5sSI5u2Ws=
@@ -897,8 +895,9 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210610132358-84b48f89b13b h1:k+E048sYJHyVnsr1GDrRZWQ32D2C7lWs9JRc0bel53A=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210913180222-943fd674d43e h1:+b/22bPvDYt4NPDcy4xAGCmON713ONAWFeY3Z7I3tR8=
+golang.org/x/net v0.0.0-20210913180222-943fd674d43e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/pkg/cmd/driftctl.go
+++ b/pkg/cmd/driftctl.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/cloudskiff/driftctl/build"
+	"github.com/cloudskiff/driftctl/pkg"
 	"github.com/cloudskiff/driftctl/sentry"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -65,7 +66,7 @@ func NewDriftctlCmd(build build.BuildInterface) *DriftctlCmd {
 	cmd.PersistentFlags().BoolP("disable-telemetry", "", false, "Disable telemetry")
 	cmd.PersistentFlags().BoolP("send-crash-report", "", false, "Enable error reporting. Crash data will be sent to us via Sentry.\nWARNING: may leak sensitive data (please read the documentation for more details)\nThis flag should be used only if an error occurs during execution")
 
-	cmd.AddCommand(NewScanCmd())
+	cmd.AddCommand(NewScanCmd(&pkg.ScanOptions{}))
 	cmd.AddCommand(NewGenDriftIgnoreCmd())
 
 	return cmd

--- a/pkg/cmd/testdata/terraform_invalid.lock.hcl
+++ b/pkg/cmd/testdata/terraform_invalid.lock.hcl
@@ -1,0 +1,17 @@
+provider "registry.terraform.io/hashicorp/aws" {
+    constraints = "~> 3.47.0"
+    hashes = [
+        "h1:gXncRh1KtgLNMeb3/bYq5CvGfy8YTR+n6ds1noc5ggc=",
+        "zh:07bb6bda5b9fdb782dd568a2e85cfe0ab108770e2218f3411e57ed845c58af40",
+        "zh:0926b161a109e75bdc8691e8a32f568b4cd77a55510cf27573261fb5ba382287",
+        "zh:0a91adf25a78ad31d547da513db24f493d27592d3675ed291a7698351c30992d",
+        "zh:0f95f01e3bf0dab306ed86afb1ca00e01ce94ed6696765158d544b1569483b13",
+        "zh:10466a520c617354ebbee9366267e0878b091a15d49cb97846511e952bd9db90",
+        "zh:2fc627d3dc5a6df904591c673d640e6d3a697dcc12d1a43cf71066a47314f7c0",
+        "zh:a85476047ddb359acdc0db5b9cbe0a7e13c4e65289b03f6c93303d0452db450b",
+        "zh:cbadde98d44e8953cc78487b6788b97cff12632e9fda065bb970b001205662cb",
+        "zh:db05702323c5fa253d5e067458340b89126738b8f6a9847465ee3e75b0f28320",
+        "zh:e16cf52ff3b067adb33a75b89c03f9b03e666e2d45adb2ee296ae12b36cd5776",
+        "zh:fcb8f73f7f5e195e3345d5694b526e0d5e77562d2e7dd468366ee15b1be6b418",
+    ]
+}

--- a/pkg/cmd/testdata/terraform_valid.lock.hcl
+++ b/pkg/cmd/testdata/terraform_valid.lock.hcl
@@ -1,0 +1,18 @@
+provider "registry.terraform.io/hashicorp/aws" {
+    version     = "3.47.0"
+    constraints = "~> 3.47.0"
+    hashes = [
+        "h1:gXncRh1KtgLNMeb3/bYq5CvGfy8YTR+n6ds1noc5ggc=",
+        "zh:07bb6bda5b9fdb782dd568a2e85cfe0ab108770e2218f3411e57ed845c58af40",
+        "zh:0926b161a109e75bdc8691e8a32f568b4cd77a55510cf27573261fb5ba382287",
+        "zh:0a91adf25a78ad31d547da513db24f493d27592d3675ed291a7698351c30992d",
+        "zh:0f95f01e3bf0dab306ed86afb1ca00e01ce94ed6696765158d544b1569483b13",
+        "zh:10466a520c617354ebbee9366267e0878b091a15d49cb97846511e952bd9db90",
+        "zh:2fc627d3dc5a6df904591c673d640e6d3a697dcc12d1a43cf71066a47314f7c0",
+        "zh:a85476047ddb359acdc0db5b9cbe0a7e13c4e65289b03f6c93303d0452db450b",
+        "zh:cbadde98d44e8953cc78487b6788b97cff12632e9fda065bb970b001205662cb",
+        "zh:db05702323c5fa253d5e067458340b89126738b8f6a9847465ee3e75b0f28320",
+        "zh:e16cf52ff3b067adb33a75b89c03f9b03e666e2d45adb2ee296ae12b36cd5776",
+        "zh:fcb8f73f7f5e195e3345d5694b526e0d5e77562d2e7dd468366ee15b1be6b418",
+    ]
+}

--- a/pkg/remote/aws/init.go
+++ b/pkg/remote/aws/init.go
@@ -25,9 +25,6 @@ func Init(version string, alerter *alerter.Alerter,
 	factory resource.ResourceFactory,
 	configDir string) error {
 
-	if version == "" {
-		version = "3.19.0"
-	}
 	provider, err := NewAWSTerraformProvider(version, progress, configDir)
 	if err != nil {
 		return err
@@ -190,7 +187,7 @@ func Init(version string, alerter *alerter.Alerter,
 	remoteLibrary.AddEnumerator(NewAppAutoscalingTargetEnumerator(appAutoScalingRepository, factory))
 	remoteLibrary.AddDetailsFetcher(aws.AwsAppAutoscalingTargetResourceType, common.NewGenericDetailsFetcher(aws.AwsAppAutoscalingTargetResourceType, provider, deserializer))
 
-	err = resourceSchemaRepository.Init(terraform.AWS, version, provider.Schema())
+	err = resourceSchemaRepository.Init(terraform.AWS, provider.Version(), provider.Schema())
 	if err != nil {
 		return err
 	}

--- a/pkg/remote/aws/provider.go
+++ b/pkg/remote/aws/provider.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"github.com/aws/aws-sdk-go/aws/session"
-
 	"github.com/cloudskiff/driftctl/pkg/output"
 	"github.com/cloudskiff/driftctl/pkg/remote/terraform"
 	tf "github.com/cloudskiff/driftctl/pkg/terraform"
@@ -45,6 +44,9 @@ type AWSTerraformProvider struct {
 }
 
 func NewAWSTerraformProvider(version string, progress output.Progress, configDir string) (*AWSTerraformProvider, error) {
+	if version == "" {
+		version = "3.19.0"
+	}
 	p := &AWSTerraformProvider{
 		version: version,
 		name:    "aws",

--- a/pkg/remote/azurerm/init.go
+++ b/pkg/remote/azurerm/init.go
@@ -23,10 +23,6 @@ func Init(
 	factory resource.ResourceFactory,
 	configDir string) error {
 
-	if version == "" {
-		version = "2.71.0"
-	}
-
 	provider, err := NewAzureTerraformProvider(version, progress, configDir)
 	if err != nil {
 		return err

--- a/pkg/remote/azurerm/provider.go
+++ b/pkg/remote/azurerm/provider.go
@@ -16,6 +16,9 @@ type AzureTerraformProvider struct {
 }
 
 func NewAzureTerraformProvider(version string, progress output.Progress, configDir string) (*AzureTerraformProvider, error) {
+	if version == "" {
+		version = "2.71.0"
+	}
 	// Just pass your version and name
 	p := &AzureTerraformProvider{
 		version: version,

--- a/pkg/remote/common/providers.go
+++ b/pkg/remote/common/providers.go
@@ -1,8 +1,30 @@
 package common
 
+import (
+	tf "github.com/cloudskiff/driftctl/pkg/terraform"
+	"github.com/cloudskiff/driftctl/pkg/terraform/lock"
+)
+
+type RemoteParameter string
+
 const (
 	RemoteAWSTerraform    = "aws+tf"
 	RemoteGithubTerraform = "github+tf"
 	RemoteGoogleTerraform = "gcp+tf"
 	RemoteAzureTerraform  = "azure+tf"
 )
+
+var remoteParameterMapping = map[RemoteParameter]string{
+	RemoteAWSTerraform:    tf.AWS,
+	RemoteGithubTerraform: tf.GITHUB,
+	RemoteGoogleTerraform: tf.GOOGLE,
+	RemoteAzureTerraform:  tf.AZURE,
+}
+
+func (p RemoteParameter) GetProviderAddress() *lock.ProviderAddress {
+	return &lock.ProviderAddress{
+		Hostname:  "registry.terraform.io",
+		Namespace: "hashicorp",
+		Type:      remoteParameterMapping[p],
+	}
+}

--- a/pkg/remote/github/init.go
+++ b/pkg/remote/github/init.go
@@ -22,9 +22,6 @@ func Init(version string, alerter *alerter.Alerter,
 	resourceSchemaRepository *resource.SchemaRepository,
 	factory resource.ResourceFactory,
 	configDir string) error {
-	if version == "" {
-		version = "4.4.0"
-	}
 
 	provider, err := NewGithubTerraformProvider(version, progress, configDir)
 	if err != nil {
@@ -56,7 +53,7 @@ func Init(version string, alerter *alerter.Alerter,
 	remoteLibrary.AddEnumerator(NewGithubBranchProtectionEnumerator(repository, factory))
 	remoteLibrary.AddDetailsFetcher(github.GithubBranchProtectionResourceType, common.NewGenericDetailsFetcher(github.GithubBranchProtectionResourceType, provider, deserializer))
 
-	err = resourceSchemaRepository.Init(terraform.GITHUB, version, provider.Schema())
+	err = resourceSchemaRepository.Init(terraform.GITHUB, provider.Version(), provider.Schema())
 	if err != nil {
 		return err
 	}

--- a/pkg/remote/github/provider.go
+++ b/pkg/remote/github/provider.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"github.com/cloudskiff/driftctl/pkg/output"
-
 	"github.com/cloudskiff/driftctl/pkg/remote/terraform"
 	tf "github.com/cloudskiff/driftctl/pkg/terraform"
 )
@@ -22,6 +21,9 @@ type githubConfig struct {
 }
 
 func NewGithubTerraformProvider(version string, progress output.Progress, configDir string) (*GithubTerraformProvider, error) {
+	if version == "" {
+		version = "4.4.0"
+	}
 	p := &GithubTerraformProvider{
 		version: version,
 		name:    "github",

--- a/pkg/remote/google/init.go
+++ b/pkg/remote/google/init.go
@@ -22,10 +22,6 @@ func Init(version string, alerter *alerter.Alerter,
 	factory resource.ResourceFactory,
 	configDir string) error {
 
-	if version == "" {
-		version = "3.78.0"
-	}
-
 	provider, err := NewGCPTerraformProvider(version, progress, configDir)
 	if err != nil {
 		return err
@@ -60,7 +56,7 @@ func Init(version string, alerter *alerter.Alerter,
 	remoteLibrary.AddEnumerator(NewGoogleComputeNetworkEnumerator(assetRepository, factory))
 	remoteLibrary.AddDetailsFetcher(google.GoogleComputeNetworkResourceType, common.NewGenericDetailsFetcher(google.GoogleComputeNetworkResourceType, provider, deserializer))
 
-	err = resourceSchemaRepository.Init(terraform.GOOGLE, version, provider.Schema())
+	err = resourceSchemaRepository.Init(terraform.GOOGLE, provider.Version(), provider.Schema())
 	if err != nil {
 		return err
 	}

--- a/pkg/remote/google/provider.go
+++ b/pkg/remote/google/provider.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cloudskiff/driftctl/pkg/output"
 	"github.com/cloudskiff/driftctl/pkg/remote/google/config"
-
 	"github.com/cloudskiff/driftctl/pkg/remote/terraform"
 	tf "github.com/cloudskiff/driftctl/pkg/terraform"
 )
@@ -17,6 +16,9 @@ type GCPTerraformProvider struct {
 }
 
 func NewGCPTerraformProvider(version string, progress output.Progress, configDir string) (*GCPTerraformProvider, error) {
+	if version == "" {
+		version = "3.78.0"
+	}
 	p := &GCPTerraformProvider{
 		version: version,
 		name:    tf.GOOGLE,

--- a/pkg/remote/terraform/provider.go
+++ b/pkg/remote/terraform/provider.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/cloudskiff/driftctl/pkg/output"
-
 	"github.com/eapache/go-resiliency/retrier"
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/plugin/discovery"
@@ -88,7 +87,6 @@ func (p *TerraformProvider) Runner() *parallel.ParallelRunner {
 }
 
 func (p *TerraformProvider) configure(alias string) error {
-
 	providerPath, err := p.providerInstaller.Install()
 	if err != nil {
 		return err

--- a/pkg/terraform/lock/lockfile.go
+++ b/pkg/terraform/lock/lockfile.go
@@ -1,0 +1,54 @@
+package lock
+
+import (
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclparse"
+)
+
+type ProviderBlock struct {
+	Address     string   `hcl:"address,label"`
+	Version     string   `hcl:"version,attr"`
+	Constraints string   `hcl:"constraints,optional"`
+	Hashes      []string `hcl:"hashes,optional"`
+}
+
+// ProviderAddress encapsulates a single provider type. In the future this will be
+// extended to include additional fields including Namespace and SourceHost
+type ProviderAddress struct {
+	Type      string
+	Namespace string
+	Hostname  string
+}
+
+func (p *ProviderAddress) String() string {
+	return strings.Join([]string{p.Hostname, p.Namespace, p.Type}, "/")
+}
+
+type Lockfile struct {
+	Providers []ProviderBlock `hcl:"provider,block"`
+}
+
+func (l *Lockfile) GetProviderByAddress(addr *ProviderAddress) *ProviderBlock {
+	for _, p := range l.Providers {
+		if p.Address == addr.String() {
+			return &p
+		}
+	}
+	return nil
+}
+
+func ReadLocksFromFile(filename string) (*Lockfile, error) {
+	var lock Lockfile
+
+	parser := hclparse.NewParser()
+	f, diags := parser.ParseHCLFile(filename)
+	if diags.HasErrors() {
+		return &lock, diags
+	}
+
+	diags = gohcl.DecodeBody(f.Body, nil, &lock)
+
+	return &lock, diags
+}

--- a/pkg/terraform/lock/lockfile_test.go
+++ b/pkg/terraform/lock/lockfile_test.go
@@ -22,9 +22,9 @@ func Test_ReadLockFile(t *testing.T) {
 					Hostname:  "registry.terraform.io",
 				})
 
-				assert.Len(t, locks.Providers, 0)
-				assert.Nil(t, provider)
-				assert.EqualError(t, err, "<nil>: Failed to read file; The configuration file \"testdata/file_does_not_exist.hcl\" could not be read.")
+				assert.Len(tt, locks.Providers, 0)
+				assert.Nil(tt, provider)
+				assert.EqualError(tt, err, "<nil>: Failed to read file; The configuration file \"testdata/file_does_not_exist.hcl\" could not be read.")
 			},
 		},
 		{
@@ -37,11 +37,11 @@ func Test_ReadLockFile(t *testing.T) {
 					Hostname:  "registry.terraform.io",
 				})
 
-				assert.Len(t, locks.Providers, 10)
-				assert.Equal(t, "3.47.0", provider.Version)
-				assert.Equal(t, "registry.terraform.io/hashicorp/aws", provider.Address)
-				assert.Equal(t, "~> 3.47.0", provider.Constraints)
-				assert.Nil(t, err)
+				assert.Len(tt, locks.Providers, 10)
+				assert.Equal(tt, "3.47.0", provider.Version)
+				assert.Equal(tt, "registry.terraform.io/hashicorp/aws", provider.Address)
+				assert.Equal(tt, "~> 3.47.0", provider.Constraints)
+				assert.Nil(tt, err)
 			},
 		},
 		{
@@ -50,9 +50,9 @@ func Test_ReadLockFile(t *testing.T) {
 			assert: func(tt *testing.T, locks *Lockfile, err error) {
 				provider := locks.GetProviderByAddress(&ProviderAddress{})
 
-				assert.Len(t, locks.Providers, 10)
-				assert.Nil(t, provider)
-				assert.Nil(t, err)
+				assert.Len(tt, locks.Providers, 10)
+				assert.Nil(tt, provider)
+				assert.Nil(tt, err)
 			},
 		},
 		{
@@ -61,9 +61,9 @@ func Test_ReadLockFile(t *testing.T) {
 			assert: func(tt *testing.T, locks *Lockfile, err error) {
 				provider := locks.GetProviderByAddress(&ProviderAddress{})
 
-				assert.Len(t, locks.Providers, 0)
-				assert.Nil(t, provider)
-				assert.Nil(t, err)
+				assert.Len(tt, locks.Providers, 0)
+				assert.Nil(tt, provider)
+				assert.Nil(tt, err)
 			},
 		},
 		{
@@ -72,9 +72,9 @@ func Test_ReadLockFile(t *testing.T) {
 			assert: func(tt *testing.T, locks *Lockfile, err error) {
 				provider := locks.GetProviderByAddress(&ProviderAddress{})
 
-				assert.Len(t, locks.Providers, 1)
-				assert.Nil(t, provider)
-				assert.EqualError(t, err, "testdata/lockfile_invalid.hcl:4,48-48: Missing required argument; The argument \"version\" is required, but no definition was found.")
+				assert.Len(tt, locks.Providers, 1)
+				assert.Nil(tt, provider)
+				assert.EqualError(tt, err, "testdata/lockfile_invalid.hcl:4,48-48: Missing required argument; The argument \"version\" is required, but no definition was found.")
 			},
 		},
 		{
@@ -87,11 +87,11 @@ func Test_ReadLockFile(t *testing.T) {
 					Hostname:  "registry.terraform.io",
 				})
 
-				assert.Len(t, locks.Providers, 2)
-				assert.Equal(t, "2.71.0", provider.Version)
-				assert.Equal(t, "registry.terraform.io/hashicorp/google-beta", provider.Address)
-				assert.Equal(t, "~> 2.71.0", provider.Constraints)
-				assert.Nil(t, err)
+				assert.Len(tt, locks.Providers, 2)
+				assert.Equal(tt, "2.71.0", provider.Version)
+				assert.Equal(tt, "registry.terraform.io/hashicorp/google-beta", provider.Address)
+				assert.Equal(tt, "~> 2.71.0", provider.Constraints)
+				assert.Nil(tt, err)
 			},
 		},
 		{
@@ -104,11 +104,11 @@ func Test_ReadLockFile(t *testing.T) {
 					Hostname:  "registry.terraform.io",
 				})
 
-				assert.Len(t, locks.Providers, 2)
-				assert.Equal(t, "2.71.0", provider.Version)
-				assert.Equal(t, "registry.terraform.io/hashicorp/google-beta", provider.Address)
-				assert.Equal(t, "~> 2.71.0", provider.Constraints)
-				assert.Nil(t, err)
+				assert.Len(tt, locks.Providers, 2)
+				assert.Equal(tt, "2.71.0", provider.Version)
+				assert.Equal(tt, "registry.terraform.io/hashicorp/google-beta", provider.Address)
+				assert.Equal(tt, "~> 2.71.0", provider.Constraints)
+				assert.Nil(tt, err)
 			},
 		},
 		{
@@ -121,9 +121,9 @@ func Test_ReadLockFile(t *testing.T) {
 					Hostname:  "registry.terraform.io",
 				})
 
-				assert.Len(t, locks.Providers, 10)
-				assert.Nil(t, provider)
-				assert.Nil(t, err)
+				assert.Len(tt, locks.Providers, 10)
+				assert.Nil(tt, provider)
+				assert.Nil(tt, err)
 			},
 		},
 	}

--- a/pkg/terraform/lock/lockfile_test.go
+++ b/pkg/terraform/lock/lockfile_test.go
@@ -1,0 +1,137 @@
+package lock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ReadLockFile(t *testing.T) {
+	cases := []struct {
+		test     string
+		filepath string
+		assert   func(*testing.T, *Lockfile, error)
+	}{
+		{
+			test:     "should attempt to read non existing file",
+			filepath: "testdata/file_does_not_exist.hcl",
+			assert: func(tt *testing.T, locks *Lockfile, err error) {
+				provider := locks.GetProviderByAddress(&ProviderAddress{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
+				})
+
+				assert.Len(t, locks.Providers, 0)
+				assert.Nil(t, provider)
+				assert.EqualError(t, err, "<nil>: Failed to read file; The configuration file \"testdata/file_does_not_exist.hcl\" could not be read.")
+			},
+		},
+		{
+			test:     "should read valid lock file",
+			filepath: "testdata/lockfile_valid.hcl",
+			assert: func(tt *testing.T, locks *Lockfile, err error) {
+				provider := locks.GetProviderByAddress(&ProviderAddress{
+					Type:      "aws",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
+				})
+
+				assert.Len(t, locks.Providers, 10)
+				assert.Equal(t, "3.47.0", provider.Version)
+				assert.Equal(t, "registry.terraform.io/hashicorp/aws", provider.Address)
+				assert.Equal(t, "~> 3.47.0", provider.Constraints)
+				assert.Nil(t, err)
+			},
+		},
+		{
+			test:     "should fail to retrieve provider block with invalid address",
+			filepath: "testdata/lockfile_valid.hcl",
+			assert: func(tt *testing.T, locks *Lockfile, err error) {
+				provider := locks.GetProviderByAddress(&ProviderAddress{})
+
+				assert.Len(t, locks.Providers, 10)
+				assert.Nil(t, provider)
+				assert.Nil(t, err)
+			},
+		},
+		{
+			test:     "should read empty file without error",
+			filepath: "testdata/lockfile_empty.hcl",
+			assert: func(tt *testing.T, locks *Lockfile, err error) {
+				provider := locks.GetProviderByAddress(&ProviderAddress{})
+
+				assert.Len(t, locks.Providers, 0)
+				assert.Nil(t, provider)
+				assert.Nil(t, err)
+			},
+		},
+		{
+			test:     "should return error for invalid lock file",
+			filepath: "testdata/lockfile_invalid.hcl",
+			assert: func(tt *testing.T, locks *Lockfile, err error) {
+				provider := locks.GetProviderByAddress(&ProviderAddress{})
+
+				assert.Len(t, locks.Providers, 1)
+				assert.Nil(t, provider)
+				assert.EqualError(t, err, "testdata/lockfile_invalid.hcl:4,48-48: Missing required argument; The argument \"version\" is required, but no definition was found.")
+			},
+		},
+		{
+			test:     "should parse provider blocks without error",
+			filepath: "testdata/lockfile_invalid_type-1.hcl",
+			assert: func(tt *testing.T, locks *Lockfile, err error) {
+				provider := locks.GetProviderByAddress(&ProviderAddress{
+					Type:      "google-beta",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
+				})
+
+				assert.Len(t, locks.Providers, 2)
+				assert.Equal(t, "2.71.0", provider.Version)
+				assert.Equal(t, "registry.terraform.io/hashicorp/google-beta", provider.Address)
+				assert.Equal(t, "~> 2.71.0", provider.Constraints)
+				assert.Nil(t, err)
+			},
+		},
+		{
+			test:     "should parse provider blocks without error",
+			filepath: "testdata/lockfile_invalid_type-3.hcl",
+			assert: func(tt *testing.T, locks *Lockfile, err error) {
+				provider := locks.GetProviderByAddress(&ProviderAddress{
+					Type:      "google-beta",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
+				})
+
+				assert.Len(t, locks.Providers, 2)
+				assert.Equal(t, "2.71.0", provider.Version)
+				assert.Equal(t, "registry.terraform.io/hashicorp/google-beta", provider.Address)
+				assert.Equal(t, "~> 2.71.0", provider.Constraints)
+				assert.Nil(t, err)
+			},
+		},
+		{
+			test:     "should not find provider address",
+			filepath: "testdata/lockfile_valid.hcl",
+			assert: func(tt *testing.T, locks *Lockfile, err error) {
+				provider := locks.GetProviderByAddress(&ProviderAddress{
+					Type:      "unknown",
+					Namespace: "hashicorp",
+					Hostname:  "registry.terraform.io",
+				})
+
+				assert.Len(t, locks.Providers, 10)
+				assert.Nil(t, provider)
+				assert.Nil(t, err)
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.test, func(tt *testing.T) {
+			locks, err := ReadLocksFromFile(c.filepath)
+			c.assert(t, locks, err)
+		})
+	}
+}

--- a/pkg/terraform/lock/testdata/lockfile_empty.hcl
+++ b/pkg/terraform/lock/testdata/lockfile_empty.hcl
@@ -1,0 +1,2 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.

--- a/pkg/terraform/lock/testdata/lockfile_invalid.hcl
+++ b/pkg/terraform/lock/testdata/lockfile_invalid.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+    constraints = "~> 3.47.0"
+    hashes = [
+        "h1:gXncRh1KtgLNMeb3/bYq5CvGfy8YTR+n6ds1noc5ggc=",
+        "zh:07bb6bda5b9fdb782dd568a2e85cfe0ab108770e2218f3411e57ed845c58af40",
+        "zh:0926b161a109e75bdc8691e8a32f568b4cd77a55510cf27573261fb5ba382287",
+        "zh:0a91adf25a78ad31d547da513db24f493d27592d3675ed291a7698351c30992d",
+        "zh:0f95f01e3bf0dab306ed86afb1ca00e01ce94ed6696765158d544b1569483b13",
+        "zh:10466a520c617354ebbee9366267e0878b091a15d49cb97846511e952bd9db90",
+        "zh:2fc627d3dc5a6df904591c673d640e6d3a697dcc12d1a43cf71066a47314f7c0",
+        "zh:a85476047ddb359acdc0db5b9cbe0a7e13c4e65289b03f6c93303d0452db450b",
+        "zh:cbadde98d44e8953cc78487b6788b97cff12632e9fda065bb970b001205662cb",
+        "zh:db05702323c5fa253d5e067458340b89126738b8f6a9847465ee3e75b0f28320",
+        "zh:e16cf52ff3b067adb33a75b89c03f9b03e666e2d45adb2ee296ae12b36cd5776",
+        "zh:fcb8f73f7f5e195e3345d5694b526e0d5e77562d2e7dd468366ee15b1be6b418",
+    ]
+}

--- a/pkg/terraform/lock/testdata/lockfile_invalid_type-1.hcl
+++ b/pkg/terraform/lock/testdata/lockfile_invalid_type-1.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+    version     = "2.71.0"
+    constraints = "~> 2.71.0"
+    hashes = [
+        "h1:RiFIxNI4Yr9CqleqEdgg1ydLAZ5JiYiz6l5iTD3WcuU=",
+        "zh:2b9d8a703a0222f72cbceb8d2bdb580066afdcd7f28b6ad65d5ed935319b5433",
+        "zh:332988f4c1747bcc8ebd32734bf8de2bea4c13a6fbd08d7eb97d0c43d335b15e",
+        "zh:3a902470276ba48e23ad4dd6baff16a9ce3b60b29c0b07064dbe96ce4640a31c",
+        "zh:5eaa0d0c2c6554913421be10fbf4bb6a9ef98fbbd750d3d1f02c99798aae2c22",
+        "zh:67859f40ed2f770f33ace9d3911e8b9c9be505947b38a0578e6d097f5db1d4bf",
+        "zh:7cd9bf4899fe383fc7eeede03cad138d637244878cd295a7a1044ca20ca0652c",
+        "zh:afcb82c1382a1a9d63a41137321e077144aad768e4e46057a7ea604d067b4181",
+        "zh:c6e358759ed00a628dcfe7adb0906b2c98576ac3056fdd70930786d404e1da66",
+        "zh:cb3390c34f6790ad656929d0268ab3bc082678e8cbe2add0a177cf7896068844",
+        "zh:cc213dbf59cf41506e86b83492ccfef6ef5f34d4d00d9e49fc8a01fee253f4ee",
+        "zh:d1e8c9b507e2d187ea2447ae156028ba3f76db2164674761987c14217d04fee5",
+    ]
+}
+
+provider "registry.terraform.io/hashicorp/terraform-provider-aws" {
+    version     = "2.71.0"
+    constraints = "~> 2.71.0"
+    hashes = [
+        "h1:RiFIxNI4Yr9CqleqEdgg1ydLAZ5JiYiz6l5iTD3WcuU=",
+        "zh:2b9d8a703a0222f72cbceb8d2bdb580066afdcd7f28b6ad65d5ed935319b5433",
+        "zh:332988f4c1747bcc8ebd32734bf8de2bea4c13a6fbd08d7eb97d0c43d335b15e",
+        "zh:3a902470276ba48e23ad4dd6baff16a9ce3b60b29c0b07064dbe96ce4640a31c",
+        "zh:5eaa0d0c2c6554913421be10fbf4bb6a9ef98fbbd750d3d1f02c99798aae2c22",
+        "zh:67859f40ed2f770f33ace9d3911e8b9c9be505947b38a0578e6d097f5db1d4bf",
+        "zh:7cd9bf4899fe383fc7eeede03cad138d637244878cd295a7a1044ca20ca0652c",
+        "zh:afcb82c1382a1a9d63a41137321e077144aad768e4e46057a7ea604d067b4181",
+        "zh:c6e358759ed00a628dcfe7adb0906b2c98576ac3056fdd70930786d404e1da66",
+        "zh:cb3390c34f6790ad656929d0268ab3bc082678e8cbe2add0a177cf7896068844",
+        "zh:cc213dbf59cf41506e86b83492ccfef6ef5f34d4d00d9e49fc8a01fee253f4ee",
+        "zh:d1e8c9b507e2d187ea2447ae156028ba3f76db2164674761987c14217d04fee5",
+    ]
+}

--- a/pkg/terraform/lock/testdata/lockfile_invalid_type-3.hcl
+++ b/pkg/terraform/lock/testdata/lockfile_invalid_type-3.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+    version     = "2.71.0"
+    constraints = "~> 2.71.0"
+    hashes = [
+        "h1:RiFIxNI4Yr9CqleqEdgg1ydLAZ5JiYiz6l5iTD3WcuU=",
+        "zh:2b9d8a703a0222f72cbceb8d2bdb580066afdcd7f28b6ad65d5ed935319b5433",
+        "zh:332988f4c1747bcc8ebd32734bf8de2bea4c13a6fbd08d7eb97d0c43d335b15e",
+        "zh:3a902470276ba48e23ad4dd6baff16a9ce3b60b29c0b07064dbe96ce4640a31c",
+        "zh:5eaa0d0c2c6554913421be10fbf4bb6a9ef98fbbd750d3d1f02c99798aae2c22",
+        "zh:67859f40ed2f770f33ace9d3911e8b9c9be505947b38a0578e6d097f5db1d4bf",
+        "zh:7cd9bf4899fe383fc7eeede03cad138d637244878cd295a7a1044ca20ca0652c",
+        "zh:afcb82c1382a1a9d63a41137321e077144aad768e4e46057a7ea604d067b4181",
+        "zh:c6e358759ed00a628dcfe7adb0906b2c98576ac3056fdd70930786d404e1da66",
+        "zh:cb3390c34f6790ad656929d0268ab3bc082678e8cbe2add0a177cf7896068844",
+        "zh:cc213dbf59cf41506e86b83492ccfef6ef5f34d4d00d9e49fc8a01fee253f4ee",
+        "zh:d1e8c9b507e2d187ea2447ae156028ba3f76db2164674761987c14217d04fee5",
+    ]
+}
+
+provider "registry.terraform.io/-/test" {
+    version     = "2.71.0"
+    constraints = "~> 2.71.0"
+    hashes = [
+        "h1:RiFIxNI4Yr9CqleqEdgg1ydLAZ5JiYiz6l5iTD3WcuU=",
+        "zh:2b9d8a703a0222f72cbceb8d2bdb580066afdcd7f28b6ad65d5ed935319b5433",
+        "zh:332988f4c1747bcc8ebd32734bf8de2bea4c13a6fbd08d7eb97d0c43d335b15e",
+        "zh:3a902470276ba48e23ad4dd6baff16a9ce3b60b29c0b07064dbe96ce4640a31c",
+        "zh:5eaa0d0c2c6554913421be10fbf4bb6a9ef98fbbd750d3d1f02c99798aae2c22",
+        "zh:67859f40ed2f770f33ace9d3911e8b9c9be505947b38a0578e6d097f5db1d4bf",
+        "zh:7cd9bf4899fe383fc7eeede03cad138d637244878cd295a7a1044ca20ca0652c",
+        "zh:afcb82c1382a1a9d63a41137321e077144aad768e4e46057a7ea604d067b4181",
+        "zh:c6e358759ed00a628dcfe7adb0906b2c98576ac3056fdd70930786d404e1da66",
+        "zh:cb3390c34f6790ad656929d0268ab3bc082678e8cbe2add0a177cf7896068844",
+        "zh:cc213dbf59cf41506e86b83492ccfef6ef5f34d4d00d9e49fc8a01fee253f4ee",
+        "zh:d1e8c9b507e2d187ea2447ae156028ba3f76db2164674761987c14217d04fee5",
+    ]
+}

--- a/pkg/terraform/lock/testdata/lockfile_valid.hcl
+++ b/pkg/terraform/lock/testdata/lockfile_valid.hcl
@@ -1,0 +1,188 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+    version     = "3.47.0"
+    constraints = "~> 3.47.0"
+    hashes = [
+        "h1:gXncRh1KtgLNMeb3/bYq5CvGfy8YTR+n6ds1noc5ggc=",
+        "zh:07bb6bda5b9fdb782dd568a2e85cfe0ab108770e2218f3411e57ed845c58af40",
+        "zh:0926b161a109e75bdc8691e8a32f568b4cd77a55510cf27573261fb5ba382287",
+        "zh:0a91adf25a78ad31d547da513db24f493d27592d3675ed291a7698351c30992d",
+        "zh:0f95f01e3bf0dab306ed86afb1ca00e01ce94ed6696765158d544b1569483b13",
+        "zh:10466a520c617354ebbee9366267e0878b091a15d49cb97846511e952bd9db90",
+        "zh:2fc627d3dc5a6df904591c673d640e6d3a697dcc12d1a43cf71066a47314f7c0",
+        "zh:a85476047ddb359acdc0db5b9cbe0a7e13c4e65289b03f6c93303d0452db450b",
+        "zh:cbadde98d44e8953cc78487b6788b97cff12632e9fda065bb970b001205662cb",
+        "zh:db05702323c5fa253d5e067458340b89126738b8f6a9847465ee3e75b0f28320",
+        "zh:e16cf52ff3b067adb33a75b89c03f9b03e666e2d45adb2ee296ae12b36cd5776",
+        "zh:fcb8f73f7f5e195e3345d5694b526e0d5e77562d2e7dd468366ee15b1be6b418",
+    ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+    version     = "2.71.0"
+    constraints = "~> 2.71.0"
+    hashes = [
+        "h1:RiFIxNI4Yr9CqleqEdgg1ydLAZ5JiYiz6l5iTD3WcuU=",
+        "zh:2b9d8a703a0222f72cbceb8d2bdb580066afdcd7f28b6ad65d5ed935319b5433",
+        "zh:332988f4c1747bcc8ebd32734bf8de2bea4c13a6fbd08d7eb97d0c43d335b15e",
+        "zh:3a902470276ba48e23ad4dd6baff16a9ce3b60b29c0b07064dbe96ce4640a31c",
+        "zh:5eaa0d0c2c6554913421be10fbf4bb6a9ef98fbbd750d3d1f02c99798aae2c22",
+        "zh:67859f40ed2f770f33ace9d3911e8b9c9be505947b38a0578e6d097f5db1d4bf",
+        "zh:7cd9bf4899fe383fc7eeede03cad138d637244878cd295a7a1044ca20ca0652c",
+        "zh:afcb82c1382a1a9d63a41137321e077144aad768e4e46057a7ea604d067b4181",
+        "zh:c6e358759ed00a628dcfe7adb0906b2c98576ac3056fdd70930786d404e1da66",
+        "zh:cb3390c34f6790ad656929d0268ab3bc082678e8cbe2add0a177cf7896068844",
+        "zh:cc213dbf59cf41506e86b83492ccfef6ef5f34d4d00d9e49fc8a01fee253f4ee",
+        "zh:d1e8c9b507e2d187ea2447ae156028ba3f76db2164674761987c14217d04fee5",
+    ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+    version = "2.2.0"
+    hashes = [
+        "h1:tQLNREqesrdCQ/bIJnl0+yUK+XfdWzAG0wo4lp10LvM=",
+        "zh:76825122171f9ea2287fd27e23e80a7eb482f6491a4f41a096d77b666896ee96",
+        "zh:795a36dee548e30ca9c9d474af9ad6d29290e0a9816154ad38d55381cd0ab12d",
+        "zh:9200f02cb917fb99e44b40a68936fd60d338e4d30a718b7e2e48024a795a61b9",
+        "zh:a33cf255dc670c20678063aa84218e2c1b7a67d557f480d8ec0f68bc428ed472",
+        "zh:ba3c1b2cd0879286c1f531862c027ec04783ece81de67c9a3b97076f1ce7f58f",
+        "zh:bd575456394428a1a02191d2e46af0c00e41fd4f28cfe117d57b6aeb5154a0fb",
+        "zh:c68dd1db83d8437c36c92dc3fc11d71ced9def3483dd28c45f8640cfcd59de9a",
+        "zh:cbfe34a90852ed03cc074601527bb580a648127255c08589bc3ef4bf4f2e7e0c",
+        "zh:d6ffd7398c6d1f359b96f5b757e77b99b339fbb91df1b96ac974fe71bc87695c",
+        "zh:d9c15285f847d7a52df59e044184fb3ba1b7679fd0386291ed183782683d9517",
+        "zh:f7dd02f6d36844da23c9a27bb084503812c29c1aec4aba97237fec16860fdc8c",
+    ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+    version = "3.82.0"
+    hashes = [
+        "h1:+D/onH+6h1gUbGQhEEzR63eQ+sVDieKUUULsgONSpQg=",
+        "zh:08d93ebb10ebacb1abf98bd03dd6e8974b6b30c603212464295cd2a4a2cd36f4",
+        "zh:1665ccede1ed0ff571083ba609b34242ba397ec38959121513b44e8916ab71fb",
+        "zh:525274e5767fc41515d5d397b53cc6a528c343253be4d4491d2d58f74670f387",
+        "zh:61b84b6ca55a99e1f624641e8710d3ed3409ead85d50fbf4633d509a9ba18684",
+        "zh:780829197c2daaac0dba7b6ecb520f140d4bc4519e522c9338e278a16f7daaa1",
+        "zh:9e4a2a17e46e18378d2b30d44ce6fb1f012f9919891d5cb8aaff9b1628387b87",
+        "zh:9eac4c47da2c0482e6005df0827c282ce18da959989424fd831f32b15edffecd",
+        "zh:a1ff3276a0cadc181116235ca681f4e0e97b67b752822bed924b946e3862c73f",
+        "zh:ae646e03d7cdb831054d0913aa45d9eca5a422c31170ecea9f9a28cca7ecca2c",
+        "zh:b4443cca277416880a72e954d40b8db5f67bd17eeabf85f640a09b5b7c58269e",
+        "zh:f9a0bb1a9ecf8234b90c1c7c828efbbf87ea2aaba1f10283341aec24dc482d96",
+    ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+    version     = "2.4.1"
+    constraints = ">= 1.11.1, >= 2.0.1"
+    hashes = [
+        "h1:wU6cDBN6KPhjbBvPWXRgryN9amNlhL/n9l39cFm3X/U=",
+        "zh:10a368f3a3f26d821f02b55f0c42bdd4d2cd0dc5e2568c513bce39d92d25526f",
+        "zh:2183272a6d44f23d562d47ff4d6592685d8797838bdae69a50f92121743b020f",
+        "zh:24c492d61ce4dbcac4bb4410bd5e657ab28d19ab320d41104148ee626b44f5ed",
+        "zh:291380db0cd581d806158e5ddfd7133592055151109fcf0c923644cede5f30c7",
+        "zh:46933ddae44108d1a2956d917bafdb8879147b204b1bfac0c238773d2587e288",
+        "zh:5b96c1c330d709d87faa44f1cc9b1db87baeba5056638fe07c51a9b5a67f297e",
+        "zh:9fbb4ac6de96f68df324adbb77fd5eee6138f534f5393dc3bac18e615c75e0d0",
+        "zh:b8da6bbb97c20ec6e26c0160060c24d4e91b5057342b8b93a43f4019ab36e344",
+        "zh:c12390d668ef2f4c943c385de3befb54c0bfd0f9a3aa28b6aec55f7db4f4a518",
+        "zh:dee3d13f664037ada51e6f51c7e1c1361e643e1e61fbc9403b0f3985caa29c90",
+        "zh:ed10c04a636fa4a0f6e5e6068cb2f9a0f976b596cbabb9bd429631e3ba7fa35a",
+    ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+    version     = "2.0.0"
+    constraints = ">= 1.4.0, 2.0.0"
+    hashes = [
+        "h1:EC6eh7avwx1rF56h3RZcxgEp/14ihi7Sk/4J3Hn4nIE=",
+        "zh:34ce8b79493ace8333d094752b579ccc907fa9392a2c1d6933a6c95d0786d3f1",
+        "zh:5c5a19c4f614a4ffb68bae0b0563f3860115cf7539b8adc21108324cfdc10092",
+        "zh:67ddb1ca2cd3e1a8f948302597ceb967f19d2eeb2d125303493667388fe6330e",
+        "zh:68e6b16f3a8e180fcba1a99754118deb2d82331b51f6cca39f04518339bfdfa6",
+        "zh:8393a12eb11598b2799d51c9b0a922a3d9fadda5a626b94a1b4914086d53120e",
+        "zh:90daea4b2010a86f2aca1e3a9590e0b3ddcab229c2bd3685fae76a832e9e836f",
+        "zh:99308edc734a0ac9149b44f8e316ca879b2670a1cae387a8ae754c180b57cdb4",
+        "zh:c76594db07a9d1a73372a073888b672df64adb455d483c2426cc220eda7e092e",
+        "zh:dc09c1fb36c6a706bdac96cce338952888c8423978426a09f5df93031aa88b84",
+        "zh:deda88134e9780319e8de91b3745520be48ead6ec38cb662694d09185c3dac70",
+    ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+    version     = "3.0.0"
+    constraints = "3.0.0"
+    hashes = [
+        "h1:ysHGBhBNkIiJLEpthB/IVCLpA1Qoncp3KbCTFGFZTO0=",
+        "zh:05fb7eab469324c97e9b73a61d2ece6f91de4e9b493e573bfeda0f2077bc3a4c",
+        "zh:1688aa91885a395c4ae67636d411475d0b831e422e005dcf02eedacaafac3bb4",
+        "zh:24a0b1292e3a474f57c483a7a4512d797e041bc9c2fbaac42fe12e86a7fb5a3c",
+        "zh:2fc951bd0d1b9b23427acc93be09b6909d72871e464088171da60fbee4fdde03",
+        "zh:6db825759425599a326385a68acc6be2d9ba0d7d6ef587191d0cdc6daef9ac63",
+        "zh:85985763d02618993c32c294072cc6ec51f1692b803cb506fcfedca9d40eaec9",
+        "zh:a53186599c57058be1509f904da512342cfdc5d808efdaf02dec15f0f3cb039a",
+        "zh:c2e07b49b6efa676bdc7b00c06333ea1792a983a5720f9e2233db27323d2707c",
+        "zh:cdc8fe1096103cf5374751e2e8408ec4abd2eb67d5a1c5151fe2c7ecfd525bef",
+        "zh:dbdef21df0c012b0d08776f3d4f34eb0f2f229adfde07ff252a119e52c0f65b7",
+    ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+    version     = "3.0.0"
+    constraints = "3.0.0"
+    hashes = [
+        "h1:grDzxfnOdFXi90FRIIwP/ZrCzirJ/SfsGBe6cE0Shg4=",
+        "zh:0fcb00ff8b87dcac1b0ee10831e47e0203a6c46aafd76cb140ba2bab81f02c6b",
+        "zh:123c984c0e04bad910c421028d18aa2ca4af25a153264aef747521f4e7c36a17",
+        "zh:287443bc6fd7fa9a4341dec235589293cbcc6e467a042ae225fd5d161e4e68dc",
+        "zh:2c1be5596dd3cca4859466885eaedf0345c8e7628503872610629e275d71b0d2",
+        "zh:684a2ef6f415287944a3d966c4c8cee82c20e393e096e2f7cdcb4b2528407f6b",
+        "zh:7625ccbc6ff17c2d5360ff2af7f9261c3f213765642dcd84e84ae02a3768fd51",
+        "zh:9a60811ab9e6a5bfa6352fbb943bb530acb6198282a49373283a8fa3aa2b43fc",
+        "zh:c73e0eaeea6c65b1cf5098b101d51a2789b054201ce7986a6d206a9e2dacaefd",
+        "zh:e8f9ed41ac83dbe407de9f0206ef1148204a0d51ba240318af801ffb3ee5f578",
+        "zh:fbdd0684e62563d3ac33425b0ac9439d543a3942465f4b26582bcfabcb149515",
+    ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+    version     = "2.2.0"
+    constraints = "2.2.0"
+    hashes = [
+        "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
+        "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+        "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+        "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+        "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+        "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+        "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+        "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+        "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+        "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+        "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+    ]
+}
+
+provider "registry.terraform.io/terraform-aws-modules/http" {
+    version     = "2.4.1"
+    constraints = ">= 2.4.1"
+    hashes = [
+        "h1:ZnkXcawrIr611RvZpoDzbtPU7SVFyHym+7p1t+PQh20=",
+        "zh:0111f54de2a9815ded291f23136d41f3d2731c58ea663a2e8f0fef02d377d697",
+        "zh:0740152d76f0ccf54f4d0e8e0753739a5233b022acd60b5d2353d248c4c17204",
+        "zh:569518f46809ec9cdc082b4dfd4e828236eee2b50f87b301d624cfd83b8f5b0d",
+        "zh:7669f7691de91eec9f381e9a4be81aa4560f050348a86c6ea7804925752a01bb",
+        "zh:81cd53e796ec806aca2d8e92a2aed9135661e170eeff6cf0418e54f98816cd05",
+        "zh:82f01abd905090f978b169ac85d7a5952322a5f0f460269dd981b3596652d304",
+        "zh:9a235610066e0f7e567e69c23a53327271a6fc568b06bf152d8fe6594749ed2b",
+        "zh:aeabdd8e633d143feb67c52248c85358951321e35b43943aeab577c005abd30a",
+        "zh:c20d22dba5c79731918e7192bc3d0b364d47e98a74f47d287e6cc66236bc0ed0",
+        "zh:c4fea2cb18c31ed7723deec5ebaff85d6795bb6b6ed3b954794af064d17a7f9f",
+        "zh:e21e88b6e7e55b9f29b046730d9928c65a4f181fd5f60a42f1cd41b46a0a938d",
+        "zh:eddb888a74dea348a0acdfee13a08875bacddde384bd9c28342a534269665568",
+        "zh:f46d5f1403b8d8dfafab9bdd7129d3080bb62a91ea726f477fd43560887b8c4a",
+    ]
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #929
| ❓ Documentation  | https://github.com/cloudskiff/driftctl-docs/pull/130 <!-- does this require documentation update ? -->

## Description

This PR implement a lock package that parses the content of a Terraform lock file. This logic is used in the Terraform supplier in order to install a specific version when we found a Terraform lock file in at the given path.