### PR TITLE
Fix crash in output when source is nil

### DIFF
--- a/pkg/cmd/scan/output/html_test.go
+++ b/pkg/cmd/scan/output/html_test.go
@@ -183,20 +183,6 @@ func TestHTML_Write(t *testing.T) {
 							},
 						},
 					}})
-				a.AddDifference(analyser.Difference{
-					Res: &resource.Resource{
-						Id:   "diff-id-3",
-						Type: "aws_diff_resource",
-					}, Changelog: []analyser.Change{
-						{
-							Change: diff.Change{
-								Type: diff.UPDATE,
-								Path: []string{"InstanceInitiatedShutdownBehavior"},
-								From: "",
-								To:   nil,
-							},
-						},
-					}})
 				a.ProviderName = "AWS"
 				a.ProviderVersion = "3.19.0"
 				return a

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -38,11 +38,6 @@ func fakeAnalysis() *analyser.Analysis {
 		}, &resource.Resource{
 			Id:   "deleted-id-2",
 			Type: "aws_deleted_resource",
-			Source: &resource.TerraformStateSource{
-				State:  "tfstate://delete_state.tfstate",
-				Module: "module",
-				Name:   "name",
-			},
 		},
 	)
 	a.AddManaged(
@@ -55,6 +50,23 @@ func fakeAnalysis() *analyser.Analysis {
 			Type: "aws_no_diff_resource",
 		},
 	)
+	// Cover the case when a diff occur on a resource without a source
+	a.AddDifference(analyser.Difference{
+		Res: &resource.Resource{
+			Id:   "diff-id-2",
+			Type: "aws_diff_resource",
+		},
+		Changelog: []analyser.Change{
+			{
+				Change: diff.Change{
+					Type: diff.UPDATE,
+					Path: []string{"updated", "field"},
+					From: "foobar",
+					To:   "barfoo",
+				},
+			},
+		},
+	})
 	a.AddDifference(analyser.Difference{Res: &resource.Resource{
 		Id:   "diff-id-1",
 		Type: "aws_diff_resource",

--- a/pkg/cmd/scan/output/testdata/output.html
+++ b/pkg/cmd/scan/output/testdata/output.html
@@ -518,6 +518,20 @@ input[type="search"], select {
                             <div role="row" data-kind="resource-changed" class="resource-item">
                                 <div class="row">
                                     <span role="cell">
+                                        <span data-type="resource-id">diff-id-2</span>
+                                        <span>(aws_diff_resource)</span>
+                                        <span style="display:none;" data-type="resource-type">aws_diff_resource</span>
+                                    </span>
+                                    
+                                </div>
+                                <pre class="code-box">
+                                    <code class="code-box-line">&emsp;~ updated.field: <span class="code-box-line-delete">"foobar"</span> => <span class="code-box-line-create">"barfoo"</span><br></code>
+                                </pre>
+                            </div>
+                            
+                            <div role="row" data-kind="resource-changed" class="resource-item">
+                                <div class="row">
+                                    <span role="cell">
                                         <span data-type="resource-id">diff-id-1</span>
                                         (<span>module.aws_diff_resource.name</span>)
                                         <span style="display:none;" data-type="resource-type">aws_diff_resource</span>
@@ -573,20 +587,6 @@ input[type="search"], select {
                                 </pre>
                             </div>
                             
-                            <div role="row" data-kind="resource-changed" class="resource-item">
-                                <div class="row">
-                                    <span role="cell">
-                                        <span data-type="resource-id">diff-id-3</span>
-                                        <span>(aws_diff_resource)</span>
-                                        <span style="display:none;" data-type="resource-type">aws_diff_resource</span>
-                                    </span>
-                                    
-                                </div>
-                                <pre class="code-box">
-                                    <code class="code-box-line">&emsp;~ InstanceInitiatedShutdownBehavior: <span class="code-box-line-delete">""</span> => <span class="code-box-line-create">null</span><br></code>
-                                </pre>
-                            </div>
-                            
                         </div>
                     </div>
                     <div class="empty-panel is-hidden">
@@ -617,10 +617,10 @@ input[type="search"], select {
                         <tr data-kind="resource-deleted" class="resource-item row">
                             <td>
                                 <span data-type="resource-id">deleted-id-2</span>
-                                <span>(module.aws_deleted_resource.name)</span>
+                                <span>(aws_deleted_resource)</span>
                                 <span data-type="resource-type" style="display:none;">aws_deleted_resource</span>
                             </td>
-                            <td data-type="resource-source">tfstate://delete_state.tfstate</td>
+                            
                         </tr>
                         
                         <tr data-kind="resource-deleted" class="resource-item row">

--- a/pkg/cmd/scan/output/testdata/output.json
+++ b/pkg/cmd/scan/output/testdata/output.json
@@ -1,7 +1,7 @@
 {
 	"summary": {
 		"total_resources": 6,
-		"total_changed": 1,
+		"total_changed": 2,
 		"total_unmanaged": 2,
 		"total_missing": 2,
 		"total_managed": 2
@@ -38,15 +38,28 @@
 		},
 		{
 			"id": "deleted-id-2",
-			"type": "aws_deleted_resource",
-			"source": {
-				"source": "tfstate://delete_state.tfstate",
-				"namespace": "module",
-				"internal_name": "name"
-			}
+			"type": "aws_deleted_resource"
 		}
 	],
 	"differences": [
+		{
+			"res": {
+				"id": "diff-id-2",
+				"type": "aws_diff_resource"
+			},
+			"changelog": [
+				{
+					"type": "update",
+					"path": [
+						"updated",
+						"field"
+					],
+					"from": "foobar",
+					"to": "barfoo",
+					"computed": false
+				}
+			]
+		},
 		{
 			"res": {
 				"id": "diff-id-1",

--- a/pkg/cmd/scan/output/testdata/output.txt
+++ b/pkg/cmd/scan/output/testdata/output.txt
@@ -1,7 +1,7 @@
 Found missing resources:
+  - deleted-id-2 (aws_deleted_resource)
   From tfstate://delete_state.tfstate
     - deleted-id-1 (module.aws_deleted_resource.name)
-    - deleted-id-2 (module.aws_deleted_resource.name)
   From tfstate://test_state.tfstate
     - test-id-1 (module.aws_test_resource.name)
     - test-id-2 (module.aws_test_resource.name)
@@ -14,6 +14,8 @@ Found resources not covered by IaC:
     - unmanaged-id-1
     - unmanaged-id-2
 Found changed resources:
+  - diff-id-2 (aws_diff_resource):
+      ~ updated.field: "foobar" => "barfoo"
   From tfstate://state.tfstate
     - diff-id-1 (module.aws_diff_resource.name):
         ~ updated.field: "foobar" => "barfoo"
@@ -22,6 +24,6 @@ Found changed resources:
 Found 10 resource(s)
  - 20% coverage
  - 2 resource(s) managed by terraform
-     - 1/2 resource(s) out of sync with Terraform state
+     - 2/2 resource(s) out of sync with Terraform state
  - 4 resource(s) not managed by Terraform
  - 4 resource(s) found in a Terraform state but missing on the cloud provider

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -73,6 +73,9 @@ func (r *Resource) Src() Source {
 }
 
 func (r *Resource) SourceString() string {
+	if r.Source == nil {
+		return ""
+	}
 	if r.Source.Namespace() == "" {
 		return fmt.Sprintf("%s.%s", r.ResourceType(), r.Source.InternalName())
 	}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #942 
| ❓ Documentation  | no

## Description

Handle nil source in output to avoid crash.