### PR TITLE
Fix azure authentication

### DIFF
--- a/pkg/remote/azurerm/common/config.go
+++ b/pkg/remote/azurerm/common/config.go
@@ -1,8 +1,5 @@
 package common
 
 type AzureProviderConfig struct {
-	SubscriptionID,
-	TenantID,
-	ClientID,
-	ClientSecret string
+	SubscriptionID string
 }

--- a/pkg/remote/azurerm/provider.go
+++ b/pkg/remote/azurerm/provider.go
@@ -43,10 +43,7 @@ func NewAzureTerraformProvider(version string, progress output.Progress, configD
 
 func (p *AzureTerraformProvider) GetConfig() common.AzureProviderConfig {
 	return common.AzureProviderConfig{
-		SubscriptionID: os.Getenv("ARM_SUBSCRIPTION_ID"),
-		TenantID:       os.Getenv("ARM_TENANT_ID"),
-		ClientID:       os.Getenv("ARM_CLIENT_ID"),
-		ClientSecret:   os.Getenv("ARM_CLIENT_SECRET"),
+		SubscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
 	}
 }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | yes
| 🔗 Related issues | none
| ❓ Documentation  | https://github.com/cloudskiff/driftctl-docs/pull/111

## Description

It was a mistake to reuse terraform env vars, the azure SDK uses another env var naming which can cause issues.