### PR TITLE
Add api_gateway_api_key

### DIFF
--- a/pkg/iac/terraform/state/terraform_state_reader_test.go
+++ b/pkg/iac/terraform/state/terraform_state_reader_test.go
@@ -151,6 +151,7 @@ func TestTerraformStateReader_AWS_Resources(t *testing.T) {
 		{name: "Cloudformation stack", dirName: "cloudformation_stack", wantErr: false},
 		{name: "Api Gateway Rest Api", dirName: "api_gateway_rest_api", wantErr: false},
 		{name: "Api Gateway Account", dirName: "api_gateway_account", wantErr: false},
+		{name: "Api Gateway Api Key", dirName: "api_gateway_api_key", wantErr: false},
 		{name: "AppAutoScaling Targets", dirName: "aws_appautoscaling_target", wantErr: false},
 		{name: "network acl", dirName: "aws_network_acl", wantErr: false},
 		{name: "network acl rule", dirName: "aws_network_acl_rule", wantErr: false},

--- a/pkg/iac/terraform/state/test/api_gateway_api_key/results.golden.json
+++ b/pkg/iac/terraform/state/test/api_gateway_api_key/results.golden.json
@@ -1,0 +1,30 @@
+[
+ {
+  "Id": "9ge737dd45",
+  "Type": "aws_api_gateway_api_key",
+  "Attrs": {
+   "arn": "arn:aws:apigateway:us-east-1::/apikeys/9ge737dd45",
+   "created_date": "2021-09-27T09:10:54Z",
+   "description": "Foo Api Key",
+   "enabled": false,
+   "id": "9ge737dd45",
+   "last_updated_date": "2021-09-27T09:10:54Z",
+   "name": "foo",
+   "value": "nHt1Wqv9538R7HUN5LtH11DyaluIiGwM39svyqqi"
+  }
+ },
+ {
+  "Id": "fuwnl8lrva",
+  "Type": "aws_api_gateway_api_key",
+  "Attrs": {
+   "arn": "arn:aws:apigateway:us-east-1::/apikeys/fuwnl8lrva",
+   "created_date": "2021-09-27T09:10:54Z",
+   "description": "Bar Api Key",
+   "enabled": false,
+   "id": "fuwnl8lrva",
+   "last_updated_date": "2021-09-27T09:10:54Z",
+   "name": "bar",
+   "value": "pmqQupx2Eu2KG4bh8UPTP5gpPTYC5dlF6VcrygNy"
+  }
+ }
+]

--- a/pkg/iac/terraform/state/test/api_gateway_api_key/terraform.tfstate
+++ b/pkg/iac/terraform/state/test/api_gateway_api_key/terraform.tfstate
@@ -1,0 +1,59 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.7",
+  "serial": 41,
+  "lineage": "85f5bee6-139e-8db2-ae5d-82aa82f62611",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_api_gateway_api_key",
+      "name": "bar",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:apigateway:us-east-1::/apikeys/fuwnl8lrva",
+            "created_date": "2021-09-27T09:10:54Z",
+            "description": "Bar Api Key",
+            "enabled": false,
+            "id": "fuwnl8lrva",
+            "last_updated_date": "2021-09-27T09:10:54Z",
+            "name": "bar",
+            "tags": {},
+            "tags_all": {},
+            "value": "pmqQupx2Eu2KG4bh8UPTP5gpPTYC5dlF6VcrygNy"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_api_gateway_api_key",
+      "name": "foo",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:apigateway:us-east-1::/apikeys/9ge737dd45",
+            "created_date": "2021-09-27T09:10:54Z",
+            "description": "Foo Api Key",
+            "enabled": false,
+            "id": "9ge737dd45",
+            "last_updated_date": "2021-09-27T09:10:54Z",
+            "name": "foo",
+            "tags": {},
+            "tags_all": {},
+            "value": "nHt1Wqv9538R7HUN5LtH11DyaluIiGwM39svyqqi"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/remote/aws/api_gateway_api_key_enumerator.go
+++ b/pkg/remote/aws/api_gateway_api_key_enumerator.go
@@ -1,0 +1,46 @@
+package aws
+
+import (
+	"github.com/cloudskiff/driftctl/pkg/remote/aws/repository"
+	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
+	"github.com/cloudskiff/driftctl/pkg/resource"
+	"github.com/cloudskiff/driftctl/pkg/resource/aws"
+)
+
+type ApiGatewayApiKeyEnumerator struct {
+	repository repository.ApiGatewayRepository
+	factory    resource.ResourceFactory
+}
+
+func NewApiGatewayApiKeyEnumerator(repo repository.ApiGatewayRepository, factory resource.ResourceFactory) *ApiGatewayApiKeyEnumerator {
+	return &ApiGatewayApiKeyEnumerator{
+		repository: repo,
+		factory:    factory,
+	}
+}
+
+func (e *ApiGatewayApiKeyEnumerator) SupportedType() resource.ResourceType {
+	return aws.AwsApiGatewayApiKeyResourceType
+}
+
+func (e *ApiGatewayApiKeyEnumerator) Enumerate() ([]*resource.Resource, error) {
+	keys, err := e.repository.ListAllApiKeys()
+	if err != nil {
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
+	}
+
+	results := make([]*resource.Resource, len(keys))
+
+	for _, key := range keys {
+		results = append(
+			results,
+			e.factory.CreateAbstractResource(
+				string(e.SupportedType()),
+				*key.Id,
+				map[string]interface{}{},
+			),
+		)
+	}
+
+	return results, err
+}

--- a/pkg/remote/aws/init.go
+++ b/pkg/remote/aws/init.go
@@ -184,6 +184,7 @@ func Init(version string, alerter *alerter.Alerter,
 
 	remoteLibrary.AddEnumerator(NewApiGatewayRestApiEnumerator(apigatewayRepository, factory))
 	remoteLibrary.AddEnumerator(NewApiGatewayAccountEnumerator(apigatewayRepository, factory))
+	remoteLibrary.AddEnumerator(NewApiGatewayApiKeyEnumerator(apigatewayRepository, factory))
 
 	remoteLibrary.AddEnumerator(NewAppAutoscalingTargetEnumerator(appAutoScalingRepository, factory))
 	remoteLibrary.AddDetailsFetcher(aws.AwsAppAutoscalingTargetResourceType, common.NewGenericDetailsFetcher(aws.AwsAppAutoscalingTargetResourceType, provider, deserializer))

--- a/pkg/remote/aws/repository/api_gateway_repository.go
+++ b/pkg/remote/aws/repository/api_gateway_repository.go
@@ -10,6 +10,7 @@ import (
 type ApiGatewayRepository interface {
 	ListAllRestApis() ([]*apigateway.RestApi, error)
 	GetAccount() (*apigateway.Account, error)
+	ListAllApiKeys() ([]*apigateway.ApiKey, error)
 }
 
 type apigatewayRepository struct {
@@ -57,4 +58,25 @@ func (r *apigatewayRepository) GetAccount() (*apigateway.Account, error) {
 
 	r.cache.Put("apigatewayGetAccount", account)
 	return account, nil
+}
+
+func (r *apigatewayRepository) ListAllApiKeys() ([]*apigateway.ApiKey, error) {
+	if v := r.cache.Get("apigatewayListAllApiKeys"); v != nil {
+		return v.([]*apigateway.ApiKey), nil
+	}
+
+	var apiKeys []*apigateway.ApiKey
+	input := apigateway.GetApiKeysInput{}
+	err := r.client.GetApiKeysPages(&input,
+		func(resp *apigateway.GetApiKeysOutput, lastPage bool) bool {
+			apiKeys = append(apiKeys, resp.Items...)
+			return !lastPage
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	r.cache.Put("apigatewayListAllApiKeys", apiKeys)
+	return apiKeys, nil
 }

--- a/pkg/remote/aws/repository/api_gateway_repository_test.go
+++ b/pkg/remote/aws/repository/api_gateway_repository_test.go
@@ -139,3 +139,73 @@ func Test_apigatewayRepository_GetAccount(t *testing.T) {
 		})
 	}
 }
+
+func Test_apigatewayRepository_ListAllApiKeys(t *testing.T) {
+	keys := []*apigateway.ApiKey{
+		{Id: aws.String("apikey1")},
+		{Id: aws.String("apikey2")},
+		{Id: aws.String("apikey3")},
+		{Id: aws.String("apikey4")},
+		{Id: aws.String("apikey5")},
+		{Id: aws.String("apikey6")},
+	}
+
+	tests := []struct {
+		name    string
+		mocks   func(client *awstest.MockFakeApiGateway, store *cache.MockCache)
+		want    []*apigateway.ApiKey
+		wantErr error
+	}{
+		{
+			name: "list multiple api keys",
+			mocks: func(client *awstest.MockFakeApiGateway, store *cache.MockCache) {
+				client.On("GetApiKeysPages",
+					&apigateway.GetApiKeysInput{},
+					mock.MatchedBy(func(callback func(res *apigateway.GetApiKeysOutput, lastPage bool) bool) bool {
+						callback(&apigateway.GetApiKeysOutput{
+							Items: keys[:3],
+						}, false)
+						callback(&apigateway.GetApiKeysOutput{
+							Items: keys[3:],
+						}, true)
+						return true
+					})).Return(nil).Once()
+
+				store.On("Get", "apigatewayListAllApiKeys").Return(nil).Times(1)
+				store.On("Put", "apigatewayListAllApiKeys", keys).Return(false).Times(1)
+			},
+			want: keys,
+		},
+		{
+			name: "should hit cache",
+			mocks: func(client *awstest.MockFakeApiGateway, store *cache.MockCache) {
+				store.On("Get", "apigatewayListAllApiKeys").Return(keys).Times(1)
+			},
+			want: keys,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &cache.MockCache{}
+			client := &awstest.MockFakeApiGateway{}
+			tt.mocks(client, store)
+			r := &apigatewayRepository{
+				client: client,
+				cache:  store,
+			}
+			got, err := r.ListAllApiKeys()
+			assert.Equal(t, tt.wantErr, err)
+
+			changelog, err := diff.Diff(got, tt.want)
+			assert.Nil(t, err)
+			if len(changelog) > 0 {
+				for _, change := range changelog {
+					t.Errorf("%s: %s -> %s", strings.Join(change.Path, "."), change.From, change.To)
+				}
+				t.Fail()
+			}
+			store.AssertExpectations(t)
+			client.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/remote/aws/repository/mock_ApiGatewayRepository.go
+++ b/pkg/remote/aws/repository/mock_ApiGatewayRepository.go
@@ -35,6 +35,29 @@ func (_m *MockApiGatewayRepository) GetAccount() (*apigateway.Account, error) {
 	return r0, r1
 }
 
+// ListAllApiKeys provides a mock function with given fields:
+func (_m *MockApiGatewayRepository) ListAllApiKeys() ([]*apigateway.ApiKey, error) {
+	ret := _m.Called()
+
+	var r0 []*apigateway.ApiKey
+	if rf, ok := ret.Get(0).(func() []*apigateway.ApiKey); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*apigateway.ApiKey)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListAllRestApis provides a mock function with given fields:
 func (_m *MockApiGatewayRepository) ListAllRestApis() ([]*apigateway.RestApi, error) {
 	ret := _m.Called()

--- a/pkg/resource/aws/aws_api_gateway_api_key.go
+++ b/pkg/resource/aws/aws_api_gateway_api_key.go
@@ -1,0 +1,3 @@
+package aws
+
+const AwsApiGatewayApiKeyResourceType = "aws_api_gateway_api_key"

--- a/pkg/resource/aws/aws_api_gateway_api_key_test.go
+++ b/pkg/resource/aws/aws_api_gateway_api_key_test.go
@@ -1,0 +1,30 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/cloudskiff/driftctl/test"
+	"github.com/cloudskiff/driftctl/test/acceptance"
+)
+
+func TestAcc_Aws_ApiGatewayApiKey(t *testing.T) {
+	acceptance.Run(t, acceptance.AccTestCase{
+		TerraformVersion: "0.15.5",
+		Paths:            []string{"./testdata/acc/aws_api_gateway_api_key"},
+		Args:             []string{"scan", "--filter", "Type=='aws_api_gateway_api_key'"},
+		Checks: []acceptance.AccCheck{
+			{
+				Env: map[string]string{
+					"AWS_REGION": "us-east-1",
+				},
+				Check: func(result *test.ScanResult, stdout string, err error) {
+					if err != nil {
+						t.Fatal(err)
+					}
+					result.AssertInfrastructureIsInSync()
+					result.AssertManagedCount(2)
+				},
+			},
+		},
+	})
+}

--- a/pkg/resource/aws/testdata/acc/aws_api_gateway_api_key/.terraform.lock.hcl
+++ b/pkg/resource/aws/testdata/acc/aws_api_gateway_api_key/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.19.0"
+  constraints = "3.19.0"
+  hashes = [
+    "h1:xur9tF49NgsovNnmwmBR8RdpN8Fcg1TD4CKQPJD6n1A=",
+    "zh:185a5259153eb9ee4699d4be43b3d509386b473683392034319beee97d470c3b",
+    "zh:2d9a0a01f93e8d16539d835c02b8b6e1927b7685f4076e96cb07f7dd6944bc6c",
+    "zh:703f6da36b1b5f3497baa38fccaa7765fb8a2b6440344e4c97172516b49437dd",
+    "zh:770855565462abadbbddd98cb357d2f1a8f30f68a358cb37cbd5c072cb15b377",
+    "zh:8008db43149fe4345301f81e15e6d9ddb47aa5e7a31648f9b290af96ad86e92a",
+    "zh:8cdd27d375da6dcb7687f1fed126b7c04efce1671066802ee876dbbc9c66ec79",
+    "zh:be22ae185005690d1a017c1b909e0d80ab567e239b4f06ecacdba85080667c1c",
+    "zh:d2d02e72dbd80f607636cd6237a6c862897caabc635c7b50c0cb243d11246723",
+    "zh:d8f125b66a1eda2555c0f9bbdf12036a5f8d073499a22ca9e4812b68067fea31",
+    "zh:f5a98024c64d5d2973ff15b093725a074c0cb4afde07ef32c542e69f17ac90bc",
+  ]
+}

--- a/pkg/resource/aws/testdata/acc/aws_api_gateway_api_key/terraform.tf
+++ b/pkg/resource/aws/testdata/acc/aws_api_gateway_api_key/terraform.tf
@@ -1,0 +1,21 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = "3.19.0"
+  }
+}
+
+resource "aws_api_gateway_api_key" "foo" {
+    name = "foo"
+    description = "Foo Api Key"
+    enabled = false
+}
+
+resource "aws_api_gateway_api_key" "bar" {
+    name = "bar"
+    description = "Bar Api Key"
+    enabled = false
+}

--- a/pkg/resource/resource_types.go
+++ b/pkg/resource/resource_types.go
@@ -62,6 +62,7 @@ var supportedTypes = map[string]struct{}{
 	"aws_cloudformation_stack":              {},
 	"aws_api_gateway_rest_api":              {},
 	"aws_api_gateway_account":               {},
+	"aws_api_gateway_api_key":               {},
 	"aws_appautoscaling_target":             {},
 	"aws_rds_cluster_instance":              {},
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #960
| ❓ Documentation  | https://github.com/cloudskiff/driftctl-docs/pull/123

## Description

Add `aws_api_gateway_api_key` resource