### PR TITLE
Remove marks from values in the deserializer

### DIFF
--- a/pkg/resource/deserializer.go
+++ b/pkg/resource/deserializer.go
@@ -33,8 +33,12 @@ func (s *Deserializer) DeserializeOne(ty string, value cty.Value) (*Resource, er
 		return nil, nil
 	}
 
+	// Marked values cannot be deserialized to JSON.
+	// For example, this ensures we can deserialize sensitive values too.
+	unmarkedVal, _ := value.UnmarkDeep()
+
 	var attrs Attributes
-	bytes, _ := ctyjson.Marshal(value, value.Type())
+	bytes, _ := ctyjson.Marshal(unmarkedVal, unmarkedVal.Type())
 	err := json.Unmarshal(bytes, &attrs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | https://github.com/cloudskiff/driftctl/issues/947#issuecomment-932175905
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

This PR fixes an issue discovered by @sjourdan caused by sensitives values in Terraform that prevents the resource to be deserialized. Marked values cannot be deserialized, which requires us to unmark the cty value.

![image](https://user-images.githubusercontent.com/16480203/135631020-92bdd555-107a-41c9-8dad-1f8b15be5530.png)
