### PR TITLE
Add api_gateway_stage resource

### DIFF
--- a/pkg/driftctl.go
+++ b/pkg/driftctl.go
@@ -112,6 +112,7 @@ func (d DriftCTL) Run() (*analyser.Analysis, error) {
 		middlewares.NewRDSClusterInstanceExpander(d.resourceFactory),
 		middlewares.NewGoogleLegacyBucketIAMBindings(),
 		middlewares.NewAzurermSubnetExpander(d.resourceFactory),
+		middlewares.NewAwsApiGatewayDeploymentExpander(d.resourceFactory),
 	)
 
 	if !d.opts.StrictMode {

--- a/pkg/iac/terraform/state/terraform_state_reader_test.go
+++ b/pkg/iac/terraform/state/terraform_state_reader_test.go
@@ -153,6 +153,7 @@ func TestTerraformStateReader_AWS_Resources(t *testing.T) {
 		{name: "Api Gateway Account", dirName: "api_gateway_account", wantErr: false},
 		{name: "Api Gateway Api Key", dirName: "api_gateway_api_key", wantErr: false},
 		{name: "Api Gateway authorizer", dirName: "api_gateway_authorizer", wantErr: false},
+		{name: "Api Gateway stage", dirName: "api_gateway_stage", wantErr: false},
 		{name: "AppAutoScaling Targets", dirName: "aws_appautoscaling_target", wantErr: false},
 		{name: "network acl", dirName: "aws_network_acl", wantErr: false},
 		{name: "network acl rule", dirName: "aws_network_acl_rule", wantErr: false},

--- a/pkg/iac/terraform/state/test/api_gateway_stage/results.golden.json
+++ b/pkg/iac/terraform/state/test/api_gateway_stage/results.golden.json
@@ -1,0 +1,40 @@
+[
+ {
+  "Id": "ags-3of73v5ob4-baz",
+  "Type": "aws_api_gateway_stage",
+  "Attrs": {
+   "arn": "arn:aws:apigateway:us-east-1::/restapis/3of73v5ob4/stages/baz",
+   "cache_cluster_enabled": false,
+   "cache_cluster_size": "",
+   "client_certificate_id": "",
+   "deployment_id": "i5bl4e",
+   "description": "",
+   "documentation_version": "",
+   "execution_arn": "arn:aws:execute-api:us-east-1:047081014315:3of73v5ob4/baz",
+   "id": "ags-3of73v5ob4-baz",
+   "invoke_url": "https://3of73v5ob4.execute-api.us-east-1.amazonaws.com/baz",
+   "rest_api_id": "3of73v5ob4",
+   "stage_name": "baz",
+   "xray_tracing_enabled": false
+  }
+ },
+ {
+  "Id": "ags-3of73v5ob4-foo",
+  "Type": "aws_api_gateway_stage",
+  "Attrs": {
+   "arn": "arn:aws:apigateway:us-east-1::/restapis/3of73v5ob4/stages/foo",
+   "cache_cluster_enabled": false,
+   "cache_cluster_size": "",
+   "client_certificate_id": "",
+   "deployment_id": "i5bl4e",
+   "description": "",
+   "documentation_version": "",
+   "execution_arn": "arn:aws:execute-api:us-east-1:047081014315:3of73v5ob4/foo",
+   "id": "ags-3of73v5ob4-foo",
+   "invoke_url": "https://3of73v5ob4.execute-api.us-east-1.amazonaws.com/foo",
+   "rest_api_id": "3of73v5ob4",
+   "stage_name": "foo",
+   "xray_tracing_enabled": false
+  }
+ }
+]

--- a/pkg/iac/terraform/state/test/api_gateway_stage/terraform.tfstate
+++ b/pkg/iac/terraform/state/test/api_gateway_stage/terraform.tfstate
@@ -1,0 +1,81 @@
+{
+  "version": 4,
+  "terraform_version": "1.0.7",
+  "serial": 107,
+  "lineage": "85f5bee6-139e-8db2-ae5d-82aa82f62611",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_api_gateway_stage",
+      "name": "bar",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "access_log_settings": [],
+            "arn": "arn:aws:apigateway:us-east-1::/restapis/3of73v5ob4/stages/baz",
+            "cache_cluster_enabled": false,
+            "cache_cluster_size": "",
+            "client_certificate_id": "",
+            "deployment_id": "i5bl4e",
+            "description": "",
+            "documentation_version": "",
+            "execution_arn": "arn:aws:execute-api:us-east-1:047081014315:3of73v5ob4/baz",
+            "id": "ags-3of73v5ob4-baz",
+            "invoke_url": "https://3of73v5ob4.execute-api.us-east-1.amazonaws.com/baz",
+            "rest_api_id": "3of73v5ob4",
+            "stage_name": "baz",
+            "tags": null,
+            "tags_all": {},
+            "variables": null,
+            "xray_tracing_enabled": false
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_api_gateway_deployment.test",
+            "aws_api_gateway_rest_api.bar"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_api_gateway_stage",
+      "name": "foo",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "access_log_settings": [],
+            "arn": "arn:aws:apigateway:us-east-1::/restapis/3of73v5ob4/stages/foo",
+            "cache_cluster_enabled": false,
+            "cache_cluster_size": "",
+            "client_certificate_id": "",
+            "deployment_id": "i5bl4e",
+            "description": "",
+            "documentation_version": "",
+            "execution_arn": "arn:aws:execute-api:us-east-1:047081014315:3of73v5ob4/foo",
+            "id": "ags-3of73v5ob4-foo",
+            "invoke_url": "https://3of73v5ob4.execute-api.us-east-1.amazonaws.com/foo",
+            "rest_api_id": "3of73v5ob4",
+            "stage_name": "foo",
+            "tags": null,
+            "tags_all": {},
+            "variables": null,
+            "xray_tracing_enabled": false
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_api_gateway_deployment.test",
+            "aws_api_gateway_rest_api.bar"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/middlewares/aws_api_gateway_deployment_expander.go
+++ b/pkg/middlewares/aws_api_gateway_deployment_expander.go
@@ -1,0 +1,44 @@
+package middlewares
+
+import (
+	"strings"
+
+	"github.com/cloudskiff/driftctl/pkg/resource"
+	"github.com/cloudskiff/driftctl/pkg/resource/aws"
+)
+
+// Create a aws_api_gateway_stage resource from a aws_api_gateway_deployment resource and ignore the latter resource
+// since we don't support it
+type AwsApiGatewayDeploymentExpander struct {
+	resourceFactory resource.ResourceFactory
+}
+
+func NewAwsApiGatewayDeploymentExpander(resourceFactory resource.ResourceFactory) AwsApiGatewayDeploymentExpander {
+	return AwsApiGatewayDeploymentExpander{resourceFactory}
+}
+
+func (m AwsApiGatewayDeploymentExpander) Execute(_, resourcesFromState *[]*resource.Resource) error {
+	var newResources []*resource.Resource
+	for _, res := range *resourcesFromState {
+		if res.ResourceType() != aws.AwsApiGatewayDeploymentResourceType {
+			newResources = append(newResources, res)
+			continue
+		}
+
+		stageName := res.Attributes().GetString("stage_name")
+		if stageName == nil || *stageName == "" {
+			continue
+		}
+
+		newStage := m.resourceFactory.CreateAbstractResource(
+			aws.AwsApiGatewayStageResourceType,
+			strings.Join([]string{"ags", *(res.Attributes().GetString("rest_api_id")), *stageName}, "-"),
+			map[string]interface{}{},
+		)
+
+		newResources = append(newResources, newStage)
+	}
+	*resourcesFromState = newResources
+
+	return nil
+}

--- a/pkg/middlewares/aws_api_gateway_deployment_expander_test.go
+++ b/pkg/middlewares/aws_api_gateway_deployment_expander_test.go
@@ -1,0 +1,126 @@
+package middlewares
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/cloudskiff/driftctl/pkg/resource"
+	"github.com/cloudskiff/driftctl/pkg/resource/aws"
+	"github.com/cloudskiff/driftctl/pkg/terraform"
+
+	"github.com/r3labs/diff/v2"
+)
+
+func TestAwsApiGatewayDeploymentExpander_Execute(t *testing.T) {
+	tests := []struct {
+		name               string
+		resourcesFromState []*resource.Resource
+		mocks              func(*terraform.MockResourceFactory)
+		expected           []*resource.Resource
+	}{
+		{
+			name: "no stages created from deployment state resources",
+			resourcesFromState: []*resource.Resource{
+				{
+					Id:   "foo",
+					Type: aws.AwsApiGatewayDeploymentResourceType,
+					Attrs: &resource.Attributes{
+						"rest_api_id": "api",
+					},
+				},
+				{
+					Id:   "bar",
+					Type: aws.AwsApiGatewayDeploymentResourceType,
+					Attrs: &resource.Attributes{
+						"stage_name":  "",
+						"rest_api_id": "api",
+					},
+				},
+				{
+					Id:   "ags-api-baz",
+					Type: aws.AwsApiGatewayStageResourceType,
+					Attrs: &resource.Attributes{
+						"stage_name": "baz",
+					},
+				},
+			},
+			expected: []*resource.Resource{
+				{
+					Id:   "ags-api-baz",
+					Type: aws.AwsApiGatewayStageResourceType,
+					Attrs: &resource.Attributes{
+						"stage_name": "baz",
+					},
+				},
+			},
+		},
+		{
+			name: "stages created from deployment state resources",
+			mocks: func(factory *terraform.MockResourceFactory) {
+				factory.On(
+					"CreateAbstractResource",
+					aws.AwsApiGatewayStageResourceType,
+					"ags-api-foo",
+					map[string]interface{}{},
+				).Once().Return(&resource.Resource{
+					Id:   "ags-api-foo",
+					Type: aws.AwsApiGatewayStageResourceType,
+				})
+			},
+			resourcesFromState: []*resource.Resource{
+				{
+					Id:   "foo",
+					Type: aws.AwsApiGatewayDeploymentResourceType,
+					Attrs: &resource.Attributes{
+						"stage_name":  "foo",
+						"rest_api_id": "api",
+					},
+				},
+				{
+					Id:   "ags-api-baz",
+					Type: aws.AwsApiGatewayStageResourceType,
+					Attrs: &resource.Attributes{
+						"stage_name": "baz",
+					},
+				},
+			},
+			expected: []*resource.Resource{
+				{
+					Id:   "ags-api-baz",
+					Type: aws.AwsApiGatewayStageResourceType,
+					Attrs: &resource.Attributes{
+						"stage_name": "baz",
+					},
+				},
+				{
+					Id:   "ags-api-foo",
+					Type: aws.AwsApiGatewayStageResourceType,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory := &terraform.MockResourceFactory{}
+			if tt.mocks != nil {
+				tt.mocks(factory)
+			}
+
+			m := NewAwsApiGatewayDeploymentExpander(factory)
+			err := m.Execute(&[]*resource.Resource{}, &tt.resourcesFromState)
+			if err != nil {
+				t.Fatal(err)
+			}
+			changelog, err := diff.Diff(tt.expected, tt.resourcesFromState)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(changelog) > 0 {
+				for _, change := range changelog {
+					t.Errorf("%s got = %v, want %v", strings.Join(change.Path, "."), awsutil.Prettify(change.From), awsutil.Prettify(change.To))
+				}
+			}
+		})
+	}
+}

--- a/pkg/remote/api_gateway_scanner_test.go
+++ b/pkg/remote/api_gateway_scanner_test.go
@@ -361,3 +361,100 @@ func TestApiGatewayAuthorizer(t *testing.T) {
 		})
 	}
 }
+
+func TestApiGatewayStage(t *testing.T) {
+	dummyError := errors.New("this is an error")
+	apis := []*apigateway.RestApi{
+		{Id: awssdk.String("3of73v5ob4")},
+	}
+
+	tests := []struct {
+		test           string
+		mocks          func(*repository.MockApiGatewayRepository, *mocks.AlerterInterface)
+		assertExpected func(t *testing.T, got []*resource.Resource)
+		wantErr        error
+	}{
+		{
+			test: "no api gateway stages",
+			mocks: func(repo *repository.MockApiGatewayRepository, alerter *mocks.AlerterInterface) {
+				repo.On("ListAllRestApis").Return(apis, nil)
+				repo.On("ListAllRestApiStages", *apis[0].Id).Return([]*apigateway.Stage{}, nil)
+			},
+			assertExpected: func(t *testing.T, got []*resource.Resource) {
+				assert.Len(t, got, 0)
+			},
+		},
+		{
+			test: "multiple api gateway stages",
+			mocks: func(repo *repository.MockApiGatewayRepository, alerter *mocks.AlerterInterface) {
+				repo.On("ListAllRestApis").Return(apis, nil)
+				repo.On("ListAllRestApiStages", *apis[0].Id).Return([]*apigateway.Stage{
+					{StageName: awssdk.String("foo")},
+					{StageName: awssdk.String("baz")},
+				}, nil)
+			},
+			assertExpected: func(t *testing.T, got []*resource.Resource) {
+				assert.Len(t, got, 2)
+
+				assert.Equal(t, got[0].ResourceId(), "ags-3of73v5ob4-foo")
+				assert.Equal(t, got[0].ResourceType(), resourceaws.AwsApiGatewayStageResourceType)
+
+				assert.Equal(t, got[1].ResourceId(), "ags-3of73v5ob4-baz")
+				assert.Equal(t, got[1].ResourceType(), resourceaws.AwsApiGatewayStageResourceType)
+			},
+		},
+		{
+			test: "cannot list rest apis",
+			mocks: func(repo *repository.MockApiGatewayRepository, alerter *mocks.AlerterInterface) {
+				repo.On("ListAllRestApis").Return(nil, dummyError)
+				alerter.On("SendAlert", resourceaws.AwsApiGatewayStageResourceType, alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, remoteerr.NewResourceListingErrorWithType(dummyError, resourceaws.AwsApiGatewayStageResourceType, resourceaws.AwsApiGatewayRestApiResourceType), alerts.EnumerationPhase)).Return()
+			},
+			wantErr: remoteerr.NewResourceListingErrorWithType(dummyError, resourceaws.AwsApiGatewayStageResourceType, resourceaws.AwsApiGatewayRestApiResourceType),
+		},
+		{
+			test: "cannot list api gateway stages",
+			mocks: func(repo *repository.MockApiGatewayRepository, alerter *mocks.AlerterInterface) {
+				repo.On("ListAllRestApis").Return(apis, nil)
+				repo.On("ListAllRestApiStages", *apis[0].Id).Return(nil, dummyError)
+				alerter.On("SendAlert", resourceaws.AwsApiGatewayStageResourceType, alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, remoteerr.NewResourceListingErrorWithType(dummyError, resourceaws.AwsApiGatewayStageResourceType, resourceaws.AwsApiGatewayStageResourceType), alerts.EnumerationPhase)).Return()
+			},
+			wantErr: remoteerr.NewResourceListingError(dummyError, resourceaws.AwsApiGatewayStageResourceType),
+		},
+	}
+
+	providerVersion := "3.19.0"
+	schemaRepository := testresource.InitFakeSchemaRepository("aws", providerVersion)
+	resourceaws.InitResourcesMetadata(schemaRepository)
+	factory := terraform.NewTerraformResourceFactory(schemaRepository)
+
+	for _, c := range tests {
+		t.Run(c.test, func(tt *testing.T) {
+			scanOptions := ScannerOptions{}
+			remoteLibrary := common.NewRemoteLibrary()
+
+			// Initialize mocks
+			alerter := &mocks.AlerterInterface{}
+			fakeRepo := &repository.MockApiGatewayRepository{}
+			c.mocks(fakeRepo, alerter)
+
+			var repo repository.ApiGatewayRepository = fakeRepo
+
+			remoteLibrary.AddEnumerator(aws.NewApiGatewayStageEnumerator(repo, factory))
+
+			testFilter := &filter.MockFilter{}
+			testFilter.On("IsTypeIgnored", mock.Anything).Return(false)
+
+			s := NewScanner(remoteLibrary, alerter, scanOptions, testFilter)
+			got, err := s.Resources()
+			assert.Equal(tt, err, c.wantErr)
+			if err != nil {
+				return
+			}
+
+			c.assertExpected(tt, got)
+			alerter.AssertExpectations(tt)
+			fakeRepo.AssertExpectations(tt)
+			testFilter.AssertExpectations(tt)
+		})
+	}
+}

--- a/pkg/remote/aws/api_gateway_stage_enumerator.go
+++ b/pkg/remote/aws/api_gateway_stage_enumerator.go
@@ -1,0 +1,57 @@
+package aws
+
+import (
+	"strings"
+
+	"github.com/cloudskiff/driftctl/pkg/remote/aws/repository"
+	remoteerror "github.com/cloudskiff/driftctl/pkg/remote/error"
+	"github.com/cloudskiff/driftctl/pkg/resource"
+	"github.com/cloudskiff/driftctl/pkg/resource/aws"
+)
+
+type ApiGatewayStageEnumerator struct {
+	repository repository.ApiGatewayRepository
+	factory    resource.ResourceFactory
+}
+
+func NewApiGatewayStageEnumerator(repo repository.ApiGatewayRepository, factory resource.ResourceFactory) *ApiGatewayStageEnumerator {
+	return &ApiGatewayStageEnumerator{
+		repository: repo,
+		factory:    factory,
+	}
+}
+
+func (e *ApiGatewayStageEnumerator) SupportedType() resource.ResourceType {
+	return aws.AwsApiGatewayStageResourceType
+}
+
+func (e *ApiGatewayStageEnumerator) Enumerate() ([]*resource.Resource, error) {
+	apis, err := e.repository.ListAllRestApis()
+	if err != nil {
+		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsApiGatewayRestApiResourceType)
+	}
+
+	results := make([]*resource.Resource, 0)
+
+	for _, api := range apis {
+		a := api
+		stages, err := e.repository.ListAllRestApiStages(*a.Id)
+		if err != nil {
+			return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
+		}
+
+		for _, stage := range stages {
+			s := stage
+			results = append(
+				results,
+				e.factory.CreateAbstractResource(
+					string(e.SupportedType()),
+					strings.Join([]string{"ags", *a.Id, *s.StageName}, "-"),
+					map[string]interface{}{},
+				),
+			)
+		}
+
+	}
+	return results, err
+}

--- a/pkg/remote/aws/init.go
+++ b/pkg/remote/aws/init.go
@@ -186,6 +186,7 @@ func Init(version string, alerter *alerter.Alerter,
 	remoteLibrary.AddEnumerator(NewApiGatewayAccountEnumerator(apigatewayRepository, factory))
 	remoteLibrary.AddEnumerator(NewApiGatewayApiKeyEnumerator(apigatewayRepository, factory))
 	remoteLibrary.AddEnumerator(NewApiGatewayAuthorizerEnumerator(apigatewayRepository, factory))
+	remoteLibrary.AddEnumerator(NewApiGatewayStageEnumerator(apigatewayRepository, factory))
 
 	remoteLibrary.AddEnumerator(NewAppAutoscalingTargetEnumerator(appAutoScalingRepository, factory))
 	remoteLibrary.AddDetailsFetcher(aws.AwsAppAutoscalingTargetResourceType, common.NewGenericDetailsFetcher(aws.AwsAppAutoscalingTargetResourceType, provider, deserializer))

--- a/pkg/remote/aws/repository/api_gateway_repository_test.go
+++ b/pkg/remote/aws/repository/api_gateway_repository_test.go
@@ -283,3 +283,68 @@ func Test_apigatewayRepository_ListAllRestApiAuthorizers(t *testing.T) {
 		})
 	}
 }
+
+func Test_apigatewayRepository_ListAllRestApiStages(t *testing.T) {
+	api := &apigateway.RestApi{
+		Id: aws.String("restapi1"),
+	}
+
+	apiStages := []*apigateway.Stage{
+		{StageName: aws.String("stage1")},
+		{StageName: aws.String("stage2")},
+		{StageName: aws.String("stage3")},
+		{StageName: aws.String("stage4")},
+	}
+
+	tests := []struct {
+		name    string
+		mocks   func(client *awstest.MockFakeApiGateway, store *cache.MockCache)
+		want    []*apigateway.Stage
+		wantErr error
+	}{
+		{
+			name: "list multiple rest api stages",
+			mocks: func(client *awstest.MockFakeApiGateway, store *cache.MockCache) {
+				client.On("GetStages",
+					&apigateway.GetStagesInput{
+						RestApiId: aws.String("restapi1"),
+					}).Return(&apigateway.GetStagesOutput{Item: apiStages}, nil).Once()
+
+				store.On("Get", "apigatewayListAllRestApiStages_api_restapi1").Return(nil).Times(1)
+				store.On("Put", "apigatewayListAllRestApiStages_api_restapi1", apiStages).Return(false).Times(1)
+			},
+			want: apiStages,
+		},
+		{
+			name: "should hit cache",
+			mocks: func(client *awstest.MockFakeApiGateway, store *cache.MockCache) {
+				store.On("Get", "apigatewayListAllRestApiStages_api_restapi1").Return(apiStages).Times(1)
+			},
+			want: apiStages,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &cache.MockCache{}
+			client := &awstest.MockFakeApiGateway{}
+			tt.mocks(client, store)
+			r := &apigatewayRepository{
+				client: client,
+				cache:  store,
+			}
+			got, err := r.ListAllRestApiStages(*api.Id)
+			assert.Equal(t, tt.wantErr, err)
+
+			changelog, err := diff.Diff(got, tt.want)
+			assert.Nil(t, err)
+			if len(changelog) > 0 {
+				for _, change := range changelog {
+					t.Errorf("%s: %s -> %s", strings.Join(change.Path, "."), change.From, change.To)
+				}
+				t.Fail()
+			}
+			store.AssertExpectations(t)
+			client.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/remote/aws/repository/mock_ApiGatewayRepository.go
+++ b/pkg/remote/aws/repository/mock_ApiGatewayRepository.go
@@ -81,6 +81,29 @@ func (_m *MockApiGatewayRepository) ListAllRestApiAuthorizers(_a0 []*apigateway.
 	return r0, r1
 }
 
+// ListAllRestApiStages provides a mock function with given fields: _a0
+func (_m *MockApiGatewayRepository) ListAllRestApiStages(_a0 string) ([]*apigateway.Stage, error) {
+	ret := _m.Called(_a0)
+
+	var r0 []*apigateway.Stage
+	if rf, ok := ret.Get(0).(func(string) []*apigateway.Stage); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*apigateway.Stage)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListAllRestApis provides a mock function with given fields:
 func (_m *MockApiGatewayRepository) ListAllRestApis() ([]*apigateway.RestApi, error) {
 	ret := _m.Called()

--- a/pkg/resource/aws/aws_api_gateway_deployment.go
+++ b/pkg/resource/aws/aws_api_gateway_deployment.go
@@ -1,0 +1,3 @@
+package aws
+
+const AwsApiGatewayDeploymentResourceType = "aws_api_gateway_deployment"

--- a/pkg/resource/aws/aws_api_gateway_stage.go
+++ b/pkg/resource/aws/aws_api_gateway_stage.go
@@ -1,0 +1,3 @@
+package aws
+
+const AwsApiGatewayStageResourceType = "aws_api_gateway_stage"

--- a/pkg/resource/aws/aws_api_gateway_stage_test.go
+++ b/pkg/resource/aws/aws_api_gateway_stage_test.go
@@ -1,0 +1,30 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/cloudskiff/driftctl/test"
+	"github.com/cloudskiff/driftctl/test/acceptance"
+)
+
+func TestAcc_Aws_ApiGatewayStage(t *testing.T) {
+	acceptance.Run(t, acceptance.AccTestCase{
+		TerraformVersion: "0.15.5",
+		Paths:            []string{"./testdata/acc/aws_api_gateway_stage"},
+		Args:             []string{"scan", "--filter", "Type=='aws_api_gateway_stage'"},
+		Checks: []acceptance.AccCheck{
+			{
+				Env: map[string]string{
+					"AWS_REGION": "us-east-1",
+				},
+				Check: func(result *test.ScanResult, stdout string, err error) {
+					if err != nil {
+						t.Fatal(err)
+					}
+					result.AssertInfrastructureIsInSync()
+					result.AssertManagedCount(2)
+				},
+			},
+		},
+	})
+}

--- a/pkg/resource/aws/testdata/acc/aws_api_gateway_stage/.terraform.lock.hcl
+++ b/pkg/resource/aws/testdata/acc/aws_api_gateway_stage/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.19.0"
+  constraints = "3.19.0"
+  hashes = [
+    "h1:xur9tF49NgsovNnmwmBR8RdpN8Fcg1TD4CKQPJD6n1A=",
+    "zh:185a5259153eb9ee4699d4be43b3d509386b473683392034319beee97d470c3b",
+    "zh:2d9a0a01f93e8d16539d835c02b8b6e1927b7685f4076e96cb07f7dd6944bc6c",
+    "zh:703f6da36b1b5f3497baa38fccaa7765fb8a2b6440344e4c97172516b49437dd",
+    "zh:770855565462abadbbddd98cb357d2f1a8f30f68a358cb37cbd5c072cb15b377",
+    "zh:8008db43149fe4345301f81e15e6d9ddb47aa5e7a31648f9b290af96ad86e92a",
+    "zh:8cdd27d375da6dcb7687f1fed126b7c04efce1671066802ee876dbbc9c66ec79",
+    "zh:be22ae185005690d1a017c1b909e0d80ab567e239b4f06ecacdba85080667c1c",
+    "zh:d2d02e72dbd80f607636cd6237a6c862897caabc635c7b50c0cb243d11246723",
+    "zh:d8f125b66a1eda2555c0f9bbdf12036a5f8d073499a22ca9e4812b68067fea31",
+    "zh:f5a98024c64d5d2973ff15b093725a074c0cb4afde07ef32c542e69f17ac90bc",
+  ]
+}

--- a/pkg/resource/aws/testdata/acc/aws_api_gateway_stage/terraform.tf
+++ b/pkg/resource/aws/testdata/acc/aws_api_gateway_stage/terraform.tf
@@ -1,0 +1,53 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = "3.19.0"
+  }
+}
+
+resource "aws_api_gateway_rest_api" "foo" {
+    name        = "foo"
+    description = "This is foo API"
+    body = jsonencode({
+        openapi = "3.0.1"
+        info = {
+            title   = "example"
+            version = "1.0"
+        }
+        paths = {
+            "/path1" = {
+                get = {
+                    x-amazon-apigateway-integration = {
+                        httpMethod           = "GET"
+                        payloadFormatVersion = "1.0"
+                        type                 = "HTTP_PROXY"
+                        uri                  = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+                    }
+                }
+            }
+        }
+    })
+}
+
+resource "aws_api_gateway_deployment" "foo" {
+    rest_api_id = aws_api_gateway_rest_api.foo.id
+    description = "This is foo deployment"
+    stage_name = "foo"
+    stage_description = "foo stage"
+    variables = {
+        "test" = "Test"
+    }
+}
+
+resource "aws_api_gateway_stage" "foo" {
+    deployment_id = aws_api_gateway_deployment.foo.id
+    rest_api_id   = aws_api_gateway_rest_api.foo.id
+    stage_name    = "bar"
+}
+
+resource "aws_api_gateway_deployment" "bar" {
+    rest_api_id = aws_api_gateway_rest_api.foo.id
+}

--- a/pkg/resource/resource_types.go
+++ b/pkg/resource/resource_types.go
@@ -64,6 +64,8 @@ var supportedTypes = map[string]struct{}{
 	"aws_api_gateway_account":               {},
 	"aws_api_gateway_api_key":               {},
 	"aws_api_gateway_authorizer":            {},
+	"aws_api_gateway_deployment":            {},
+	"aws_api_gateway_stage":                 {},
 	"aws_appautoscaling_target":             {},
 	"aws_rds_cluster_instance":              {},
 	"aws_appautoscaling_policy":             {},


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #960
| ❓ Documentation  | https://github.com/cloudskiff/driftctl-docs/pull/134

## Description

Add `aws_api_gateway_stage` resource.

The middleware is needed to avoid missing stages created inline by `aws_api_gateway_deployment`, a resource dropped from our last voice call last week with @eliecharra and @sjourdan