### PR TITLE
Fix acceptance test for azurerm_container_registry

### DIFF
--- a/pkg/resource/azurerm/azurerm_container_registry_test.go
+++ b/pkg/resource/azurerm/azurerm_container_registry_test.go
@@ -14,7 +14,7 @@ func TestAcc_Azure_ContainerRegistry(t *testing.T) {
 		Args: []string{
 			"scan",
 			"--to", "azure+tf",
-			"--filter", "Type=='azurerm_container_registry' && contains(Id, 'containerRegistry198745268459')",
+			"--filter", "Type=='azurerm_container_registry' && contains(Id, 'containerRegistryAcc')",
 		},
 		Checks: []acceptance.AccCheck{
 			{

--- a/pkg/resource/azurerm/testdata/acc/azurerm_container_registry/.terraform.lock.hcl
+++ b/pkg/resource/azurerm/testdata/acc/azurerm_container_registry/.terraform.lock.hcl
@@ -19,3 +19,21 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:d1e8c9b507e2d187ea2447ae156028ba3f76db2164674761987c14217d04fee5",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/pkg/resource/azurerm/testdata/acc/azurerm_container_registry/terraform.tf
+++ b/pkg/resource/azurerm/testdata/acc/azurerm_container_registry/terraform.tf
@@ -1,25 +1,31 @@
 terraform {
-    required_providers {
-        azurerm = {
-            source  = "hashicorp/azurerm"
-            version = "~> 2.71.0"
-        }
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.71.0"
     }
+  }
 }
 
 provider "azurerm" {
-    features {}
+  features {}
 }
 
 data "azurerm_resource_group" "qa1" {
-    name = "driftctl-qa-1"
+  name = "driftctl-qa-1"
+}
+
+resource "random_string" "suffix" {
+  length  = 12
+  upper   = false
+  special = false
 }
 
 resource "azurerm_container_registry" "acr" {
-    name                = "containerRegistry198745268459"
-    resource_group_name = data.azurerm_resource_group.qa1.name
-    location            = data.azurerm_resource_group.qa1.location
-    sku                 = "Premium"
-    admin_enabled       = false
-    georeplications = []
+  name                = "containerRegistryAcc${random_string.suffix.result}"
+  resource_group_name = data.azurerm_resource_group.qa1.name
+  location            = data.azurerm_resource_group.qa1.location
+  sku                 = "Premium"
+  admin_enabled       = false
+  georeplications     = []
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

ACC tests were broken after merging #1093 because the resource id needs to be globally unique.