### PR TITLE
Add ScalableDimension field in the scan output

### DIFF
--- a/pkg/resource/aws/aws_appautoscaling_policy.go
+++ b/pkg/resource/aws/aws_appautoscaling_policy.go
@@ -13,5 +13,12 @@ func initAwsAppAutoscalingPolicyMetaData(resourceSchemaRepository resource.Schem
 			"scalable_dimension": *res.Attributes().GetString("scalable_dimension"),
 		}
 	})
+	resourceSchemaRepository.SetHumanReadableAttributesFunc(AwsAppAutoscalingPolicyResourceType, func(res *resource.Resource) map[string]string {
+		attrs := make(map[string]string)
+		if v := res.Attributes().GetString("scalable_dimension"); v != nil && *v != "" {
+			attrs["Scalable dimension"] = *v
+		}
+		return attrs
+	})
 	resourceSchemaRepository.SetFlags(AwsAppAutoscalingPolicyResourceType, resource.FlagDeepMode)
 }

--- a/pkg/resource/aws/aws_appautoscaling_target.go
+++ b/pkg/resource/aws/aws_appautoscaling_target.go
@@ -11,4 +11,11 @@ func initAwsAppAutoscalingTargetMetaData(resourceSchemaRepository resource.Schem
 			"scalable_dimension": *res.Attributes().GetString("scalable_dimension"),
 		}
 	})
+	resourceSchemaRepository.SetHumanReadableAttributesFunc(AwsAppAutoscalingTargetResourceType, func(res *resource.Resource) map[string]string {
+		attrs := make(map[string]string)
+		if v := res.Attributes().GetString("scalable_dimension"); v != nil && *v != "" {
+			attrs["Scalable dimension"] = *v
+		}
+		return attrs
+	})
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | yes <!-- does this require documentation update ? -->

## Description

As reported by @sjourdan, when user has an unmanaged dynamodb table (or similar resource), since the AWS console enables autoscaling by default, they may have unmanaged `aws_appautoscaling_policy` and `aws_appautoscaling_target` as well. Since autoscaling perform on two factors : Read and Write capacity, it's expected to have two policies and two targets created. But the output doesn't make it obvious for the user. So I added the Scalable dimension field in the output so the user can understand why there's two resources of the same type.

Before:

```
Found resources not covered by IaC:
  aws_appautoscaling_policy:
    - $yadda123-scaling-policy
    - $yadda123-scaling-policy
  aws_appautoscaling_target:
    - table/yadda123
    - table/yadda123
  aws_dynamodb_table:
    - yadda123
```

After:

```
Found resources not covered by IaC:
  aws_appautoscaling_policy:
    - $yadda123-scaling-policy
        Scalable dimension: dynamodb:table:ReadCapacityUnits
    - $yadda123-scaling-policy
        Scalable dimension: dynamodb:table:WriteCapacityUnits
  aws_appautoscaling_target:
    - table/yadda123
        Scalable dimension: dynamodb:table:ReadCapacityUnits
    - table/yadda123
        Scalable dimension: dynamodb:table:WriteCapacityUnits
  aws_dynamodb_table:
    - yadda123
```