### PR TITLE
Add resource type hierarchy for smart ignore

### DIFF
--- a/pkg/filter/testdata/drift_ignore_type/.driftignore
+++ b/pkg/filter/testdata/drift_ignore_type/.driftignore
@@ -1,0 +1,3 @@
+type
+type_2
+type_3.*

--- a/pkg/filter/testdata/drift_ignore_type/.driftignore_child_1
+++ b/pkg/filter/testdata/drift_ignore_type/.driftignore_child_1
@@ -1,0 +1,3 @@
+*
+!aws_route
+!non_ignored_type.*

--- a/pkg/filter/testdata/drift_ignore_type/.driftignore_child_2
+++ b/pkg/filter/testdata/drift_ignore_type/.driftignore_child_2
@@ -1,0 +1,3 @@
+*
+!aws_iam_user_policy_attachment
+!non_ignored_type.*

--- a/pkg/resource/resource_types.go
+++ b/pkg/resource/resource_types.go
@@ -2,77 +2,124 @@ package resource
 
 type ResourceType string
 
-var supportedTypes = map[string]struct{}{
-	"aws_ami":                               {},
-	"aws_cloudfront_distribution":           {},
-	"aws_db_instance":                       {},
-	"aws_db_subnet_group":                   {},
-	"aws_default_network_acl":               {},
-	"aws_default_route_table":               {},
-	"aws_default_security_group":            {},
-	"aws_default_subnet":                    {},
-	"aws_default_vpc":                       {},
-	"aws_dynamodb_table":                    {},
-	"aws_ebs_snapshot":                      {},
-	"aws_ebs_volume":                        {},
-	"aws_ecr_repository":                    {},
-	"aws_eip":                               {},
-	"aws_eip_association":                   {},
-	"aws_iam_access_key":                    {},
-	"aws_iam_policy":                        {},
-	"aws_iam_policy_attachment":             {},
-	"aws_iam_role":                          {},
-	"aws_iam_role_policy":                   {},
-	"aws_iam_role_policy_attachment":        {},
-	"aws_iam_user":                          {},
-	"aws_iam_user_policy":                   {},
-	"aws_iam_user_policy_attachment":        {},
-	"aws_instance":                          {},
-	"aws_internet_gateway":                  {},
-	"aws_key_pair":                          {},
-	"aws_kms_alias":                         {},
-	"aws_kms_key":                           {},
-	"aws_lambda_event_source_mapping":       {},
-	"aws_lambda_function":                   {},
-	"aws_nat_gateway":                       {},
-	"aws_network_acl":                       {},
-	"aws_network_acl_rule":                  {},
-	"aws_route":                             {},
-	"aws_route53_health_check":              {},
-	"aws_route53_record":                    {},
-	"aws_route53_zone":                      {},
-	"aws_route_table":                       {},
-	"aws_route_table_association":           {},
-	"aws_s3_bucket":                         {},
+var supportedTypes = map[string]ResourceTypeMeta{
+	"aws_ami":                     {},
+	"aws_cloudfront_distribution": {},
+	"aws_db_instance":             {},
+	"aws_db_subnet_group":         {},
+	"aws_default_network_acl": {children: []ResourceType{
+		"aws_network_acl_rule",
+	}},
+	"aws_default_route_table": {children: []ResourceType{
+		"aws_route",
+	}},
+	"aws_default_security_group": {children: []ResourceType{
+		"aws_security_group_rule",
+	}},
+	"aws_default_subnet": {},
+	"aws_default_vpc": {children: []ResourceType{
+		// VPC are used by aws_internet_gateway to determine if internet gateway is the default one in middleware
+		"aws_internet_gateway",
+	}},
+	"aws_dynamodb_table": {},
+	"aws_ebs_snapshot":   {},
+	"aws_ebs_volume":     {},
+	"aws_ecr_repository": {},
+	"aws_eip": {children: []ResourceType{
+		"aws_eip_association",
+	}},
+	"aws_eip_association":       {},
+	"aws_iam_access_key":        {},
+	"aws_iam_policy":            {},
+	"aws_iam_policy_attachment": {},
+	"aws_iam_role": {children: []ResourceType{
+		"aws_iam_role_policy",
+		"aws_iam_policy_attachment",
+	}},
+	"aws_iam_role_policy": {children: []ResourceType{
+		"aws_iam_role_policy_attachment",
+	}},
+	"aws_iam_role_policy_attachment": {children: []ResourceType{
+		"aws_iam_policy_attachment",
+	}},
+	"aws_iam_user": {children: []ResourceType{
+		"aws_iam_user_policy",
+	}},
+	"aws_iam_user_policy": {children: []ResourceType{
+		"aws_iam_user_policy_attachment",
+	}},
+	"aws_iam_user_policy_attachment": {children: []ResourceType{
+		"aws_iam_policy_attachment",
+	}},
+	"aws_instance": {children: []ResourceType{
+		"aws_ebs_volume",
+	}},
+	"aws_internet_gateway": {children: []ResourceType{
+		// This is used to determine internet gateway default rule
+		"aws_route",
+	}},
+	"aws_key_pair":                    {},
+	"aws_kms_alias":                   {},
+	"aws_kms_key":                     {},
+	"aws_lambda_event_source_mapping": {},
+	"aws_lambda_function":             {},
+	"aws_nat_gateway":                 {},
+	"aws_network_acl": {children: []ResourceType{
+		"aws_network_acl_rule",
+	}},
+	"aws_network_acl_rule":     {},
+	"aws_route":                {},
+	"aws_route53_health_check": {},
+	"aws_route53_record":       {},
+	"aws_route53_zone":         {},
+	"aws_route_table": {children: []ResourceType{
+		"aws_route",
+	}},
+	"aws_route_table_association": {},
+	"aws_s3_bucket": {children: []ResourceType{
+		"aws_s3_bucket_policy",
+	}},
 	"aws_s3_bucket_analytics_configuration": {},
 	"aws_s3_bucket_inventory":               {},
 	"aws_s3_bucket_metric":                  {},
 	"aws_s3_bucket_notification":            {},
 	"aws_s3_bucket_policy":                  {},
-	"aws_security_group":                    {},
-	"aws_security_group_rule":               {},
-	"aws_sns_topic":                         {},
-	"aws_sns_topic_policy":                  {},
-	"aws_sns_topic_subscription":            {},
-	"aws_sqs_queue":                         {},
-	"aws_sqs_queue_policy":                  {},
-	"aws_subnet":                            {},
-	"aws_vpc":                               {},
-	"aws_rds_cluster":                       {},
-	"aws_cloudformation_stack":              {},
-	"aws_api_gateway_rest_api":              {},
-	"aws_api_gateway_account":               {},
-	"aws_api_gateway_api_key":               {},
-	"aws_api_gateway_authorizer":            {},
-	"aws_api_gateway_deployment":            {},
-	"aws_api_gateway_stage":                 {},
-	"aws_api_gateway_resource":              {},
-	"aws_api_gateway_domain_name":           {},
-	"aws_api_gateway_vpc_link":              {},
-	"aws_appautoscaling_target":             {},
-	"aws_rds_cluster_instance":              {},
-	"aws_appautoscaling_policy":             {},
-	"aws_appautoscaling_scheduled_action":   {},
+	"aws_security_group": {children: []ResourceType{
+		"aws_security_group_rule",
+	}},
+	"aws_security_group_rule": {},
+	"aws_sns_topic": {children: []ResourceType{
+		"aws_sns_topic_policy",
+	}},
+	"aws_sns_topic_policy":       {},
+	"aws_sns_topic_subscription": {},
+	"aws_sqs_queue": {children: []ResourceType{
+		"aws_sqs_queue_policy",
+	}},
+	"aws_sqs_queue_policy":     {},
+	"aws_subnet":               {},
+	"aws_vpc":                  {},
+	"aws_rds_cluster":          {},
+	"aws_cloudformation_stack": {},
+	"aws_api_gateway_rest_api": {children: []ResourceType{
+		"aws_api_gateway_resource",
+	}},
+	"aws_api_gateway_account":    {},
+	"aws_api_gateway_api_key":    {},
+	"aws_api_gateway_authorizer": {},
+	"aws_api_gateway_deployment": {children: []ResourceType{
+		"aws_api_gateway_stage",
+	}},
+	"aws_api_gateway_stage":       {},
+	"aws_api_gateway_resource":    {},
+	"aws_api_gateway_domain_name": {},
+	"aws_api_gateway_vpc_link":    {},
+	"aws_appautoscaling_target":   {},
+	"aws_rds_cluster_instance": {children: []ResourceType{
+		"aws_db_instance",
+	}},
+	"aws_appautoscaling_policy":           {},
+	"aws_appautoscaling_scheduled_action": {},
 
 	"github_branch_protection": {},
 	"github_membership":        {},
@@ -80,19 +127,27 @@ var supportedTypes = map[string]struct{}{
 	"github_team":              {},
 	"github_team_membership":   {},
 
-	"google_storage_bucket":             {},
-	"google_compute_firewall":           {},
-	"google_compute_router":             {},
-	"google_compute_instance":           {},
-	"google_compute_network":            {},
-	"google_storage_bucket_iam_binding": {},
-	"google_storage_bucket_iam_member":  {},
-	"google_storage_bucket_iam_policy":  {},
+	"google_storage_bucket":   {},
+	"google_compute_firewall": {},
+	"google_compute_router":   {},
+	"google_compute_instance": {},
+	"google_compute_network":  {},
+	"google_storage_bucket_iam_binding": {children: []ResourceType{
+		"google_storage_bucket_iam_member",
+	}},
+	"google_storage_bucket_iam_member": {},
+	"google_storage_bucket_iam_policy": {children: []ResourceType{
+		"google_storage_bucket_iam_member",
+	}},
 
-	"azurerm_storage_account":    {},
-	"azurerm_storage_container":  {},
-	"azurerm_virtual_network":    {},
-	"azurerm_route_table":        {},
+	"azurerm_storage_account":   {},
+	"azurerm_storage_container": {},
+	"azurerm_virtual_network": {children: []ResourceType{
+		"azurerm_subnet",
+	}},
+	"azurerm_route_table": {children: []ResourceType{
+		"azurerm_route",
+	}},
 	"azurerm_route":              {},
 	"azurerm_resource_group":     {},
 	"azurerm_subnet":             {},
@@ -109,4 +164,16 @@ func IsResourceTypeSupported(ty string) bool {
 
 func (ty ResourceType) String() string {
 	return string(ty)
+}
+
+func GetMeta(ty ResourceType) ResourceTypeMeta {
+	return supportedTypes[ty.String()]
+}
+
+type ResourceTypeMeta struct {
+	children []ResourceType
+}
+
+func (ty ResourceTypeMeta) GetChildrenTypes() []ResourceType {
+	return ty.children
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

This PR add resource type hierarchy. It allows to avoid to ignore a type if at least any of its child type is not ignored.

For example if you ignore everything but `aws_route` then `aws_route_table` should not be ignored too since we need parent resource to be present ( for expander middlewares for example)
**`aws_route` will be ignored in any ways during the analysis part since we use `IsResourceIgnored`**