### PR TITLE
Fix deep mode for aws_rds_cluster_instance

### DIFF
--- a/pkg/middlewares/aws_rds_cluster_instance_expander.go
+++ b/pkg/middlewares/aws_rds_cluster_instance_expander.go
@@ -41,7 +41,7 @@ func (m AwsRDSClusterInstanceExpander) Execute(remoteResources, resourcesFromSta
 			// If the db instance's id matches the rds cluster instance's id, import it in the state
 			if remoteRes.ResourceId() == stateRes.ResourceId() {
 				found = true
-				newDbInstance := m.resourceFactory.CreateAbstractResource(aws.AwsDbInstanceResourceType, stateRes.ResourceId(), *stateRes.Attributes())
+				newDbInstance := m.resourceFactory.CreateAbstractResource(aws.AwsDbInstanceResourceType, remoteRes.ResourceId(), *remoteRes.Attributes())
 				newResourcesFromState = append(newResourcesFromState, newDbInstance)
 				logrus.WithFields(logrus.Fields{
 					"id": newDbInstance.ResourceId(),

--- a/pkg/middlewares/aws_rds_cluster_instance_expander_test.go
+++ b/pkg/middlewares/aws_rds_cluster_instance_expander_test.go
@@ -61,14 +61,18 @@ func TestAwsRDSClusterInstanceExpander_Execute(t *testing.T) {
 					Attrs: &resource.Attributes{},
 				},
 				{
-					Id:    "aurora-cluster-demo-0",
-					Type:  aws.AwsDbInstanceResourceType,
-					Attrs: &resource.Attributes{},
+					Id:   "aurora-cluster-demo-0",
+					Type: aws.AwsDbInstanceResourceType,
+					Attrs: &resource.Attributes{
+						"field": "test",
+					},
 				},
 				{
-					Id:    "aurora-cluster-demo-1",
-					Type:  aws.AwsDbInstanceResourceType,
-					Attrs: &resource.Attributes{},
+					Id:   "aurora-cluster-demo-1",
+					Type: aws.AwsDbInstanceResourceType,
+					Attrs: &resource.Attributes{
+						"field": "test",
+					},
 				},
 			},
 			stateResources: []*resource.Resource{
@@ -95,42 +99,50 @@ func TestAwsRDSClusterInstanceExpander_Execute(t *testing.T) {
 					Attrs: &resource.Attributes{},
 				},
 				{
-					Id:    "aurora-cluster-demo-0",
-					Type:  aws.AwsDbInstanceResourceType,
-					Attrs: &resource.Attributes{},
+					Id:   "aurora-cluster-demo-0",
+					Type: aws.AwsDbInstanceResourceType,
+					Attrs: &resource.Attributes{
+						"field": "test",
+					},
 				},
 				{
-					Id:    "aurora-cluster-demo-1",
-					Type:  aws.AwsDbInstanceResourceType,
-					Attrs: &resource.Attributes{},
+					Id:   "aurora-cluster-demo-1",
+					Type: aws.AwsDbInstanceResourceType,
+					Attrs: &resource.Attributes{
+						"field": "test",
+					},
 				},
 			},
 			expectedStateResources: []*resource.Resource{
 				{
-					Id:    "aurora-cluster-demo-0",
-					Type:  aws.AwsDbInstanceResourceType,
-					Attrs: &resource.Attributes{},
+					Id:   "aurora-cluster-demo-0",
+					Type: aws.AwsDbInstanceResourceType,
+					Attrs: &resource.Attributes{
+						"field": "test",
+					},
 				},
 				{
-					Id:    "aurora-cluster-demo-1",
-					Type:  aws.AwsDbInstanceResourceType,
-					Attrs: &resource.Attributes{},
+					Id:   "aurora-cluster-demo-1",
+					Type: aws.AwsDbInstanceResourceType,
+					Attrs: &resource.Attributes{
+						"field": "test",
+					},
 				},
 			},
 			mock: func(factory *terraform.MockResourceFactory) {
-				factory.On("CreateAbstractResource", aws.AwsDbInstanceResourceType, "aurora-cluster-demo-0", map[string]interface{}{}).
+				factory.On("CreateAbstractResource", aws.AwsDbInstanceResourceType, "aurora-cluster-demo-0", map[string]interface{}{"field": "test"}).
 					Return(&resource.Resource{
 						Id:    "aurora-cluster-demo-0",
 						Type:  aws.AwsDbInstanceResourceType,
-						Attrs: &resource.Attributes{},
+						Attrs: &resource.Attributes{"field": "test"},
 					}).
 					Once()
 
-				factory.On("CreateAbstractResource", aws.AwsDbInstanceResourceType, "aurora-cluster-demo-1", map[string]interface{}{}).
+				factory.On("CreateAbstractResource", aws.AwsDbInstanceResourceType, "aurora-cluster-demo-1", map[string]interface{}{"field": "test"}).
 					Return(&resource.Resource{
 						Id:    "aurora-cluster-demo-1",
 						Type:  aws.AwsDbInstanceResourceType,
-						Attrs: &resource.Attributes{},
+						Attrs: &resource.Attributes{"field": "test"},
 					}).
 					Once()
 			},

--- a/pkg/resource/aws/aws_rds_cluster_instance_test.go
+++ b/pkg/resource/aws/aws_rds_cluster_instance_test.go
@@ -1,0 +1,30 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/cloudskiff/driftctl/test"
+	"github.com/cloudskiff/driftctl/test/acceptance"
+)
+
+func TestAcc_Aws_RDSClusterInstance(t *testing.T) {
+	acceptance.Run(t, acceptance.AccTestCase{
+		TerraformVersion: "0.15.5",
+		Paths:            []string{"./testdata/acc/aws_rds_cluster_instance"},
+		Args:             []string{"scan", "--deep"},
+		Checks: []acceptance.AccCheck{
+			{
+				Env: map[string]string{
+					"AWS_REGION": "us-east-1",
+				},
+				Check: func(result *test.ScanResult, stdout string, err error) {
+					if err != nil {
+						t.Fatal(err)
+					}
+					result.AssertInfrastructureIsInSync()
+					result.AssertManagedCount(2)
+				},
+			},
+		},
+	})
+}

--- a/pkg/resource/aws/testdata/acc/aws_rds_cluster_instance/.driftignore
+++ b/pkg/resource/aws/testdata/acc/aws_rds_cluster_instance/.driftignore
@@ -1,0 +1,2 @@
+*
+!aws_db_instance

--- a/pkg/resource/aws/testdata/acc/aws_rds_cluster_instance/.terraform.lock.hcl
+++ b/pkg/resource/aws/testdata/acc/aws_rds_cluster_instance/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.19.0"
+  constraints = "3.19.0"
+  hashes = [
+    "h1:+7Vi7p13+cnrxjXbfJiTimGSFR97xCaQwkkvWcreLns=",
+    "zh:185a5259153eb9ee4699d4be43b3d509386b473683392034319beee97d470c3b",
+    "zh:2d9a0a01f93e8d16539d835c02b8b6e1927b7685f4076e96cb07f7dd6944bc6c",
+    "zh:703f6da36b1b5f3497baa38fccaa7765fb8a2b6440344e4c97172516b49437dd",
+    "zh:770855565462abadbbddd98cb357d2f1a8f30f68a358cb37cbd5c072cb15b377",
+    "zh:8008db43149fe4345301f81e15e6d9ddb47aa5e7a31648f9b290af96ad86e92a",
+    "zh:8cdd27d375da6dcb7687f1fed126b7c04efce1671066802ee876dbbc9c66ec79",
+    "zh:be22ae185005690d1a017c1b909e0d80ab567e239b4f06ecacdba85080667c1c",
+    "zh:d2d02e72dbd80f607636cd6237a6c862897caabc635c7b50c0cb243d11246723",
+    "zh:d8f125b66a1eda2555c0f9bbdf12036a5f8d073499a22ca9e4812b68067fea31",
+    "zh:f5a98024c64d5d2973ff15b093725a074c0cb4afde07ef32c542e69f17ac90bc",
+  ]
+}

--- a/pkg/resource/aws/testdata/acc/aws_rds_cluster_instance/terraform.tf
+++ b/pkg/resource/aws/testdata/acc/aws_rds_cluster_instance/terraform.tf
@@ -1,0 +1,30 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = "3.19.0"
+  }
+}
+
+resource "aws_rds_cluster" "postgresql" {
+  cluster_identifier      = "aurora-cluster-demo"
+  engine                  = "aurora-postgresql"
+  availability_zones      = ["us-east-1a", "us-east-1b", "us-east-1d"]
+  database_name           = "mydb"
+  master_username         = "foo"
+  master_password         = "bar12345678"
+  backup_retention_period = 5
+  preferred_backup_window = "07:00-09:00"
+  skip_final_snapshot     = true
+}
+
+resource "aws_rds_cluster_instance" "cluster_instances" {
+  count              = 2
+  identifier         = "aurora-cluster-demo-${count.index}"
+  cluster_identifier = aws_rds_cluster.postgresql.id
+  instance_class     = "db.r4.large"
+  engine             = aws_rds_cluster.postgresql.engine
+  engine_version     = aws_rds_cluster.postgresql.engine_version
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | https://github.com/cloudskiff/driftctl/issues/947#issuecomment-932373190
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

As reported by @sjourdan , there was a deep mode issue with `aws_rds_cluster_instance` resources. The scan was showing false positives on attributes. This was due to the extended db instance having the cluster instance's attributes, instead of its own attributes.