### PR TITLE
Fix azure provider configuration

### DIFF
--- a/pkg/remote/azurerm/common/config.go
+++ b/pkg/remote/azurerm/common/config.go
@@ -1,5 +1,8 @@
 package common
 
 type AzureProviderConfig struct {
-	SubscriptionID string
+	SubscriptionID,
+	ClientID,
+	TenantID,
+	ClientSecret string
 }

--- a/pkg/remote/azurerm/provider.go
+++ b/pkg/remote/azurerm/provider.go
@@ -36,6 +36,15 @@ func NewAzureTerraformProvider(version string, progress output.Progress, configD
 
 	tfProvider, err := terraform.NewTerraformProvider(installer, terraform.TerraformProviderConfig{
 		Name: p.name,
+		GetProviderConfig: func(_ string) interface{} {
+			c := p.GetConfig()
+			return map[string]string{
+				"subscription_id": c.SubscriptionID,
+				"tenant_id":       c.TenantID,
+				"client_id":       c.ClientID,
+				"client_secret":   c.ClientSecret,
+			}
+		},
 	}, progress)
 	if err != nil {
 		return nil, err
@@ -47,6 +56,9 @@ func NewAzureTerraformProvider(version string, progress output.Progress, configD
 func (p *AzureTerraformProvider) GetConfig() common.AzureProviderConfig {
 	return common.AzureProviderConfig{
 		SubscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
+		TenantID:       os.Getenv("AZURE_TENANT_ID"),
+		ClientID:       os.Getenv("AZURE_CLIENT_ID"),
+		ClientSecret:   os.Getenv("AZURE_CLIENT_SECRET"),
 	}
 }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Since we now configure the provider (https://github.com/cloudskiff/driftctl/pull/1139), it seems that it try to fallback to azure CLI, and when CLI is not installed it fail.
I have choosen to configure explicitly the provider.