### PR TITLE
Fix test provider configuration

### DIFF
--- a/test/terraform/provider.go
+++ b/test/terraform/provider.go
@@ -25,7 +25,7 @@ func InitTestAwsProvider(providerLibrary *terraform.ProviderLibrary, version str
 func InitTestGithubProvider(providerLibrary *terraform.ProviderLibrary, version string) (*github.GithubTerraformProvider, error) {
 	progress := &output.MockProgress{}
 	progress.On("Inc").Maybe().Return()
-	provider, err := github.NewGithubTerraformProvider(version, progress, "")
+	provider, err := github.NewGithubTerraformProvider(version, progress, os.TempDir())
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +37,7 @@ func InitTestGithubProvider(providerLibrary *terraform.ProviderLibrary, version 
 func InitTestGoogleProvider(providerLibrary *terraform.ProviderLibrary, version string) (*google.GCPTerraformProvider, error) {
 	progress := &output.MockProgress{}
 	progress.On("Inc").Maybe().Return()
-	provider, err := google.NewGCPTerraformProvider(version, progress, "")
+	provider, err := google.NewGCPTerraformProvider(version, progress, os.TempDir())
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func InitTestGoogleProvider(providerLibrary *terraform.ProviderLibrary, version 
 func InitTestAzureProvider(providerLibrary *terraform.ProviderLibrary, version string) (*azurerm.AzureTerraformProvider, error) {
 	progress := &output.MockProgress{}
 	progress.On("Inc").Maybe().Return()
-	provider, err := azurerm.NewAzureTerraformProvider(version, progress, "")
+	provider, err := azurerm.NewAzureTerraformProvider(version, progress, os.TempDir())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

When running scanner tests with the `-update` flag, the provider (except AWS) is initialized with an empty config dir, which means we install the plugins in the current directory, generating unwanted git diffs.

```
$ git status
On branch feat/add_azurerm_ssh_public_key
Your branch is up to date with 'origin/feat/add_azurerm_ssh_public_key'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	pkg/remote/.driftctl/

no changes added to commit (use "git add" and/or "git commit -a")
```