### PR TITLE
sort resource before assertion in azure private dns scan test because it was flaky

### DIFF
--- a/pkg/remote/azurerm_privatedns_scanner_test.go
+++ b/pkg/remote/azurerm_privatedns_scanner_test.go
@@ -108,6 +108,7 @@ func TestAzurermPrivateDNSZone(t *testing.T) {
 				return
 			}
 
+			got = resource.Sort(got)
 			c.assertExpected(tt, got)
 			alerter.AssertExpectations(tt)
 			fakeRepo.AssertExpectations(tt)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->