### PR TITLE
Fix ACC test for google_compute_subnetwork

### DIFF
--- a/pkg/resource/google/testdata/acc/google_compute_subnetwork/terraform.tf
+++ b/pkg/resource/google/testdata/acc/google_compute_subnetwork/terraform.tf
@@ -10,15 +10,15 @@ terraform {
 }
 
 resource "random_string" "net-id" {
-    length  = 12
-    upper   = false
-    special = false
+  length  = 12
+  upper   = false
+  special = false
 }
 
 resource "random_string" "subnet-id" {
-    length  = 12
-    upper   = false
-    special = false
+  length  = 12
+  upper   = false
+  special = false
 }
 
 resource "google_compute_network" "default" {
@@ -30,6 +30,7 @@ resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" 
   name          = "driftctl-acc-subnet-${random_string.subnet-id.result}"
   ip_cidr_range = "10.2.0.0/16"
   network       = google_compute_network.default.id
+  region        = "us-central1"
   secondary_ip_range {
     range_name    = "tf-test-secondary-range-update1"
     ip_cidr_range = "192.168.10.0/24"


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

ACC test for this resource was failing

![image](https://user-images.githubusercontent.com/16480203/139032363-d391c79b-d5f8-4775-a55e-827b38dd472d.png)

This PR adds missing region argument to subnetwork resource.