### PR TITLE
Fix resources slice make init

### DIFF
--- a/pkg/remote/aws/api_gateway_account_enumerator.go
+++ b/pkg/remote/aws/api_gateway_account_enumerator.go
@@ -29,7 +29,7 @@ func (e *ApiGatewayAccountEnumerator) Enumerate() ([]*resource.Resource, error) 
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, 1)
+	results := make([]*resource.Resource, 0, 1)
 
 	if account != nil {
 		results = append(

--- a/pkg/remote/aws/api_gateway_api_key_enumerator.go
+++ b/pkg/remote/aws/api_gateway_api_key_enumerator.go
@@ -29,7 +29,7 @@ func (e *ApiGatewayApiKeyEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(keys))
+	results := make([]*resource.Resource, 0, len(keys))
 
 	for _, key := range keys {
 		results = append(

--- a/pkg/remote/aws/api_gateway_domain_name_enumerator.go
+++ b/pkg/remote/aws/api_gateway_domain_name_enumerator.go
@@ -29,7 +29,7 @@ func (e *ApiGatewayDomainNameEnumerator) Enumerate() ([]*resource.Resource, erro
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(domainNames))
+	results := make([]*resource.Resource, 0, len(domainNames))
 
 	for _, domainName := range domainNames {
 		results = append(

--- a/pkg/remote/aws/api_gateway_rest_api_enumerator.go
+++ b/pkg/remote/aws/api_gateway_rest_api_enumerator.go
@@ -29,7 +29,7 @@ func (e *ApiGatewayRestApiEnumerator) Enumerate() ([]*resource.Resource, error) 
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(apis))
+	results := make([]*resource.Resource, 0, len(apis))
 
 	for _, api := range apis {
 		results = append(

--- a/pkg/remote/aws/api_gateway_vpc_link_enumerator.go
+++ b/pkg/remote/aws/api_gateway_vpc_link_enumerator.go
@@ -29,7 +29,7 @@ func (e *ApiGatewayVpcLinkEnumerator) Enumerate() ([]*resource.Resource, error) 
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(vpcLinks))
+	results := make([]*resource.Resource, 0, len(vpcLinks))
 
 	for _, vpcLink := range vpcLinks {
 		results = append(

--- a/pkg/remote/aws/appautoscaling_target_enumerator.go
+++ b/pkg/remote/aws/appautoscaling_target_enumerator.go
@@ -35,7 +35,7 @@ func (e *AppAutoscalingTargetEnumerator) Enumerate() ([]*resource.Resource, erro
 		targets = append(targets, results...)
 	}
 
-	results := make([]*resource.Resource, len(targets))
+	results := make([]*resource.Resource, 0, len(targets))
 
 	for _, target := range targets {
 		results = append(

--- a/pkg/remote/aws/cloudformation_stack_enumerator.go
+++ b/pkg/remote/aws/cloudformation_stack_enumerator.go
@@ -30,7 +30,7 @@ func (e *CloudformationStackEnumerator) Enumerate() ([]*resource.Resource, error
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(stacks))
+	results := make([]*resource.Resource, 0, len(stacks))
 
 	for _, stack := range stacks {
 		attrs := map[string]interface{}{}

--- a/pkg/remote/aws/cloudfront_distribution_enumerator.go
+++ b/pkg/remote/aws/cloudfront_distribution_enumerator.go
@@ -29,7 +29,7 @@ func (e *CloudfrontDistributionEnumerator) Enumerate() ([]*resource.Resource, er
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(distributions))
+	results := make([]*resource.Resource, 0, len(distributions))
 
 	for _, distribution := range distributions {
 		results = append(

--- a/pkg/remote/aws/dynamodb_table_enumerator.go
+++ b/pkg/remote/aws/dynamodb_table_enumerator.go
@@ -29,7 +29,7 @@ func (e *DynamoDBTableEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(tables))
+	results := make([]*resource.Resource, 0, len(tables))
 
 	for _, table := range tables {
 		results = append(

--- a/pkg/remote/aws/ec2_ami_enumerator.go
+++ b/pkg/remote/aws/ec2_ami_enumerator.go
@@ -29,7 +29,7 @@ func (e *EC2AmiEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(images))
+	results := make([]*resource.Resource, 0, len(images))
 
 	for _, image := range images {
 		results = append(

--- a/pkg/remote/aws/ec2_default_subnet_enumerator.go
+++ b/pkg/remote/aws/ec2_default_subnet_enumerator.go
@@ -29,7 +29,7 @@ func (e *EC2DefaultSubnetEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(defaultSubnets))
+	results := make([]*resource.Resource, 0, len(defaultSubnets))
 
 	for _, subnet := range defaultSubnets {
 		results = append(

--- a/pkg/remote/aws/ec2_ebs_snapshot_enumerator.go
+++ b/pkg/remote/aws/ec2_ebs_snapshot_enumerator.go
@@ -29,7 +29,7 @@ func (e *EC2EbsSnapshotEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(snapshots))
+	results := make([]*resource.Resource, 0, len(snapshots))
 
 	for _, snapshot := range snapshots {
 		results = append(

--- a/pkg/remote/aws/ec2_ebs_volume_enumerator.go
+++ b/pkg/remote/aws/ec2_ebs_volume_enumerator.go
@@ -29,7 +29,7 @@ func (e *EC2EbsVolumeEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(volumes))
+	results := make([]*resource.Resource, 0, len(volumes))
 
 	for _, volume := range volumes {
 		results = append(

--- a/pkg/remote/aws/ec2_eip_enumerator.go
+++ b/pkg/remote/aws/ec2_eip_enumerator.go
@@ -29,7 +29,7 @@ func (e *EC2EipEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(addresses))
+	results := make([]*resource.Resource, 0, len(addresses))
 
 	for _, address := range addresses {
 		results = append(

--- a/pkg/remote/aws/ec2_instance_enumerator.go
+++ b/pkg/remote/aws/ec2_instance_enumerator.go
@@ -29,7 +29,7 @@ func (e *EC2InstanceEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(instances))
+	results := make([]*resource.Resource, 0, len(instances))
 
 	for _, instance := range instances {
 		results = append(

--- a/pkg/remote/aws/ec2_internet_gateway_enumerator.go
+++ b/pkg/remote/aws/ec2_internet_gateway_enumerator.go
@@ -29,7 +29,7 @@ func (e *EC2InternetGatewayEnumerator) Enumerate() ([]*resource.Resource, error)
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(internetGateways))
+	results := make([]*resource.Resource, 0, len(internetGateways))
 
 	for _, internetGateway := range internetGateways {
 		data := map[string]interface{}{}

--- a/pkg/remote/aws/ec2_key_pair_enumerator.go
+++ b/pkg/remote/aws/ec2_key_pair_enumerator.go
@@ -29,7 +29,7 @@ func (e *EC2KeyPairEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(keyPairs))
+	results := make([]*resource.Resource, 0, len(keyPairs))
 
 	for _, keyPair := range keyPairs {
 		results = append(

--- a/pkg/remote/aws/ec2_nat_gateway_enumerator.go
+++ b/pkg/remote/aws/ec2_nat_gateway_enumerator.go
@@ -29,7 +29,7 @@ func (e *EC2NatGatewayEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(natGateways))
+	results := make([]*resource.Resource, 0, len(natGateways))
 
 	for _, natGateway := range natGateways {
 

--- a/pkg/remote/aws/ec2_subnet_enumerator.go
+++ b/pkg/remote/aws/ec2_subnet_enumerator.go
@@ -29,7 +29,7 @@ func (e *EC2SubnetEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(subnets))
+	results := make([]*resource.Resource, 0, len(subnets))
 
 	for _, subnet := range subnets {
 		results = append(

--- a/pkg/remote/aws/ecr_repository_enumerator.go
+++ b/pkg/remote/aws/ecr_repository_enumerator.go
@@ -29,7 +29,7 @@ func (e *ECRRepositoryEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(repos))
+	results := make([]*resource.Resource, 0, len(repos))
 
 	for _, repo := range repos {
 		results = append(

--- a/pkg/remote/aws/iam_policy_enumerator.go
+++ b/pkg/remote/aws/iam_policy_enumerator.go
@@ -30,7 +30,7 @@ func (e *IamPolicyEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(policies))
+	results := make([]*resource.Resource, 0, len(policies))
 
 	for _, policy := range policies {
 		results = append(

--- a/pkg/remote/aws/iam_role_policy_enumerator.go
+++ b/pkg/remote/aws/iam_role_policy_enumerator.go
@@ -37,7 +37,7 @@ func (e *IamRolePolicyEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(policies))
+	results := make([]*resource.Resource, 0, len(policies))
 	for _, policy := range policies {
 		results = append(
 			results,

--- a/pkg/remote/aws/iam_user_enumerator.go
+++ b/pkg/remote/aws/iam_user_enumerator.go
@@ -30,7 +30,7 @@ func (e *IamUserEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(users))
+	results := make([]*resource.Resource, 0, len(users))
 
 	for _, user := range users {
 		results = append(

--- a/pkg/remote/aws/iam_user_policy_enumerator.go
+++ b/pkg/remote/aws/iam_user_policy_enumerator.go
@@ -33,7 +33,7 @@ func (e *IamUserPolicyEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(userPolicies))
+	results := make([]*resource.Resource, 0, len(userPolicies))
 
 	for _, userPolicy := range userPolicies {
 		results = append(

--- a/pkg/remote/aws/kms_alias_enumerator.go
+++ b/pkg/remote/aws/kms_alias_enumerator.go
@@ -29,7 +29,7 @@ func (e *KMSAliasEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(aliases))
+	results := make([]*resource.Resource, 0, len(aliases))
 
 	for _, alias := range aliases {
 		results = append(

--- a/pkg/remote/aws/kms_key_enumerator.go
+++ b/pkg/remote/aws/kms_key_enumerator.go
@@ -29,7 +29,7 @@ func (e *KMSKeyEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(keys))
+	results := make([]*resource.Resource, 0, len(keys))
 
 	for _, key := range keys {
 		results = append(

--- a/pkg/remote/aws/lambda_event_source_mapping_enumerator.go
+++ b/pkg/remote/aws/lambda_event_source_mapping_enumerator.go
@@ -29,7 +29,7 @@ func (e *LambdaEventSourceMappingEnumerator) Enumerate() ([]*resource.Resource, 
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(eventSourceMappings))
+	results := make([]*resource.Resource, 0, len(eventSourceMappings))
 
 	for _, eventSourceMapping := range eventSourceMappings {
 		results = append(

--- a/pkg/remote/aws/lambda_function_enumerator.go
+++ b/pkg/remote/aws/lambda_function_enumerator.go
@@ -29,7 +29,7 @@ func (e *LambdaFunctionEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(functions))
+	results := make([]*resource.Resource, 0, len(functions))
 
 	for _, function := range functions {
 		results = append(

--- a/pkg/remote/aws/rds_cluster_enumerator.go
+++ b/pkg/remote/aws/rds_cluster_enumerator.go
@@ -29,7 +29,7 @@ func (e *RDSClusterEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(clusters))
+	results := make([]*resource.Resource, 0, len(clusters))
 
 	for _, cluster := range clusters {
 		var databaseName string

--- a/pkg/remote/aws/rds_db_instance_enumerator.go
+++ b/pkg/remote/aws/rds_db_instance_enumerator.go
@@ -29,7 +29,7 @@ func (e *RDSDBInstanceEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(instances))
+	results := make([]*resource.Resource, 0, len(instances))
 
 	for _, instance := range instances {
 		results = append(

--- a/pkg/remote/aws/rds_db_subnet_group_enumerator.go
+++ b/pkg/remote/aws/rds_db_subnet_group_enumerator.go
@@ -29,7 +29,7 @@ func (e *RDSDBSubnetGroupEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(subnetGroups))
+	results := make([]*resource.Resource, 0, len(subnetGroups))
 
 	for _, subnetGroup := range subnetGroups {
 		results = append(

--- a/pkg/remote/aws/route53_health_check_enumerator.go
+++ b/pkg/remote/aws/route53_health_check_enumerator.go
@@ -29,7 +29,7 @@ func (e *Route53HealthCheckEnumerator) Enumerate() ([]*resource.Resource, error)
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(healthChecks))
+	results := make([]*resource.Resource, 0, len(healthChecks))
 
 	for _, healthCheck := range healthChecks {
 		results = append(

--- a/pkg/remote/aws/route53_record_enumerator.go
+++ b/pkg/remote/aws/route53_record_enumerator.go
@@ -34,7 +34,7 @@ func (e *Route53RecordEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), resourceaws.AwsRoute53ZoneResourceType)
 	}
 
-	results := make([]*resource.Resource, len(zones))
+	results := make([]*resource.Resource, 0, len(zones))
 
 	for _, hostedZone := range zones {
 		records, err := e.listRecordsForZone(strings.TrimPrefix(*hostedZone.Id, "/hostedzone/"))
@@ -55,7 +55,7 @@ func (e *Route53RecordEnumerator) listRecordsForZone(zoneId string) ([]*resource
 		return nil, err
 	}
 
-	results := make([]*resource.Resource, len(records))
+	results := make([]*resource.Resource, 0, len(records))
 
 	for _, raw := range records {
 		rawType := *raw.Type

--- a/pkg/remote/aws/route53_zone_enumerator.go
+++ b/pkg/remote/aws/route53_zone_enumerator.go
@@ -33,7 +33,7 @@ func (e *Route53ZoneSupplier) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(zones))
+	results := make([]*resource.Resource, 0, len(zones))
 
 	for _, hostedZone := range zones {
 		results = append(

--- a/pkg/remote/aws/s3_bucket_analytic_enumerator.go
+++ b/pkg/remote/aws/s3_bucket_analytic_enumerator.go
@@ -40,7 +40,7 @@ func (e *S3BucketAnalyticEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
 	}
 
-	results := make([]*resource.Resource, len(buckets))
+	results := make([]*resource.Resource, 0, len(buckets))
 
 	for _, bucket := range buckets {
 		region, err := e.repository.GetBucketLocation(*bucket.Name)

--- a/pkg/remote/aws/s3_bucket_enumerator.go
+++ b/pkg/remote/aws/s3_bucket_enumerator.go
@@ -38,7 +38,7 @@ func (e *S3BucketEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(buckets))
+	results := make([]*resource.Resource, 0, len(buckets))
 
 	for _, bucket := range buckets {
 		region, err := e.repository.GetBucketLocation(*bucket.Name)

--- a/pkg/remote/aws/s3_bucket_inventory_enumerator.go
+++ b/pkg/remote/aws/s3_bucket_inventory_enumerator.go
@@ -40,7 +40,7 @@ func (e *S3BucketInventoryEnumerator) Enumerate() ([]*resource.Resource, error) 
 		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
 	}
 
-	results := make([]*resource.Resource, len(buckets))
+	results := make([]*resource.Resource, 0, len(buckets))
 
 	for _, bucket := range buckets {
 		region, err := e.repository.GetBucketLocation(*bucket.Name)

--- a/pkg/remote/aws/s3_bucket_metrics_enumerator.go
+++ b/pkg/remote/aws/s3_bucket_metrics_enumerator.go
@@ -40,7 +40,7 @@ func (e *S3BucketMetricsEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
 	}
 
-	results := make([]*resource.Resource, len(buckets))
+	results := make([]*resource.Resource, 0, len(buckets))
 
 	for _, bucket := range buckets {
 		region, err := e.repository.GetBucketLocation(*bucket.Name)

--- a/pkg/remote/aws/s3_bucket_notification_enumerator.go
+++ b/pkg/remote/aws/s3_bucket_notification_enumerator.go
@@ -38,7 +38,7 @@ func (e *S3BucketNotificationEnumerator) Enumerate() ([]*resource.Resource, erro
 		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
 	}
 
-	results := make([]*resource.Resource, len(buckets))
+	results := make([]*resource.Resource, 0, len(buckets))
 
 	for _, bucket := range buckets {
 		region, err := e.repository.GetBucketLocation(*bucket.Name)

--- a/pkg/remote/aws/s3_bucket_policy_enumerator.go
+++ b/pkg/remote/aws/s3_bucket_policy_enumerator.go
@@ -38,7 +38,7 @@ func (e *S3BucketPolicyEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsS3BucketResourceType)
 	}
 
-	results := make([]*resource.Resource, len(buckets))
+	results := make([]*resource.Resource, 0, len(buckets))
 
 	for _, bucket := range buckets {
 		region, err := e.repository.GetBucketLocation(*bucket.Name)

--- a/pkg/remote/aws/sns_topic_enumerator.go
+++ b/pkg/remote/aws/sns_topic_enumerator.go
@@ -29,7 +29,7 @@ func (e *SNSTopicEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(topics))
+	results := make([]*resource.Resource, 0, len(topics))
 
 	for _, topic := range topics {
 		results = append(

--- a/pkg/remote/aws/sns_topic_policy_enumerator.go
+++ b/pkg/remote/aws/sns_topic_policy_enumerator.go
@@ -29,7 +29,7 @@ func (e *SNSTopicPolicyEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), aws.AwsSnsTopicResourceType)
 	}
 
-	results := make([]*resource.Resource, len(topics))
+	results := make([]*resource.Resource, 0, len(topics))
 
 	for _, topic := range topics {
 		results = append(

--- a/pkg/remote/aws/sns_topic_subscription_enumerator.go
+++ b/pkg/remote/aws/sns_topic_subscription_enumerator.go
@@ -61,7 +61,7 @@ func (e *SNSTopicSubscriptionEnumerator) Enumerate() ([]*resource.Resource, erro
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(allSubscriptions))
+	results := make([]*resource.Resource, 0, len(allSubscriptions))
 
 	for _, subscription := range allSubscriptions {
 		if subscription.SubscriptionArn == nil || !arn.IsARN(*subscription.SubscriptionArn) {

--- a/pkg/remote/aws/sqs_queue_enumerator.go
+++ b/pkg/remote/aws/sqs_queue_enumerator.go
@@ -31,7 +31,7 @@ func (e *SQSQueueEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(queues))
+	results := make([]*resource.Resource, 0, len(queues))
 
 	for _, queue := range queues {
 		results = append(

--- a/pkg/remote/azurerm/azurerm_firewalls_enumerator.go
+++ b/pkg/remote/azurerm/azurerm_firewalls_enumerator.go
@@ -29,7 +29,7 @@ func (e *AzurermFirewallsEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(resources))
+	results := make([]*resource.Resource, 0, len(resources))
 
 	for _, res := range resources {
 		results = append(

--- a/pkg/remote/azurerm/azurerm_public_ip_enumerator.go
+++ b/pkg/remote/azurerm/azurerm_public_ip_enumerator.go
@@ -29,7 +29,7 @@ func (e *AzurermPublicIPEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(resources))
+	results := make([]*resource.Resource, 0, len(resources))
 
 	for _, res := range resources {
 		results = append(

--- a/pkg/remote/azurerm/azurerm_route_enumerator.go
+++ b/pkg/remote/azurerm/azurerm_route_enumerator.go
@@ -29,7 +29,7 @@ func (e *AzurermRouteEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), azurerm.AzureRouteTableResourceType)
 	}
 
-	results := make([]*resource.Resource, len(resources))
+	results := make([]*resource.Resource, 0, len(resources))
 
 	for _, res := range resources {
 		for _, route := range res.Properties.Routes {

--- a/pkg/remote/azurerm/azurerm_route_table_enumerator.go
+++ b/pkg/remote/azurerm/azurerm_route_table_enumerator.go
@@ -29,7 +29,7 @@ func (e *AzurermRouteTableEnumerator) Enumerate() ([]*resource.Resource, error) 
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(resources))
+	results := make([]*resource.Resource, 0, len(resources))
 
 	for _, res := range resources {
 		results = append(

--- a/pkg/remote/azurerm/azurerm_storage_account_enumerator.go
+++ b/pkg/remote/azurerm/azurerm_storage_account_enumerator.go
@@ -29,7 +29,7 @@ func (e *AzurermStorageAccountEnumerator) Enumerate() ([]*resource.Resource, err
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(accounts))
+	results := make([]*resource.Resource, 0, len(accounts))
 
 	for _, account := range accounts {
 		results = append(

--- a/pkg/remote/azurerm/azurerm_virtual_network_enumerator.go
+++ b/pkg/remote/azurerm/azurerm_virtual_network_enumerator.go
@@ -29,7 +29,7 @@ func (e *AzurermVirtualNetworkEnumerator) Enumerate() ([]*resource.Resource, err
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(resources))
+	results := make([]*resource.Resource, 0, len(resources))
 
 	for _, res := range resources {
 		results = append(

--- a/pkg/remote/github/github_branch_protection_enumerator.go
+++ b/pkg/remote/github/github_branch_protection_enumerator.go
@@ -28,7 +28,7 @@ func (g *GithubBranchProtectionEnumerator) Enumerate() ([]*resource.Resource, er
 		return nil, remoteerror.NewResourceListingError(err, string(g.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(ids))
+	results := make([]*resource.Resource, 0, len(ids))
 
 	for _, id := range ids {
 		results = append(

--- a/pkg/remote/github/github_membership_enumerator.go
+++ b/pkg/remote/github/github_membership_enumerator.go
@@ -28,7 +28,7 @@ func (g *GithubMembershipEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(g.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(ids))
+	results := make([]*resource.Resource, 0, len(ids))
 
 	for _, id := range ids {
 		results = append(

--- a/pkg/remote/github/github_repository_enumerator.go
+++ b/pkg/remote/github/github_repository_enumerator.go
@@ -28,7 +28,7 @@ func (g *GithubRepositoryEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(g.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(ids))
+	results := make([]*resource.Resource, 0, len(ids))
 
 	for _, id := range ids {
 		results = append(

--- a/pkg/remote/github/github_team_enumerator.go
+++ b/pkg/remote/github/github_team_enumerator.go
@@ -30,7 +30,7 @@ func (g *GithubTeamEnumerator) Enumerate() ([]*resource.Resource, error) {
 		return nil, remoteerror.NewResourceListingError(err, string(g.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(resourceList))
+	results := make([]*resource.Resource, 0, len(resourceList))
 
 	for _, team := range resourceList {
 		results = append(

--- a/pkg/remote/github/github_team_membership_enumerator.go
+++ b/pkg/remote/github/github_team_membership_enumerator.go
@@ -28,7 +28,7 @@ func (g *GithubTeamMembershipEnumerator) Enumerate() ([]*resource.Resource, erro
 		return nil, remoteerror.NewResourceListingError(err, string(g.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(ids))
+	results := make([]*resource.Resource, 0, len(ids))
 
 	for _, id := range ids {
 		results = append(

--- a/pkg/remote/google/google_storage_bucket_enumerator.go
+++ b/pkg/remote/google/google_storage_bucket_enumerator.go
@@ -30,7 +30,7 @@ func (e *GoogleStorageBucketEnumerator) Enumerate() ([]*resource.Resource, error
 		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 	}
 
-	results := make([]*resource.Resource, len(resources))
+	results := make([]*resource.Resource, 0, len(resources))
 
 	for _, res := range resources {
 		results = append(

--- a/pkg/remote/google/google_storage_bucket_iam_member_enumerator.go
+++ b/pkg/remote/google/google_storage_bucket_iam_member_enumerator.go
@@ -33,7 +33,7 @@ func (e *GoogleStorageBucketIamMemberEnumerator) Enumerate() ([]*resource.Resour
 		return nil, remoteerror.NewResourceListingErrorWithType(err, string(e.SupportedType()), google.GoogleStorageBucketResourceType)
 	}
 
-	results := make([]*resource.Resource, len(resources))
+	results := make([]*resource.Resource, 0, len(resources))
 
 	for _, bucket := range resources {
 		bindings, err := e.storageRepository.ListAllBindings(bucket.DisplayName)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

resources slices inside many enumerators were wrongly initialized with len and cap equality which makes them have nil resources at the beginning.

This PR rewrites each make initialization to have a len of 0 instead.