### PR TITLE
Add missing comment for retry policy in ACC tests

### DIFF
--- a/pkg/resource/google/google_cloudfunctions_function_test.go
+++ b/pkg/resource/google/google_cloudfunctions_function_test.go
@@ -18,7 +18,7 @@ func TestAcc_Google_CloudFunctionsFunction(t *testing.T) {
 		},
 		Checks: []acceptance.AccCheck{
 			{
-				// New cloud function resources are not visible immediatly on GCP api after an apply
+				// New resources are not visible immediately on GCP api after an apply
 				// Logic below retry driftctl scan until we can retrieve the results (infra will be in sync) and for maximum 60 seconds
 				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
 					return !result.IsSync() && retryDuration < time.Minute

--- a/pkg/resource/google/google_storage_bucket_test.go
+++ b/pkg/resource/google/google_storage_bucket_test.go
@@ -18,6 +18,8 @@ func TestAcc_Google_StorageBucket(t *testing.T) {
 		},
 		Checks: []acceptance.AccCheck{
 			{
+				// New resources are not visible immediately on GCP api after an apply
+				// Logic below retry driftctl scan until we can retrieve the results (infra will be in sync) and for maximum 60 seconds
 				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
 					return !result.IsSync() && retryDuration < time.Minute
 				},


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

I noticed we forgot to add a comment about retry policy in #1184. I think it's important so we always remember why acc tests has such policies.