### PR TITLE
Use name instead of display_name for GCP resources

### DIFF
--- a/pkg/remote/google/google_compute_instance_group_enumerator.go
+++ b/pkg/remote/google/google_compute_instance_group_enumerator.go
@@ -46,9 +46,9 @@ func (e *GoogleComputeInstanceGroupEnumerator) Enumerate() ([]*resource.Resource
 				string(e.SupportedType()),
 				trimResourceName(res.GetName()),
 				map[string]interface{}{
-					"display_name": res.GetDisplayName(),
-					"project":      project,
-					"location":     res.GetLocation(),
+					"name":     res.GetDisplayName(),
+					"project":  project,
+					"location": res.GetLocation(),
 				},
 			),
 		)

--- a/pkg/remote/google/google_compute_subnetwork_enumerator.go
+++ b/pkg/remote/google/google_compute_subnetwork_enumerator.go
@@ -38,8 +38,8 @@ func (e *GoogleComputeSubnetworkEnumerator) Enumerate() ([]*resource.Resource, e
 				string(e.SupportedType()),
 				trimResourceName(res.GetName()),
 				map[string]interface{}{
-					"display_name": res.GetDisplayName(),
-					"location":     res.GetLocation(),
+					"name":     res.GetDisplayName(),
+					"location": res.GetLocation(),
 				},
 			),
 		)

--- a/pkg/resource/google/google_compute_instance_group.go
+++ b/pkg/resource/google/google_compute_instance_group.go
@@ -10,14 +10,14 @@ func initGoogleComputeInstanceGroupMetadata(resourceSchemaRepository resource.Sc
 	})
 	resourceSchemaRepository.SetResolveReadAttributesFunc(GoogleComputeInstanceGroupResourceType, func(res *resource.Resource) map[string]string {
 		return map[string]string{
-			"name":    *res.Attributes().GetString("display_name"),
+			"name":    *res.Attributes().GetString("name"),
 			"project": *res.Attributes().GetString("project"),
 			"zone":    *res.Attributes().GetString("location"),
 		}
 	})
 	resourceSchemaRepository.SetHumanReadableAttributesFunc(GoogleComputeInstanceGroupResourceType, func(res *resource.Resource) map[string]string {
 		attrs := make(map[string]string)
-		if v := res.Attributes().GetString("display_name"); v != nil && *v != "" {
+		if v := res.Attributes().GetString("name"); v != nil && *v != "" {
 			attrs["Name"] = *v
 		}
 		return attrs

--- a/pkg/resource/google/google_compute_subnetwork.go
+++ b/pkg/resource/google/google_compute_subnetwork.go
@@ -7,7 +7,7 @@ const GoogleComputeSubnetworkResourceType = "google_compute_subnetwork"
 func initGoogleComputeSubnetworkMetadata(resourceSchemaRepository resource.SchemaRepositoryInterface) {
 	resourceSchemaRepository.SetResolveReadAttributesFunc(GoogleComputeSubnetworkResourceType, func(res *resource.Resource) map[string]string {
 		return map[string]string{
-			"name":   *res.Attributes().GetString("display_name"),
+			"name":   *res.Attributes().GetString("name"),
 			"region": *res.Attributes().GetString("location"),
 		}
 	})
@@ -18,7 +18,7 @@ func initGoogleComputeSubnetworkMetadata(resourceSchemaRepository resource.Schem
 	resourceSchemaRepository.SetHumanReadableAttributesFunc(GoogleComputeSubnetworkResourceType, func(res *resource.Resource) map[string]string {
 		attrs := make(map[string]string)
 
-		if v := res.Attributes().GetString("display_name"); v != nil && *v != "" {
+		if v := res.Attributes().GetString("name"); v != nil && *v != "" {
 			attrs["Name"] = *v
 		}
 		return attrs


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Following this discussion https://github.com/cloudskiff/driftctl/pull/1190#discussion_r738341858, we shouldn't use the `display_name` field for GCP resources since it doesn't exist in the state attributes. If we don't check the value, the scan will panic.