### PR TITLE
Middleware should handle YAML body document now

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/getkin/kin-openapi v0.75.0
 	github.com/getsentry/sentry-go v0.10.0
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/hashicorp/go-getter v1.5.3
 	github.com/hashicorp/go-hclog v0.9.2

--- a/pkg/middlewares/aws_api_gateway_rest_api_expander.go
+++ b/pkg/middlewares/aws_api_gateway_rest_api_expander.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cloudskiff/driftctl/pkg/resource/aws"
 	"github.com/getkin/kin-openapi/openapi2"
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 )
 
@@ -54,7 +55,12 @@ func (m *AwsApiGatewayRestApiExpander) handleBody(api *resource.Resource, result
 
 	docV3 := &openapi3.T{}
 	if err := json.Unmarshal([]byte(*body), &docV3); err != nil {
-		return err
+		if _, ok := err.(*json.SyntaxError); ok {
+			err = yaml.Unmarshal([]byte(*body), &docV3)
+		}
+		if err != nil {
+			return err
+		}
 	}
 	// It's an OpenAPI v3 document
 	if docV3.OpenAPI != "" {
@@ -63,7 +69,12 @@ func (m *AwsApiGatewayRestApiExpander) handleBody(api *resource.Resource, result
 
 	docV2 := &openapi2.T{}
 	if err := json.Unmarshal([]byte(*body), &docV2); err != nil {
-		return err
+		if _, ok := err.(*json.SyntaxError); ok {
+			err = yaml.Unmarshal([]byte(*body), &docV2)
+		}
+		if err != nil {
+			return err
+		}
 	}
 	// It's an OpenAPI v2 document
 	if docV2.Swagger != "" {

--- a/pkg/middlewares/aws_api_gateway_rest_api_expander_test.go
+++ b/pkg/middlewares/aws_api_gateway_rest_api_expander_test.go
@@ -21,7 +21,7 @@ func TestAwsApiGatewayRestApiExpander_Execute(t *testing.T) {
 		expected           []*resource.Resource
 	}{
 		{
-			name: "create aws_api_gateway_resource from OpenAPI v3 document",
+			name: "create aws_api_gateway_resource from OpenAPI v3 JSON document",
 			mocks: func(factory *terraform.MockResourceFactory) {
 				factory.On(
 					"CreateAbstractResource",
@@ -210,7 +210,7 @@ func TestAwsApiGatewayRestApiExpander_Execute(t *testing.T) {
 			},
 		},
 		{
-			name: "create aws_api_gateway_resource from OpenAPI v2 document",
+			name: "create aws_api_gateway_resource from OpenAPI v2 JSON document",
 			mocks: func(factory *terraform.MockResourceFactory) {
 				factory.On(
 					"CreateAbstractResource",
@@ -806,6 +806,220 @@ func TestAwsApiGatewayRestApiExpander_Execute(t *testing.T) {
 				{
 					Id:    "aggr-v2-MISSING_AUTHENTICATION_TOKEN",
 					Type:  aws.AwsApiGatewayGatewayResponseResourceType,
+					Attrs: &resource.Attributes{},
+				},
+			},
+		},
+		{
+			name: "create api gateway resources from OpenAPI v3 YAML document",
+			mocks: func(factory *terraform.MockResourceFactory) {
+				factory.On(
+					"CreateAbstractResource",
+					aws.AwsApiGatewayResourceResourceType,
+					"bar",
+					map[string]interface{}{
+						"rest_api_id": "foo",
+						"path":        "/{path+}",
+					},
+				).Once().Return(&resource.Resource{
+					Id:   "bar",
+					Type: aws.AwsApiGatewayResourceResourceType,
+					Attrs: &resource.Attributes{
+						"rest_api_id": "foo",
+						"path":        "/{path+}",
+					},
+				})
+				factory.On(
+					"CreateAbstractResource",
+					aws.AwsApiGatewayMethodResourceType,
+					"agm-foo-bar-GET",
+					map[string]interface{}{},
+				).Once().Return(&resource.Resource{
+					Id:    "agm-foo-bar-GET",
+					Type:  aws.AwsApiGatewayMethodResourceType,
+					Attrs: &resource.Attributes{},
+				})
+				factory.On(
+					"CreateAbstractResource",
+					aws.AwsApiGatewayMethodResponseResourceType,
+					"agmr-foo-bar-GET-200",
+					map[string]interface{}{},
+				).Once().Return(&resource.Resource{
+					Id:    "agmr-foo-bar-GET-200",
+					Type:  aws.AwsApiGatewayMethodResponseResourceType,
+					Attrs: &resource.Attributes{},
+				})
+				factory.On(
+					"CreateAbstractResource",
+					aws.AwsApiGatewayIntegrationResourceType,
+					"agi-foo-bar-GET",
+					map[string]interface{}{},
+				).Once().Return(&resource.Resource{
+					Id:    "agi-foo-bar-GET",
+					Type:  aws.AwsApiGatewayIntegrationResourceType,
+					Attrs: &resource.Attributes{},
+				})
+			},
+			resourcesFromState: []*resource.Resource{
+				{
+					Id:   "foo",
+					Type: aws.AwsApiGatewayRestApiResourceType,
+					Attrs: &resource.Attributes{
+						"body": "---\nopenapi: \"3.0.1\"\ninfo:\n  title: baz\n  description: ComputelessBlog\npaths:\n  /{path+}:\n    get:\n      responses:\n        200:\n          description: \"200 response\"\n          content:\n            text/html:\n              schema:\n                $ref: \"#/components/schemas/Empty\"\n      x-amazon-apigateway-integration:\n        type: \"mock\"\n        responses:\n          default:\n            statusCode: \"200\"\n        passthroughBehavior: \"never\"\n        httpMethod: \"POST\"\ncomponents:\n  schemas:\n    Empty:\n      type: object\n      title: Empty Schema\n      description: Empty Schema",
+					},
+				},
+			},
+			remoteResources: []*resource.Resource{
+				{
+					Id:    "foo",
+					Type:  aws.AwsApiGatewayRestApiResourceType,
+					Attrs: &resource.Attributes{},
+				},
+				{
+					Id:   "bar",
+					Type: aws.AwsApiGatewayResourceResourceType,
+					Attrs: &resource.Attributes{
+						"rest_api_id": "foo",
+						"path":        "/{path+}",
+					},
+				},
+			},
+			expected: []*resource.Resource{
+				{
+					Id:   "foo",
+					Type: aws.AwsApiGatewayRestApiResourceType,
+					Attrs: &resource.Attributes{
+						"body": "---\nopenapi: \"3.0.1\"\ninfo:\n  title: baz\n  description: ComputelessBlog\npaths:\n  /{path+}:\n    get:\n      responses:\n        200:\n          description: \"200 response\"\n          content:\n            text/html:\n              schema:\n                $ref: \"#/components/schemas/Empty\"\n      x-amazon-apigateway-integration:\n        type: \"mock\"\n        responses:\n          default:\n            statusCode: \"200\"\n        passthroughBehavior: \"never\"\n        httpMethod: \"POST\"\ncomponents:\n  schemas:\n    Empty:\n      type: object\n      title: Empty Schema\n      description: Empty Schema",
+					},
+				},
+				{
+					Id:   "bar",
+					Type: aws.AwsApiGatewayResourceResourceType,
+					Attrs: &resource.Attributes{
+						"rest_api_id": "foo",
+						"path":        "/{path+}",
+					},
+				},
+				{
+					Id:    "agm-foo-bar-GET",
+					Type:  aws.AwsApiGatewayMethodResourceType,
+					Attrs: &resource.Attributes{},
+				},
+				{
+					Id:    "agmr-foo-bar-GET-200",
+					Type:  aws.AwsApiGatewayMethodResponseResourceType,
+					Attrs: &resource.Attributes{},
+				},
+				{
+					Id:    "agi-foo-bar-GET",
+					Type:  aws.AwsApiGatewayIntegrationResourceType,
+					Attrs: &resource.Attributes{},
+				},
+			},
+		},
+		{
+			name: "create api gateway resources from OpenAPI v2 YAML document",
+			mocks: func(factory *terraform.MockResourceFactory) {
+				factory.On(
+					"CreateAbstractResource",
+					aws.AwsApiGatewayResourceResourceType,
+					"bar",
+					map[string]interface{}{
+						"rest_api_id": "foo",
+						"path":        "/webhook",
+					},
+				).Once().Return(&resource.Resource{
+					Id:   "bar",
+					Type: aws.AwsApiGatewayResourceResourceType,
+					Attrs: &resource.Attributes{
+						"rest_api_id": "foo",
+						"path":        "/webhook",
+					},
+				})
+				factory.On(
+					"CreateAbstractResource",
+					aws.AwsApiGatewayMethodResourceType,
+					"agm-foo-bar-OPTIONS",
+					map[string]interface{}{},
+				).Once().Return(&resource.Resource{
+					Id:    "agm-foo-bar-OPTIONS",
+					Type:  aws.AwsApiGatewayMethodResourceType,
+					Attrs: &resource.Attributes{},
+				})
+				factory.On(
+					"CreateAbstractResource",
+					aws.AwsApiGatewayMethodResponseResourceType,
+					"agmr-foo-bar-OPTIONS-200",
+					map[string]interface{}{},
+				).Once().Return(&resource.Resource{
+					Id:    "agmr-foo-bar-OPTIONS-200",
+					Type:  aws.AwsApiGatewayMethodResponseResourceType,
+					Attrs: &resource.Attributes{},
+				})
+				factory.On(
+					"CreateAbstractResource",
+					aws.AwsApiGatewayIntegrationResourceType,
+					"agi-foo-bar-OPTIONS",
+					map[string]interface{}{},
+				).Once().Return(&resource.Resource{
+					Id:    "agi-foo-bar-OPTIONS",
+					Type:  aws.AwsApiGatewayIntegrationResourceType,
+					Attrs: &resource.Attributes{},
+				})
+			},
+			resourcesFromState: []*resource.Resource{
+				{
+					Id:   "foo",
+					Type: aws.AwsApiGatewayRestApiResourceType,
+					Attrs: &resource.Attributes{
+						"body": "---\nswagger: '2.0'\ninfo:\n  version: '1.0'\n  title: test\nschemes:\n  - https\npaths:\n  /webhook:\n    options:\n      consumes:\n        - application/json\n      produces:\n        - application/json\n      responses:\n        '200':\n          description: 200 response\n          schema:\n            $ref: \\\"#/definitions/Empty\\\"\n      x-amazon-apigateway-integration:\n        responses:\n          default:\n            statusCode: '200'\n        requestTemplates:\n          application/json: '{\\\"statusCode\\\": 200}'\n        passthroughBehavior: when_no_match\n        type: mock\n\n",
+					},
+				},
+			},
+			remoteResources: []*resource.Resource{
+				{
+					Id:    "foo",
+					Type:  aws.AwsApiGatewayRestApiResourceType,
+					Attrs: &resource.Attributes{},
+				},
+				{
+					Id:   "bar",
+					Type: aws.AwsApiGatewayResourceResourceType,
+					Attrs: &resource.Attributes{
+						"rest_api_id": "foo",
+						"path":        "/webhook",
+					},
+				},
+			},
+			expected: []*resource.Resource{
+				{
+					Id:   "foo",
+					Type: aws.AwsApiGatewayRestApiResourceType,
+					Attrs: &resource.Attributes{
+						"body": "---\nswagger: '2.0'\ninfo:\n  version: '1.0'\n  title: test\nschemes:\n  - https\npaths:\n  /webhook:\n    options:\n      consumes:\n        - application/json\n      produces:\n        - application/json\n      responses:\n        '200':\n          description: 200 response\n          schema:\n            $ref: \\\"#/definitions/Empty\\\"\n      x-amazon-apigateway-integration:\n        responses:\n          default:\n            statusCode: '200'\n        requestTemplates:\n          application/json: '{\\\"statusCode\\\": 200}'\n        passthroughBehavior: when_no_match\n        type: mock\n\n",
+					},
+				},
+				{
+					Id:   "bar",
+					Type: aws.AwsApiGatewayResourceResourceType,
+					Attrs: &resource.Attributes{
+						"rest_api_id": "foo",
+						"path":        "/webhook",
+					},
+				},
+				{
+					Id:    "agm-foo-bar-OPTIONS",
+					Type:  aws.AwsApiGatewayMethodResourceType,
+					Attrs: &resource.Attributes{},
+				},
+				{
+					Id:    "agmr-foo-bar-OPTIONS-200",
+					Type:  aws.AwsApiGatewayMethodResponseResourceType,
+					Attrs: &resource.Attributes{},
+				},
+				{
+					Id:    "agi-foo-bar-OPTIONS",
+					Type:  aws.AwsApiGatewayIntegrationResourceType,
 					Attrs: &resource.Attributes{},
 				},
 			},


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #1203
| ❓ Documentation  | no

## Description
Add the same yaml package as the one used in the kin-openapi package to parse OpenAPI document.

After we try to unmarshall json document, if it fails due to syntax error, let's try to unmarshall with the yaml format. 