### PR TITLE
Display progress bar in stdout

### DIFF
--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -216,6 +216,12 @@ func scanRun(opts *pkg.ScanOptions) error {
 
 	alerter := alerter.NewAlerter()
 
+	// For now, we only use the global printer to print progress and information about the current scan, so unless one
+	// of the configured output should silence global output we simply use console by default.
+	if output.ShouldPrint(opts.Output, opts.Quiet) {
+		globaloutput.ChangePrinter(globaloutput.NewConsolePrinter())
+	}
+
 	providerLibrary := terraform.NewProviderLibrary()
 	remoteLibrary := common.NewRemoteLibrary()
 
@@ -278,7 +284,7 @@ func scanRun(opts *pkg.ScanOptions) error {
 
 	validOutput := false
 	for _, o := range opts.Output {
-		if err = output.GetOutput(o, opts.Quiet).Write(analysis); err != nil {
+		if err = output.GetOutput(o).Write(analysis); err != nil {
 			logrus.Errorf("Error writing to output %s: %v", o.String(), err.Error())
 			continue
 		}

--- a/pkg/cmd/scan/output/output.go
+++ b/pkg/cmd/scan/output/output.go
@@ -62,6 +62,7 @@ func GetOutput(config OutputConfig) Output {
 	}
 }
 
+// ShouldPrint indicate if we should use the global output or not (e.g. when outputting to stdout).
 func ShouldPrint(outputs []OutputConfig, quiet bool) bool {
 	for _, c := range outputs {
 		p := GetPrinter(c, quiet)

--- a/pkg/cmd/scan/output/output.go
+++ b/pkg/cmd/scan/output/output.go
@@ -47,9 +47,7 @@ func IsSupported(key string) bool {
 	return false
 }
 
-func GetOutput(config OutputConfig, quiet bool) Output {
-	output.ChangePrinter(GetPrinter(config, quiet))
-
+func GetOutput(config OutputConfig) Output {
 	switch config.Key {
 	case JSONOutputType:
 		return NewJSON(config.Path)
@@ -62,6 +60,16 @@ func GetOutput(config OutputConfig, quiet bool) Output {
 	default:
 		return NewConsole()
 	}
+}
+
+func ShouldPrint(outputs []OutputConfig, quiet bool) bool {
+	for _, c := range outputs {
+		p := GetPrinter(c, quiet)
+		if _, ok := p.(*output.VoidPrinter); ok {
+			return false
+		}
+	}
+	return true
 }
 
 func GetPrinter(config OutputConfig, quiet bool) output.Printer {

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -522,3 +522,54 @@ func TestGetPrinter(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldPrint(t *testing.T) {
+	tests := []struct {
+		name    string
+		outputs []OutputConfig
+		quiet   bool
+		want    bool
+	}{
+		{
+			name: "test stdout prevents printing",
+			outputs: []OutputConfig{
+				{
+					Path: "stdout",
+					Key:  JSONOutputType,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "test output to file doesn't prevent printing",
+			outputs: []OutputConfig{
+				{
+					Path: "result.json",
+					Key:  JSONOutputType,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "test stdout prevents printing",
+			outputs: []OutputConfig{
+				{
+					Path: "result.json",
+					Key:  JSONOutputType,
+				},
+				{
+					Path: "stdout",
+					Key:  PlanOutputType,
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldPrint(tt.outputs, tt.quiet); got != tt.want {
+				t.Errorf("ShouldPrint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #1211
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

As reported by @moadibfr, the progress bar and other global output usage were hidden because as we implemented multiple output (#865), the global output was always assigned to the `voidPrinter` which prints nothing. This PR fixes that by setting the global output **before** the scan.