### PR TITLE
Support passing in the Terraform API URL to support Terraform Enterprise installations.

### DIFF
--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -168,7 +168,7 @@ func NewScanCmd(opts *pkg.ScanOptions) *cobra.Command {
 		"Terraform Cloud / Enterprise API token.\n"+
 			"Only used with tfstate+tfcloud backend.\n",
 	)
-	fl.StringVar(&opts.BackendOptions.TFCloudAPI,
+	fl.StringVar(&opts.BackendOptions.TFCloudEndpoint,
 		"tfc-endpoint",
 		"https://app.terraform.io/api/v2",
 		"Terraform Cloud / Enterprise API endpoint.\n"+

--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -168,6 +168,12 @@ func NewScanCmd(opts *pkg.ScanOptions) *cobra.Command {
 		"Terraform Cloud / Enterprise API token.\n"+
 			"Only used with tfstate+tfcloud backend.\n",
 	)
+	fl.StringVar(&opts.BackendOptions.TFCloudAPI,
+		"tfc-api",
+		"",
+		"Terraform Cloud / Enterprise API endpoint.\n"+
+			"Only used with tfstate+tfcloud backend.\n",
+	)
 	fl.String(
 		"tf-provider-version",
 		"",

--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -169,8 +169,8 @@ func NewScanCmd(opts *pkg.ScanOptions) *cobra.Command {
 			"Only used with tfstate+tfcloud backend.\n",
 	)
 	fl.StringVar(&opts.BackendOptions.TFCloudAPI,
-		"tfc-api",
-		"",
+		"tfc-endpoint",
+		"https://app.terraform.io/api/v2",
 		"Terraform Cloud / Enterprise API endpoint.\n"+
 			"Only used with tfstate+tfcloud backend.\n",
 	)

--- a/pkg/iac/terraform/state/backend/backend.go
+++ b/pkg/iac/terraform/state/backend/backend.go
@@ -20,9 +20,9 @@ var supportedBackends = []string{
 type Backend io.ReadCloser
 
 type Options struct {
-	Headers      map[string]string
-	TFCloudToken string
-	TFCloudAPI   string
+	Headers         map[string]string
+	TFCloudToken    string
+	TFCloudEndpoint string
 }
 
 func IsSupported(backend string) bool {

--- a/pkg/iac/terraform/state/backend/backend.go
+++ b/pkg/iac/terraform/state/backend/backend.go
@@ -22,6 +22,7 @@ type Backend io.ReadCloser
 type Options struct {
 	Headers      map[string]string
 	TFCloudToken string
+	TFCloudAPI   string
 }
 
 func IsSupported(backend string) bool {

--- a/pkg/iac/terraform/state/backend/tfcloud_config_reader.go
+++ b/pkg/iac/terraform/state/backend/tfcloud_config_reader.go
@@ -13,11 +13,11 @@ import (
 )
 
 type container struct {
-	Credentials map[string]containerToken `json:"credentials"`
+	Credentials map[string]containerToken
 }
 
 type containerToken struct {
-	Token string `json:"token"`
+	Token string
 }
 
 type tfCloudConfigReader struct {

--- a/pkg/iac/terraform/state/backend/tfcloud_config_reader.go
+++ b/pkg/iac/terraform/state/backend/tfcloud_config_reader.go
@@ -13,11 +13,11 @@ import (
 )
 
 type container struct {
-	Credentials struct {
-		TerraformCloud struct {
-			Token string
-		} `json:"app.terraform.io"`
-	}
+	Credentials map[string]containerToken `json:"credentials"`
+}
+
+type containerToken struct {
+	Token string `json:"token"`
 }
 
 type tfCloudConfigReader struct {
@@ -28,7 +28,7 @@ func NewTFCloudConfigReader(reader io.ReadCloser) *tfCloudConfigReader {
 	return &tfCloudConfigReader{reader}
 }
 
-func (r *tfCloudConfigReader) GetToken() (string, error) {
+func (r *tfCloudConfigReader) GetToken(host string) (string, error) {
 	b, err := ioutil.ReadAll(r.reader)
 	if err != nil {
 		return "", errors.New("unable to read file")
@@ -38,10 +38,10 @@ func (r *tfCloudConfigReader) GetToken() (string, error) {
 	if err := json.Unmarshal(b, &container); err != nil {
 		return "", err
 	}
-	if container.Credentials.TerraformCloud.Token == "" {
+	if container.Credentials[host].Token == "" {
 		return "", errors.New("driftctl could not read your Terraform configuration file, please check that this is a valid Terraform credentials file")
 	}
-	return container.Credentials.TerraformCloud.Token, nil
+	return container.Credentials[host].Token, nil
 }
 
 func getTerraformConfigFile() (string, error) {

--- a/pkg/iac/terraform/state/backend/tfcloud_config_reader_test.go
+++ b/pkg/iac/terraform/state/backend/tfcloud_config_reader_test.go
@@ -44,7 +44,7 @@ func TestTFCloudConfigReader_GetToken(t *testing.T) {
 			readerCloser := ioutil.NopCloser(strings.NewReader(tt.src))
 			defer readerCloser.Close()
 			r := NewTFCloudConfigReader(readerCloser)
-			got, err := r.GetToken(`app.terraform.io`)
+			got, err := r.GetToken("app.terraform.io")
 			if err != nil && err.Error() != tt.wantErr.Error() {
 				t.Errorf("GetToken() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/iac/terraform/state/backend/tfcloud_config_reader_test.go
+++ b/pkg/iac/terraform/state/backend/tfcloud_config_reader_test.go
@@ -44,7 +44,7 @@ func TestTFCloudConfigReader_GetToken(t *testing.T) {
 			readerCloser := ioutil.NopCloser(strings.NewReader(tt.src))
 			defer readerCloser.Close()
 			r := NewTFCloudConfigReader(readerCloser)
-			got, err := r.GetToken()
+			got, err := r.GetToken(`app.terraform.io`)
 			if err != nil && err.Error() != tt.wantErr.Error() {
 				t.Errorf("GetToken() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/iac/terraform/state/backend/tfcloud_reader.go
+++ b/pkg/iac/terraform/state/backend/tfcloud_reader.go
@@ -14,7 +14,6 @@ import (
 )
 
 const BackendKeyTFCloud = "tfcloud"
-const TFCloudAPI = "https://app.terraform.io/api/v2"
 
 type TFCloudAttributes struct {
 	HostedStateDownloadUrl string `json:"hosted-state-download-url"`
@@ -36,7 +35,12 @@ type TFCloudBackend struct {
 }
 
 func NewTFCloudReader(client pkghttp.HTTPClient, workspaceId string, opts *Options) (*TFCloudBackend, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/workspaces/%s/current-state-version", TFCloudAPI, workspaceId), nil)
+	// Assume if it was not set that the end-point is Terraform Cloud
+	if opts.TFCloudAPI == "" {
+		opts.TFCloudAPI = "https://app.terraform.io/api/v2"
+	}
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/workspaces/%s/current-state-version", opts.TFCloudAPI, workspaceId), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +61,7 @@ func (t *TFCloudBackend) authorize() error {
 		}
 		defer file.Close()
 		reader := NewTFCloudConfigReader(file)
-		token, err = reader.GetToken()
+		token, err = reader.GetToken(t.request.URL.Host)
 		if err != nil {
 			return err
 		}

--- a/pkg/iac/terraform/state/backend/tfcloud_reader.go
+++ b/pkg/iac/terraform/state/backend/tfcloud_reader.go
@@ -35,7 +35,7 @@ type TFCloudBackend struct {
 }
 
 func NewTFCloudReader(client pkghttp.HTTPClient, workspaceId string, opts *Options) (*TFCloudBackend, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/workspaces/%s/current-state-version", opts.TFCloudAPI, workspaceId), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/workspaces/%s/current-state-version", opts.TFCloudEndpoint, workspaceId), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/iac/terraform/state/backend/tfcloud_reader.go
+++ b/pkg/iac/terraform/state/backend/tfcloud_reader.go
@@ -35,11 +35,6 @@ type TFCloudBackend struct {
 }
 
 func NewTFCloudReader(client pkghttp.HTTPClient, workspaceId string, opts *Options) (*TFCloudBackend, error) {
-	// Assume if it was not set that the end-point is Terraform Cloud
-	if opts.TFCloudAPI == "" {
-		opts.TFCloudAPI = "https://app.terraform.io/api/v2"
-	}
-
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/workspaces/%s/current-state-version", opts.TFCloudAPI, workspaceId), nil)
 	if err != nil {
 		return nil, err

--- a/pkg/iac/terraform/state/backend/tfcloud_reader_test.go
+++ b/pkg/iac/terraform/state/backend/tfcloud_reader_test.go
@@ -29,7 +29,8 @@ func TestTFCloudBackend_Read(t *testing.T) {
 			args: args{
 				workspaceId: "workspaceId",
 				options: &Options{
-					TFCloudToken: "TOKEN",
+					TFCloudToken:    "TOKEN",
+					TFCloudEndpoint: "https://app.terraform.io/api/v2",
 				},
 			},
 			url:      "https://app.terraform.io/api/v2/workspaces/workspaceId/current-state-version",
@@ -54,7 +55,8 @@ func TestTFCloudBackend_Read(t *testing.T) {
 			args: args{
 				workspaceId: "wrong_workspaceId",
 				options: &Options{
-					TFCloudToken: "TOKEN",
+					TFCloudToken:    "TOKEN",
+					TFCloudEndpoint: "https://app.terraform.io/api/v2",
 				},
 			},
 			url: "https://app.terraform.io/api/v2/workspaces/wrong_workspaceId/current-state-version",
@@ -73,7 +75,8 @@ func TestTFCloudBackend_Read(t *testing.T) {
 			args: args{
 				workspaceId: "workspaceId",
 				options: &Options{
-					TFCloudToken: "TOKEN",
+					TFCloudToken:    "TOKEN",
+					TFCloudEndpoint: "https://app.terraform.io/api/v2",
 				},
 			},
 			url: "https://app.terraform.io/api/v2/workspaces/workspaceId/current-state-version",


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | 
| ❓ Documentation  | https://github.com/cloudskiff/driftctl-docs/pull/181

## Description

Documentation claims that Terraform Enterprise is supported, but there was no option to pass in the Terraform Enterprise URL.  This adds an option to pass in the Terraform Enterprise URL, --tfc-api "https://tfe.domain.net/api/v2", with the default for existing behavior.