### PR TITLE
Force azure provider registration to false.

### DIFF
--- a/pkg/remote/azurerm/provider.go
+++ b/pkg/remote/azurerm/provider.go
@@ -38,11 +38,12 @@ func NewAzureTerraformProvider(version string, progress output.Progress, configD
 		Name: p.name,
 		GetProviderConfig: func(_ string) interface{} {
 			c := p.GetConfig()
-			return map[string]string{
-				"subscription_id": c.SubscriptionID,
-				"tenant_id":       c.TenantID,
-				"client_id":       c.ClientID,
-				"client_secret":   c.ClientSecret,
+			return map[string]interface{}{
+				"subscription_id":            c.SubscriptionID,
+				"tenant_id":                  c.TenantID,
+				"client_id":                  c.ClientID,
+				"client_secret":              c.ClientSecret,
+				"skip_provider_registration": true,
 			}
 		},
 	}, progress)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Azure provider registration allow terraform provider to automatically
register azure resource providers.
In our context we are running read only so we do not want to try to
enable them during the scan.
Without this, a driftctl scan will try to register resource providers
since it is done in the gRPC configure call.
