### PR TITLE
Fix private DNS resources attributes

### DIFF
--- a/pkg/remote/azurerm/azurerm_private_dns_cname_record_enumerator.go
+++ b/pkg/remote/azurerm/azurerm_private_dns_cname_record_enumerator.go
@@ -43,7 +43,10 @@ func (e *AzurermPrivateDNSCNameRecordEnumerator) Enumerate() ([]*resource.Resour
 				e.factory.CreateAbstractResource(
 					string(e.SupportedType()),
 					*record.ID,
-					map[string]interface{}{},
+					map[string]interface{}{
+						"name":      *record.Name,
+						"zone_name": *zone.Name,
+					},
 				),
 			)
 		}

--- a/pkg/remote/azurerm/azurerm_privatedns_a_record_enumerator.go
+++ b/pkg/remote/azurerm/azurerm_privatedns_a_record_enumerator.go
@@ -44,7 +44,8 @@ func (e *AzurermPrivateDNSARecordEnumerator) Enumerate() ([]*resource.Resource, 
 					string(e.SupportedType()),
 					*record.ID,
 					map[string]interface{}{
-						"name": record.Name,
+						"name":      *record.Name,
+						"zone_name": *zone.Name,
 					},
 				),
 			)

--- a/pkg/remote/azurerm/azurerm_privatedns_aaaa_record_enumerator.go
+++ b/pkg/remote/azurerm/azurerm_privatedns_aaaa_record_enumerator.go
@@ -44,7 +44,8 @@ func (e *AzurermPrivateDNSAAAARecordEnumerator) Enumerate() ([]*resource.Resourc
 					string(e.SupportedType()),
 					*record.ID,
 					map[string]interface{}{
-						"name": record.Name,
+						"name":      *record.Name,
+						"zone_name": *zone.Name,
 					},
 				),
 			)

--- a/pkg/remote/azurerm/azurerm_privatedns_mx_record_enumerator.go
+++ b/pkg/remote/azurerm/azurerm_privatedns_mx_record_enumerator.go
@@ -43,7 +43,10 @@ func (e *AzurermPrivateDNSMXRecordEnumerator) Enumerate() ([]*resource.Resource,
 				e.factory.CreateAbstractResource(
 					string(e.SupportedType()),
 					*record.ID,
-					map[string]interface{}{},
+					map[string]interface{}{
+						"name":      *record.Name,
+						"zone_name": *zone.Name,
+					},
 				),
 			)
 		}

--- a/pkg/remote/azurerm/azurerm_privatedns_ptr_record_enumerator.go
+++ b/pkg/remote/azurerm/azurerm_privatedns_ptr_record_enumerator.go
@@ -44,7 +44,8 @@ func (e *AzurermPrivateDNSPTRRecordEnumerator) Enumerate() ([]*resource.Resource
 					string(e.SupportedType()),
 					*record.ID,
 					map[string]interface{}{
-						"name": record.Name,
+						"name":      *record.Name,
+						"zone_name": *zone.Name,
 					},
 				),
 			)

--- a/pkg/remote/azurerm/azurerm_privatedns_srv_record_enumerator.go
+++ b/pkg/remote/azurerm/azurerm_privatedns_srv_record_enumerator.go
@@ -44,8 +44,8 @@ func (e *AzurermPrivateDNSSRVRecordEnumerator) Enumerate() ([]*resource.Resource
 					string(e.SupportedType()),
 					*record.ID,
 					map[string]interface{}{
-						"name":      &record.Name,
-						"zone_name": &zone.Name,
+						"name":      *record.Name,
+						"zone_name": *zone.Name,
 					},
 				),
 			)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | o
| 🔗 Related issues | #1063 
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Running a non-deep mode scan on those resources produces a panic since some attributes return a pointer instead of a value. This behavior is not covered by unit tests since we only test those resources against deep mode.

```
panic: interface conversion: interface {} is *string, not string

goroutine 1 [running]:
github.com/cloudskiff/driftctl/pkg/resource.(*Attributes).GetString(...)
	/home/<redacted>/cloudskiff/driftctl/pkg/resource/resource.go:168
[...]
```