### PR TITLE
Make version check test more dynamic

### DIFF
--- a/pkg/cmd/driftctl_test.go
+++ b/pkg/cmd/driftctl_test.go
@@ -41,23 +41,6 @@ func TestDriftctlCmd_Help(t *testing.T) {
 	}
 }
 
-func TestDriftctlCmd_Version(t *testing.T) {
-	cmd := NewDriftctlCmd(mocks.MockBuild{})
-
-	output, err := test.Execute(&cmd.Command, "version")
-	if output == "" {
-		t.Errorf("Unexpected output: %v", output)
-	}
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
-	expected := "dev-dev\n"
-	if output != expected {
-		t.Errorf("Expected %v, got %v", expected, output)
-	}
-}
-
 func TestDriftctlCmd_Completion(t *testing.T) {
 	cmd := NewDriftctlCmd(mocks.MockBuild{})
 

--- a/pkg/cmd/version_test.go
+++ b/pkg/cmd/version_test.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/cloudskiff/driftctl/pkg/version"
 	"github.com/cloudskiff/driftctl/test"
 
 	"github.com/spf13/cobra"
@@ -20,7 +22,7 @@ func TestVersionCmd(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	expected := "dev-dev\n"
+	expected := fmt.Sprintf("%s\n", version.Current())
 	if output != expected {
 		t.Errorf("Expected %v, got %v", expected, output)
 	}


### PR DESCRIPTION
In some particular context (when packaging driftctl in release mode, check [nixpkg](https://github.com/NixOS/nixpkgs/commit/ded247ada384ceacc5d0d186cffa7c1cc927d268#diff-f6248b889160cf7652be9255c593b1ded04177a6d33449c69b8f4e4abf28ce57R45-R47)) theses test are failing since the version `dev-dev`is hardcoded.
This PR make sure that they will match the current version regardless of any ldflags.