### PR TITLE
Fix inconsistent test for RetryFor

### DIFF
--- a/test/acceptance/testing_test.go
+++ b/test/acceptance/testing_test.go
@@ -48,7 +48,7 @@ func TestRetryFor(t *testing.T) {
 	}{
 		{
 			name:    "success on first try",
-			timeout: 1 * time.Millisecond,
+			timeout: 100 * time.Millisecond,
 			f: func(c chan struct{}) error {
 				c <- struct{}{}
 				return nil


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

The test for the retry logic was failing unexpectedly in random branches because the configured timeout (1ms) is too short so the timeout sometimes exceed before the test function is executed ([example](https://app.circleci.com/pipelines/github/cloudskiff/driftctl/3784/workflows/b5d7a14a-785a-4b77-8de0-c401691fd05e/jobs/7695)). I've set the timeout to 100ms so it doesn't bother us again.