### PR TITLE
Fix acceptance cli arguments

### DIFF
--- a/test/acceptance/testing.go
+++ b/test/acceptance/testing.go
@@ -396,7 +396,6 @@ func Run(t *testing.T, c AccTestCase) {
 		c.Args = append(c.Args,
 			"--output", fmt.Sprintf("json://%s", c.getResultFilePath()),
 		)
-		c.Args = append(c.Args, "--disable-telemetry")
 	}
 
 	for _, check := range c.Checks {


### PR DESCRIPTION
In acceptance testing environment, usage report has been disabled, this means --disable-telemetry and --no-version-check flags are not supported. This PR removes it to prevent having this error : `unknown flag: --disable-telemetry`