### PR TITLE
Disable usage reporting for non release builds

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -20,5 +20,5 @@ func (b Build) IsRelease() bool {
 }
 
 func (b Build) IsUsageReportingEnabled() bool {
-	return enableUsageReporting == "true"
+	return b.IsRelease() && enableUsageReporting == "true"
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | kinda
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

We should remove usage reporting when we are not in a release build.
That will prevent us to send fake telemetry while working on driftctl