### PR TITLE
Add retry policy to azurerm_image

### DIFF
--- a/pkg/resource/azurerm/azurerm_image_test.go
+++ b/pkg/resource/azurerm/azurerm_image_test.go
@@ -2,6 +2,7 @@ package azurerm_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/snyk/driftctl/test"
 	"github.com/snyk/driftctl/test/acceptance"
@@ -17,6 +18,8 @@ func TestAcc_Azure_Image(t *testing.T) {
 		},
 		Checks: []acceptance.AccCheck{
 			{
+				// New resources are not visible immediately through Azure API after an apply operation.
+				ShouldRetry: acceptance.LinearBackoff(10 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)


### PR DESCRIPTION
## Description

This acceptance test [recently failed](https://circleci.com/gh/snyk/driftctl/10024) and showed that the resource was missing, which appear to be an inconsistency in the API results. This retry policy will retry the test periodically for 10 minutes maximum.