### PR TITLE
Fix panic in aws_ebs_encryption_by_default_reconciler middleware

### DIFF
--- a/pkg/middlewares/aws_ebs_encryption_by_default_reconciler.go
+++ b/pkg/middlewares/aws_ebs_encryption_by_default_reconciler.go
@@ -35,6 +35,11 @@ func (m AwsEbsEncryptionByDefaultReconciler) Execute(remoteResources, resourcesF
 		break
 	}
 
+	// We can encounter this case when we don't have permission to get this setting from AWS.
+	if defaultEbsEncryption == nil {
+		return nil
+	}
+
 	for _, res := range *resourcesFromState {
 		newStateResources = append(newStateResources, res)
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

This middleware was producing a panic crash when user doesn't have permission to get EBS encryption setting (or whatever other reason).

![image](https://user-images.githubusercontent.com/99100216/161554872-168ad7e4-c713-43be-9e02-357be29936e0.png)
