### PR TITLE
Fix aws_ebs_encryption_by_default_reconciler middleware

### DIFF
--- a/pkg/middlewares/aws_ebs_encryption_by_default_reconciler.go
+++ b/pkg/middlewares/aws_ebs_encryption_by_default_reconciler.go
@@ -32,7 +32,6 @@ func (m AwsEbsEncryptionByDefaultReconciler) Execute(remoteResources, resourcesF
 			continue
 		}
 		defaultEbsEncryption = res
-		break
 	}
 
 	// We can encounter this case when we don't have permission to get this setting from AWS.

--- a/pkg/middlewares/aws_ebs_encryption_by_default_reconciler_test.go
+++ b/pkg/middlewares/aws_ebs_encryption_by_default_reconciler_test.go
@@ -150,16 +150,16 @@ func TestAwsEbsEncryptionByDefaultReconciler_Execute(t *testing.T) {
 			mocks: func(factory *terraform.MockResourceFactory) {},
 			remoteResources: []*resource.Resource{
 				{
-					Id:    "bucket-1",
-					Type:  aws.AwsS3BucketResourceType,
-					Attrs: &resource.Attributes{},
-				},
-				{
 					Id:   "test-encryption",
 					Type: aws.AwsEbsEncryptionByDefaultResourceType,
 					Attrs: &resource.Attributes{
 						"enabled": false,
 					},
+				},
+				{
+					Id:    "bucket-1",
+					Type:  aws.AwsS3BucketResourceType,
+					Attrs: &resource.Attributes{},
 				},
 			},
 			resourcesFromState: []*resource.Resource{


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

A simple break statement in that middleware was preventing many remote resources to be included in the scan, resulting in many missing resources. Bug introduced in #1448 but not released yet. The reason why we didn't notice it is because we didn't test it with many remote resources, not even in unit tests.