### PR TITLE
Add date to JSON-serialized analysis

### DIFF
--- a/pkg/analyser/analysis.go
+++ b/pkg/analyser/analysis.go
@@ -65,6 +65,7 @@ type serializableAnalysis struct {
 	ProviderName    string                                 `json:"provider_name"`
 	ProviderVersion string                                 `json:"provider_version"`
 	ScanDuration    uint                                   `json:"scan_duration,omitempty"`
+	Date            time.Time                              `json:"date"`
 }
 
 type GenDriftIgnoreOptions struct {
@@ -110,6 +111,7 @@ func (a Analysis) MarshalJSON() ([]byte, error) {
 	bla.ProviderVersion = a.ProviderVersion
 	bla.ScanDuration = uint(a.Duration.Seconds())
 	bla.Options = a.Options()
+	bla.Date = a.Date
 
 	return json.Marshal(bla)
 }
@@ -173,6 +175,7 @@ func (a *Analysis) UnmarshalJSON(bytes []byte) error {
 	a.SetIaCSourceCount(bla.Summary.TotalIaCSourceCount)
 	a.Duration = time.Duration(bla.ScanDuration) * time.Second
 	a.options = bla.Options
+	a.Date = bla.Date
 	return nil
 }
 

--- a/pkg/analyser/analyzer_test.go
+++ b/pkg/analyser/analyzer_test.go
@@ -1272,6 +1272,7 @@ func TestAnalysis_MarshalJSON(t *testing.T) {
 	goldenFile := "./testdata/output.json"
 	analysis := Analysis{
 		Duration: 241 * time.Second,
+		Date:     time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC),
 	}
 	analysis.SetIaCSourceCount(1)
 	analysis.AddManaged(
@@ -1421,6 +1422,7 @@ func TestAnalysis_UnmarshalJSON(t *testing.T) {
 		},
 		ProviderName:    "AWS",
 		ProviderVersion: "2.18.5",
+		Date:            time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC),
 	}
 
 	got := Analysis{}

--- a/pkg/analyser/testdata/input.json
+++ b/pkg/analyser/testdata/input.json
@@ -70,5 +70,6 @@
     ]
   },
   "provider_name": "AWS",
-  "provider_version": "2.18.5"
+  "provider_version": "2.18.5",
+  "date": "2022-04-08T10:35:00Z"
 }

--- a/pkg/analyser/testdata/output.json
+++ b/pkg/analyser/testdata/output.json
@@ -76,5 +76,6 @@
 	},
 	"provider_name": "AWS",
 	"provider_version": "2.18.5",
-	"scan_duration": 241
+	"scan_duration": 241,
+	"date": "2022-04-08T10:35:00Z"
 }

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -23,6 +23,7 @@ func fakeAnalysis(opts analyser.AnalyzerOptions) *analyser.Analysis {
 		opts = analyser.AnalyzerOptions{Deep: true}
 	}
 	a := analyser.NewAnalysis(opts)
+	a.Date = time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC)
 	a.SetIaCSourceCount(3)
 	a.Duration = 12 * time.Second
 	a.AddUnmanaged(
@@ -118,6 +119,7 @@ func fakeAnalysis(opts analyser.AnalyzerOptions) *analyser.Analysis {
 
 func fakeAnalysisWithAlerts() *analyser.Analysis {
 	a := fakeAnalysis(analyser.AnalyzerOptions{})
+	a.Date = time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC)
 	a.SetAlerts(alerter.Alerts{
 		"": []alerter.Alert{
 			alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, remoteerr.NewResourceListingErrorWithType(errors.New("dummy error"), "aws_vpc", "aws_vpc"), alerts.EnumerationPhase),
@@ -131,6 +133,7 @@ func fakeAnalysisWithAlerts() *analyser.Analysis {
 
 func fakeAnalysisNoDrift() *analyser.Analysis {
 	a := analyser.Analysis{}
+	a.Date = time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC)
 	for i := 0; i < 5; i++ {
 		a.AddManaged(&resource.Resource{
 			Id:   "managed-id-" + fmt.Sprintf("%d", i),
@@ -144,6 +147,7 @@ func fakeAnalysisNoDrift() *analyser.Analysis {
 
 func fakeAnalysisWithJsonFields() *analyser.Analysis {
 	a := analyser.NewAnalysis(analyser.AnalyzerOptions{Deep: true})
+	a.Date = time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC)
 	a.AddManaged(
 		&resource.Resource{
 			Id:   "diff-id-1",
@@ -205,6 +209,7 @@ func fakeAnalysisWithJsonFields() *analyser.Analysis {
 
 func fakeAnalysisWithoutAttrs() *analyser.Analysis {
 	a := analyser.NewAnalysis(analyser.AnalyzerOptions{Deep: true})
+	a.Date = time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC)
 	a.AddDeleted(
 		&resource.Resource{
 			Id:    "dfjkgnbsgj",
@@ -238,6 +243,7 @@ func fakeAnalysisWithoutAttrs() *analyser.Analysis {
 
 func fakeAnalysisWithStringerResources() *analyser.Analysis {
 	a := analyser.NewAnalysis(analyser.AnalyzerOptions{Deep: true})
+	a.Date = time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC)
 	schema := &resource.Schema{HumanReadableAttributesFunc: func(res *resource.Resource) map[string]string {
 		return map[string]string{
 			"Name": (*res.Attrs)["name"].(string),
@@ -307,6 +313,7 @@ func fakeAnalysisWithStringerResources() *analyser.Analysis {
 
 func fakeAnalysisWithComputedFields() *analyser.Analysis {
 	a := analyser.NewAnalysis(analyser.AnalyzerOptions{Deep: true})
+	a.Date = time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC)
 	a.AddManaged(
 		&resource.Resource{
 			Id:   "diff-id-1",
@@ -389,6 +396,7 @@ func fakeAnalysisWithComputedFields() *analyser.Analysis {
 
 func fakeAnalysisWithAWSEnumerationError() *analyser.Analysis {
 	a := analyser.Analysis{}
+	a.Date = time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC)
 	a.SetAlerts(alerter.Alerts{
 		"": []alerter.Alert{
 			alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, remoteerr.NewResourceListingErrorWithType(errors.New("dummy error"), "aws_vpc", "aws_vpc"), alerts.EnumerationPhase),
@@ -403,6 +411,7 @@ func fakeAnalysisWithAWSEnumerationError() *analyser.Analysis {
 
 func fakeAnalysisWithGithubEnumerationError() *analyser.Analysis {
 	a := analyser.Analysis{}
+	a.Date = time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC)
 	a.SetAlerts(alerter.Alerts{
 		"": []alerter.Alert{
 			alerts.NewRemoteAccessDeniedAlert(common.RemoteGithubTerraform, remoteerr.NewResourceListingErrorWithType(errors.New("dummy error"), "github_team", "github_team"), alerts.EnumerationPhase),
@@ -416,6 +425,7 @@ func fakeAnalysisWithGithubEnumerationError() *analyser.Analysis {
 
 func fakeAnalysisForJSONPlan() *analyser.Analysis {
 	a := analyser.Analysis{}
+	a.Date = time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC)
 	a.AddUnmanaged(
 		&resource.Resource{
 			Id:   "unmanaged-id-1",
@@ -455,6 +465,7 @@ func fakeAnalysisForJSONPlan() *analyser.Analysis {
 
 func fakeAnalysisWithoutDeep() *analyser.Analysis {
 	a := analyser.Analysis{}
+	a.Date = time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC)
 	a.AddUnmanaged(
 		&resource.Resource{
 			Id:   "unmanaged-id-1",
@@ -471,6 +482,7 @@ func fakeAnalysisWithoutDeep() *analyser.Analysis {
 
 func fakeAnalysisWithOnlyManagedFlag() *analyser.Analysis {
 	a := analyser.Analysis{}
+	a.Date = time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC)
 	a.SetOptions(analyser.AnalyzerOptions{
 		OnlyManaged: true,
 		Deep:        true,
@@ -522,6 +534,7 @@ func fakeAnalysisWithOnlyManagedFlag() *analyser.Analysis {
 
 func fakeAnalysisWithOnlyUnmanagedFlag() *analyser.Analysis {
 	a := analyser.Analysis{}
+	a.Date = time.Date(2022, 4, 8, 10, 35, 0, 0, time.UTC)
 	a.SetOptions(analyser.AnalyzerOptions{
 		OnlyUnmanaged: true,
 	})

--- a/pkg/cmd/scan/output/testdata/output.json
+++ b/pkg/cmd/scan/output/testdata/output.json
@@ -113,5 +113,6 @@
 	"alerts": null,
 	"provider_name": "AWS",
 	"provider_version": "3.19.0",
-	"scan_duration": 12
+	"scan_duration": 12,
+	"date": "2022-04-08T10:35:00Z"
 }

--- a/pkg/cmd/scan/output/testdata/output_access_denied_alert_aws.json
+++ b/pkg/cmd/scan/output/testdata/output_access_denied_alert_aws.json
@@ -31,5 +31,6 @@
 		]
 	},
 	"provider_name": "AWS",
-	"provider_version": "3.19.0"
+	"provider_version": "3.19.0",
+	"date": "2022-04-08T10:35:00Z"
 }

--- a/pkg/cmd/scan/output/testdata/output_access_denied_alert_github.json
+++ b/pkg/cmd/scan/output/testdata/output_access_denied_alert_github.json
@@ -28,5 +28,6 @@
 		]
 	},
 	"provider_name": "AWS",
-	"provider_version": "3.19.0"
+	"provider_version": "3.19.0",
+	"date": "2022-04-08T10:35:00Z"
 }

--- a/pkg/cmd/scan/output/testdata/output_computed_fields.json
+++ b/pkg/cmd/scan/output/testdata/output_computed_fields.json
@@ -96,5 +96,6 @@
 		]
 	},
 	"provider_name": "AWS",
-	"provider_version": "3.19.0"
+	"provider_version": "3.19.0",
+	"date": "2022-04-08T10:35:00Z"
 }

--- a/pkg/cmd/scan/output/testdata/output_multiples_times.json
+++ b/pkg/cmd/scan/output/testdata/output_multiples_times.json
@@ -19,5 +19,6 @@
 	"coverage": 0,
 	"alerts": null,
 	"provider_name": "",
-	"provider_version": ""
+	"provider_version": "",
+	"date": "0001-01-01T00:00:00Z"
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | https://github.com/snyk/driftctl-docs/pull/235 <!-- does this require documentation update ? -->

## Description

Some outputs may need the scanning date, which is missing when the analysis is serialized. So there's an invalid date when outputting to HTML with the fmt command. This PR adds the date in the JSON-serialized analysis so it can be parsed by the fmt command.

Related to [CFG-1761](https://snyksec.atlassian.net/browse/CFG-1761).