### PR TITLE
Add managed security group to ELB's acceptance test

### DIFF
--- a/pkg/resource/aws/testdata/acc/aws_elb/main.tf
+++ b/pkg/resource/aws/testdata/acc/aws_elb/main.tf
@@ -1,55 +1,94 @@
 provider "aws" {
-    region = "us-east-1"
+  region = "us-east-1"
 }
 
 terraform {
-    required_providers {
-        aws = {
-            version = "3.44.0"
-        }
+  required_providers {
+    aws = {
+      version = "3.44.0"
     }
+  }
 }
 
 data "aws_ami" "ubuntu" {
-    most_recent = true
+  most_recent = true
 
-    filter {
-        name   = "name"
-        values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
-    }
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
 
-    filter {
-        name   = "virtualization-type"
-        values = ["hvm"]
-    }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
 
-    owners = ["099720109477"] # Canonical
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.100.0.0/16"
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_security_group" "main" {
+  name        = "elb_sg"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "TLS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [aws_vpc.main.cidr_block]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+resource "aws_subnet" "subnet1" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.100.0.0/24"
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_subnet" "subnet2" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.100.1.0/24"
+  availability_zone = "us-east-1b"
 }
 
 resource "aws_instance" "web" {
-    ami           = data.aws_ami.ubuntu.id
-    instance_type = "t3.micro"
-
-    tags = {
-        Name = "HelloWorld"
-    }
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+  subnet_id     = aws_subnet.subnet1.id
 }
 
-# Create a new load balancer
 resource "aws_elb" "bar" {
-    name               = "acc-test-terraform-elb"
-    availability_zones = ["us-east-1a", "us-east-1b"]
+  name = "acc-test-terraform-elb"
 
-    listener {
-        instance_port     = 8000
-        instance_protocol = "http"
-        lb_port           = 80
-        lb_protocol       = "http"
-    }
+  listener {
+    instance_port     = 8000
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
 
-    instances                   = [aws_instance.web.id]
-    cross_zone_load_balancing   = true
-    idle_timeout                = 400
-    connection_draining         = true
-    connection_draining_timeout = 400
+  instances                   = [aws_instance.web.id]
+  cross_zone_load_balancing   = true
+  idle_timeout                = 400
+  connection_draining         = true
+  connection_draining_timeout = 400
+  security_groups             = [aws_security_group.main.id]
+  subnets                     = [aws_subnet.subnet1.id, aws_subnet.subnet2.id]
 }


### PR DESCRIPTION
## Description

As pointed out by @wbeuil [on Discord](https://discord.com/channels/783720783469871124/799233341483778089/964095075166584852), a default security group is created when no one is specified for a newly created ELB, resulting in a unmanaged dangling security group.

![image](https://user-images.githubusercontent.com/99100216/163423278-4c30a5b8-fedf-4daf-99d3-32f2718edfcb.png)

This PR makes this security group managed so it gets covered by the Terraform destroy operation. I also ran `terraform fmt`, so apologize for the noise here.