### PR TITLE
Add retry policy for google_compute_firewall acc test

### DIFF
--- a/pkg/resource/google/google_compute_firewall_test.go
+++ b/pkg/resource/google/google_compute_firewall_test.go
@@ -2,6 +2,7 @@ package google_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/snyk/driftctl/test"
 	"github.com/snyk/driftctl/test/acceptance"
@@ -18,6 +19,8 @@ func TestAcc_Google_ComputeFirewall(t *testing.T) {
 		},
 		Checks: []acceptance.AccCheck{
 			{
+				// New resources are not visible immediately through GCP API after an apply operation.
+				ShouldRetry: acceptance.LinearBackoff(10 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)


### PR DESCRIPTION
## Description

Following [this failure](https://app.circleci.com/pipelines/github/snyk/driftctl/4538/workflows/251b8a24-8318-4520-b23e-276bafaecd99/jobs/10509), this PR adds a retry policy for the `google_compute_firewall` acceptance test.