### PR TITLE
fix: weakness in eip enumerator

### DIFF
--- a/pkg/remote/aws/ec2_eip_enumerator.go
+++ b/pkg/remote/aws/ec2_eip_enumerator.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"github.com/sirupsen/logrus"
 	"github.com/snyk/driftctl/pkg/remote/aws/repository"
 	remoteerror "github.com/snyk/driftctl/pkg/remote/error"
 	"github.com/snyk/driftctl/pkg/resource"
@@ -32,6 +33,10 @@ func (e *EC2EipEnumerator) Enumerate() ([]*resource.Resource, error) {
 	results := make([]*resource.Resource, 0, len(addresses))
 
 	for _, address := range addresses {
+		if address.AllocationId == nil {
+			logrus.Warn("Elastic IP does not have an allocation ID, ignoring")
+			continue
+		}
 		results = append(
 			results,
 			e.factory.CreateAbstractResource(

--- a/pkg/remote/aws_ec2_scanner_test.go
+++ b/pkg/remote/aws_ec2_scanner_test.go
@@ -232,7 +232,9 @@ func TestEC2Eip(t *testing.T) {
 			test:    "no eips",
 			dirName: "aws_ec2_eip_empty",
 			mocks: func(repository *repository.MockEC2Repository, alerter *mocks.AlerterInterface) {
-				repository.On("ListAllAddresses").Return([]*ec2.Address{}, nil)
+				repository.On("ListAllAddresses").Return([]*ec2.Address{
+					{}, // Test Eip without AllocationId because it can happen (seen in sentry)
+				}, nil)
 			},
 		},
 		{


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Sentry Issue: [DRIFTCTL-1S](https://sentry.io/organizations/snyk/issues/3266908553/?referrer=github_integration)

```
*errors.fundamental: A runner routine paniced: runtime error: invalid memory address or nil pointer dereference
  File "github.com/snyk/driftctl/pkg/parallel/parallel_runner.go", line 94, in (*ParallelRunner).Run.func1.1
  File "github.com/snyk/driftctl/pkg/remote/aws/ec2_eip_enumerator.go", line 39, in (*EC2EipEnumerator).Enumerate
  File "github.com/snyk/driftctl/pkg/remote/scanner.go", line 71, in (*Scanner).scan.func1
  File "github.com/snyk/driftctl/pkg/parallel/parallel_runner.go", line 97, in (*ParallelRunner).Run.func1
```