### PR TITLE
chore: fix issue tagging script

### DIFF
--- a/scripts/issue-tagging.sh
+++ b/scripts/issue-tagging.sh
@@ -50,9 +50,11 @@ for pr in $PRs; do
     ISSUES+=("$id")
 done
 
-# Remove duplicate IDs
-# This can happen when we release using a separate branch (e.g. patch releases)
-mapfile -t ISSUES < <(printf "%s\n" "${ISSUES[@]}" | sort -u)
+if (( ${#ISSUES[@]} > 0 )); then
+    # Remove duplicate IDs
+    # This can happen when we release using a separate branch (e.g. patch releases)
+    mapfile -t ISSUES < <(printf "%s\n" "${ISSUES[@]}" | sort -u)
+fi
 
 echo "Creating milestone $LATEST_TAG in github.com/$REPO"
 curl -X POST \


### PR DESCRIPTION
## Description

This script was throwing an error when there's no issue to create a milestone for. This PR adds a check on the ISSUES array, if it's empty, don't rewrite the array. So it will create an empty milestone for this release.

[Example of failure](https://app.circleci.com/pipelines/github/snyk/driftctl/4609/workflows/9d07eebf-df2d-41e8-bc9e-5cbe14284e74/jobs/10826)