### PR TITLE
chore: Stop failing issue tagging on invalid issue links

### DIFF
--- a/scripts/issue-tagging.sh
+++ b/scripts/issue-tagging.sh
@@ -35,7 +35,6 @@ echo "Finding merged pull requests between $BASE_TAG and $LATEST_TAG..."
 PRs=$(git log --pretty=oneline "$BASE_TAG"..."$LATEST_TAG" | grep 'Merge pull request #' | grep -oE '#[0-9]+' | sed 's/#//')
 
 # Find fixed issues from $BASE_TAG to $LATEST_TAG
-EXIT_CODE=0
 ISSUES=()
 for pr in $PRs; do
     id=$($GHCLI_BIN pr view "$pr" --json body | grep -oE '(Related issues \| )(.*)?[0-9]+(.*|\r|\n)?(\|)' | sed 's/[^[:digit:]]//g' | sed -z 's/\n//g' || true)
@@ -44,7 +43,6 @@ for pr in $PRs; do
     fi
     if ! $GHCLI_BIN issue view "$id" --json title &> /dev/null; then
         echo "Invalid issue $id for pull request $pr. Skipping."
-        EXIT_CODE=1
         continue
     fi
     ISSUES+=("$id")
@@ -75,4 +73,3 @@ for issue in "${ISSUES[@]}"; do
 done
 
 echo "Done."
-exit $EXIT_CODE


### PR DESCRIPTION
## Description

The script was detecting JIRA issue links as GH issues and subsequently failing when checking that a GH issue with the same ID exists (example of a failure [here](https://app.circleci.com/pipelines/github/snyk/driftctl/4640/workflows/02c81b9b-96d1-4e0a-af16-a0b84da03316/jobs/10958?invite=true#step-105-5)).

Given we seem to have a mix of GH and JIRA issue links, we can just not fail the job if no GH issue can be found for a certain ID.