### PR TITLE
fix: ecr repo without policy was crashing the whole execution

### DIFF
--- a/pkg/remote/aws/ecr_repository_policy_enumerator.go
+++ b/pkg/remote/aws/ecr_repository_policy_enumerator.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/snyk/driftctl/pkg/remote/aws/repository"
 	remoteerror "github.com/snyk/driftctl/pkg/remote/error"
 	"github.com/snyk/driftctl/pkg/resource"
@@ -33,6 +34,9 @@ func (e *ECRRepositoryPolicyEnumerator) Enumerate() ([]*resource.Resource, error
 
 	for _, repo := range repos {
 		repoOutput, err := e.repository.GetRepositoryPolicy(repo)
+		if _, ok := err.(*ecr.RepositoryPolicyNotFoundException); ok {
+			continue
+		}
 		if err != nil {
 			return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 		}

--- a/pkg/remote/aws_ecr_scanner_test.go
+++ b/pkg/remote/aws_ecr_scanner_test.go
@@ -138,6 +138,7 @@ func TestECRRepositoryPolicy(t *testing.T) {
 			mocks: func(client *repository.MockECRRepository, alerter *mocks.AlerterInterface) {
 				client.On("ListAllRepositories").Return([]*ecr.Repository{
 					{RepositoryName: awssdk.String("test_ecr_repo_policy")},
+					{RepositoryName: awssdk.String("test_ecr_repo_without_policy")},
 				}, nil)
 				client.On("GetRepositoryPolicy", &ecr.Repository{
 					RepositoryName: awssdk.String("test_ecr_repo_policy"),
@@ -145,6 +146,9 @@ func TestECRRepositoryPolicy(t *testing.T) {
 					RegistryId:     awssdk.String("1"),
 					RepositoryName: awssdk.String("test_ecr_repo_policy"),
 				}, nil)
+				client.On("GetRepositoryPolicy", &ecr.Repository{
+					RepositoryName: awssdk.String("test_ecr_repo_without_policy"),
+				}).Return(nil, &ecr.RepositoryPolicyNotFoundException{})
 			},
 			assertExpected: func(t *testing.T, got []*resource.Resource) {
 				assert.Len(t, got, 1)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #1549
| ❓ Documentation  | no

## Description

Fix a crash when scanning ECR repositories without attached policy.
Introduced in #1494