### PR TITLE
Discover tfstate from hcl

### DIFF
--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -387,7 +387,7 @@ func retrieveBackendsFromHCL(workdir string) ([]config.SupplierConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	var supplierConfigs []config.SupplierConfig
+	supplierConfigs := make([]config.SupplierConfig, 0)
 
 	for _, match := range matches {
 		body, err := hcl.ParseTerraformFromHCL(match)

--- a/pkg/cmd/testdata/backend/s3/invalid.tf
+++ b/pkg/cmd/testdata/backend/s3/invalid.tf
@@ -1,0 +1,1 @@
+invalid {}

--- a/pkg/cmd/testdata/backend/s3/s3.tf
+++ b/pkg/cmd/testdata/backend/s3/s3.tf
@@ -1,0 +1,7 @@
+terraform {
+    backend "s3" {
+        bucket = "terraform-state-prod"
+        key    = "network/terraform.tfstate"
+        region = "us-east-1"
+    }
+}

--- a/pkg/iac/terraform/state/backend/gs_reader.go
+++ b/pkg/iac/terraform/state/backend/gs_reader.go
@@ -53,6 +53,9 @@ func (s *GSBackend) Read(p []byte) (int, error) {
 }
 
 func (s *GSBackend) Close() error {
+	if s.storageClient == nil {
+		return nil
+	}
 	if err := s.storageClient.Close(); err != nil {
 		return err
 	}

--- a/pkg/terraform/hcl/backend.go
+++ b/pkg/terraform/hcl/backend.go
@@ -1,0 +1,81 @@
+package hcl
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/snyk/driftctl/pkg/iac/config"
+	"github.com/snyk/driftctl/pkg/iac/terraform/state"
+	"github.com/snyk/driftctl/pkg/iac/terraform/state/backend"
+)
+
+type BackendBlock struct {
+	Name          string   `hcl:"name,label"`
+	Path          string   `hcl:"path,optional"`
+	WorkspaceDir  string   `hcl:"workspace_dir,optional"`
+	Bucket        string   `hcl:"bucket,optional"`
+	Key           string   `hcl:"key,optional"`
+	Region        string   `hcl:"region,optional"`
+	Prefix        string   `hcl:"prefix,optional"`
+	ContainerName string   `hcl:"container_name,optional"`
+	Remain        hcl.Body `hcl:",remain"`
+}
+
+func (b BackendBlock) SupplierConfig() *config.SupplierConfig {
+	switch b.Name {
+	case "local":
+		return b.parseLocalBackend()
+	case "s3":
+		return b.parseS3Backend()
+	case "gcs":
+		return b.parseGCSBackend()
+	case "azurerm":
+		return b.parseAzurermBackend()
+	}
+	return nil
+}
+
+func (b BackendBlock) parseLocalBackend() *config.SupplierConfig {
+	if b.Path == "" {
+		return nil
+	}
+	return &config.SupplierConfig{
+		Key:     state.TerraformStateReaderSupplier,
+		Backend: backend.BackendKeyFile,
+		Path:    path.Join(b.WorkspaceDir, b.Path),
+	}
+}
+
+func (b BackendBlock) parseS3Backend() *config.SupplierConfig {
+	if b.Bucket == "" || b.Key == "" {
+		return nil
+	}
+	return &config.SupplierConfig{
+		Key:     state.TerraformStateReaderSupplier,
+		Backend: backend.BackendKeyS3,
+		Path:    path.Join(b.Bucket, b.Key),
+	}
+}
+
+func (b BackendBlock) parseGCSBackend() *config.SupplierConfig {
+	if b.Bucket == "" || b.Prefix == "" {
+		return nil
+	}
+	return &config.SupplierConfig{
+		Key:     state.TerraformStateReaderSupplier,
+		Backend: backend.BackendKeyGS,
+		Path:    fmt.Sprintf("%s.tfstate", path.Join(b.Bucket, b.Prefix)),
+	}
+}
+
+func (b BackendBlock) parseAzurermBackend() *config.SupplierConfig {
+	if b.ContainerName == "" || b.Key == "" {
+		return nil
+	}
+	return &config.SupplierConfig{
+		Key:     state.TerraformStateReaderSupplier,
+		Backend: backend.BackendKeyAzureRM,
+		Path:    path.Join(b.ContainerName, b.Key),
+	}
+}

--- a/pkg/terraform/hcl/backend_test.go
+++ b/pkg/terraform/hcl/backend_test.go
@@ -1,0 +1,78 @@
+package hcl
+
+import (
+	"testing"
+
+	"github.com/snyk/driftctl/pkg/iac/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackend_SupplierConfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		dir     string
+		want    *config.SupplierConfig
+		wantErr string
+	}{
+		{
+			name:    "test with no backend block",
+			dir:     "testdata/no_backend_block.tf",
+			want:    nil,
+			wantErr: "testdata/no_backend_block.tf:1,11-11: Missing backend block; A backend block is required.",
+		},
+		{
+			name: "test with local backend block",
+			dir:  "testdata/local_backend_block.tf",
+			want: &config.SupplierConfig{
+				Key:  "tfstate",
+				Path: "terraform-state-prod/network/terraform.tfstate",
+			},
+		},
+		{
+			name: "test with S3 backend block",
+			dir:  "testdata/s3_backend_block.tf",
+			want: &config.SupplierConfig{
+				Key:     "tfstate",
+				Backend: "s3",
+				Path:    "terraform-state-prod/network/terraform.tfstate",
+			},
+		},
+		{
+			name: "test with GCS backend block",
+			dir:  "testdata/gcs_backend_block.tf",
+			want: &config.SupplierConfig{
+				Key:     "tfstate",
+				Backend: "gs",
+				Path:    "tf-state-prod/terraform/state.tfstate",
+			},
+		},
+		{
+			name: "test with Azure backend block",
+			dir:  "testdata/azurerm_backend_block.tf",
+			want: &config.SupplierConfig{
+				Key:     "tfstate",
+				Backend: "azurerm",
+				Path:    "states/prod.terraform.tfstate",
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			hcl, err := ParseTerraformFromHCL(tt.dir)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			if hcl.Backend.SupplierConfig() == nil {
+				assert.Nil(t, tt.want)
+				return
+			}
+
+			assert.Equal(t, *tt.want, *hcl.Backend.SupplierConfig())
+		})
+	}
+}

--- a/pkg/terraform/hcl/hcl.go
+++ b/pkg/terraform/hcl/hcl.go
@@ -1,0 +1,31 @@
+package hcl
+
+import (
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclparse"
+)
+
+type MainBodyBlock struct {
+	Terraform TerraformBlock `hcl:"terraform,block"`
+}
+
+type TerraformBlock struct {
+	Backend BackendBlock `hcl:"backend,block"`
+}
+
+func ParseTerraformFromHCL(filename string) (*TerraformBlock, error) {
+	var v MainBodyBlock
+
+	parser := hclparse.NewParser()
+	f, diags := parser.ParseHCLFile(filename)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	diags = gohcl.DecodeBody(f.Body, nil, &v)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return &v.Terraform, nil
+}

--- a/pkg/terraform/hcl/testdata/azurerm_backend_block.tf
+++ b/pkg/terraform/hcl/testdata/azurerm_backend_block.tf
@@ -1,0 +1,8 @@
+terraform {
+    backend "azurerm" {
+        resource_group_name  = "StorageAccount-ResourceGroup"
+        storage_account_name = "abcd1234"
+        container_name       = "states"
+        key                  = "prod.terraform.tfstate"
+    }
+}

--- a/pkg/terraform/hcl/testdata/gcs_backend_block.tf
+++ b/pkg/terraform/hcl/testdata/gcs_backend_block.tf
@@ -1,0 +1,6 @@
+terraform {
+    backend "gcs" {
+        bucket  = "tf-state-prod"
+        prefix  = "terraform/state"
+    }
+}

--- a/pkg/terraform/hcl/testdata/local_backend_block.tf
+++ b/pkg/terraform/hcl/testdata/local_backend_block.tf
@@ -1,0 +1,5 @@
+terraform {
+    backend "local" {
+        path = "terraform-state-prod/network/terraform.tfstate"
+    }
+}

--- a/pkg/terraform/hcl/testdata/no_backend_block.tf
+++ b/pkg/terraform/hcl/testdata/no_backend_block.tf
@@ -1,0 +1,1 @@
+terraform {}

--- a/pkg/terraform/hcl/testdata/s3_backend_block.tf
+++ b/pkg/terraform/hcl/testdata/s3_backend_block.tf
@@ -1,0 +1,7 @@
+terraform {
+    backend "s3" {
+        bucket = "terraform-state-prod"
+        key    = "network/terraform.tfstate"
+        region = "us-east-1"
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | [CFG-1972](https://snyksec.atlassian.net/browse/CFG-1972)
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

This PR introduces support for Terraform backend discovering when user doesn't specify a IAC source. Most of the code in Terraform related to backends can't be used in third party code so I couldn't use it.