### PR TITLE
fix: fix #1558 by ignoring FeatureNotSupported

### DIFF
--- a/pkg/resource/azurerm/testdata/acc/azurerm_storage_container/terraform.tf
+++ b/pkg/resource/azurerm/testdata/acc/azurerm_storage_container/terraform.tf
@@ -27,6 +27,15 @@ resource "azurerm_storage_account" "example" {
     }
 }
 
+resource "azurerm_storage_account" "noblob" {
+    name                     = "testaccdriftctlnoblob"
+    resource_group_name      = data.azurerm_resource_group.qa1.name
+    location                 = data.azurerm_resource_group.qa1.location
+    account_tier             = "Premium"
+    account_replication_type = "LRS"
+    account_kind = "FileStorage"
+}
+
 resource "azurerm_storage_container" "private" {
     name                  = "private"
     storage_account_name  = azurerm_storage_account.example.name


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #1558
| ❓ Documentation  | no

## Description

For azure when one of you storage account does not support blob it throws error and used to end the scan.
We decided to ignore the error inside the repository and return empty list as basically not having blob support mean there won't be any related resources.