### PR TITLE
Upgrade debian image to debian-11 in acc test

### DIFF
--- a/pkg/resource/google/testdata/acc/google_compute_instance/terraform.tf
+++ b/pkg/resource/google/testdata/acc/google_compute_instance/terraform.tf
@@ -20,7 +20,7 @@ resource "google_compute_instance" "default" {
 
     boot_disk {
         initialize_params {
-            image = "debian-cloud/debian-9"
+            image = "debian-cloud/debian-11"
         }
     }
 

--- a/pkg/resource/google/testdata/acc/google_compute_instance_group_manager/terraform.tf
+++ b/pkg/resource/google/testdata/acc/google_compute_instance_group_manager/terraform.tf
@@ -45,7 +45,7 @@ resource "google_compute_instance_template" "appserver" {
 
     // boot disk
     disk {
-        source_image      = "debian-cloud/debian-9"
+        source_image      = "debian-cloud/debian-11"
         auto_delete       = true
         boot              = true
     }


### PR DESCRIPTION
## Description

Those tests [were failing](https://app.circleci.com/pipelines/github/snyk/driftctl/4771/workflows/eef2bec1-ec64-460e-9e9e-e3728a5d29d2/jobs/11523) because debian-9 was removed from the GCP registry. This PR upgrades the image to debian-11.