### PR TITLE
fix: do not panic on aws provider init

### DIFF
--- a/enumeration/remote/aws/provider.go
+++ b/enumeration/remote/aws/provider.go
@@ -63,9 +63,14 @@ func NewAWSTerraformProvider(version string, progress enumeration.ProgressCounte
 	if err != nil {
 		return nil, err
 	}
-	p.session = session.Must(session.NewSessionWithOptions(session.Options{
+
+	p.session, err = session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
-	}))
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	tfProvider, err := terraform.NewTerraformProvider(installer, terraform.TerraformProviderConfig{
 		Name:         p.name,
 		DefaultAlias: *p.session.Config.Region,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Remove the must so we do not panic on aws session creation and forward the error.