### PR TITLE
fix: enumlib: remove a scan-specific error message

### DIFF
--- a/enumeration/remote/aws/provider.go
+++ b/enumeration/remote/aws/provider.go
@@ -101,12 +101,13 @@ func (p *AWSTerraformProvider) Version() string {
 	return p.version
 }
 
+var AWSCredentialsNotFoundError = errors.New("Could not find a way to authenticate on AWS!\n" +
+	"Please refer to AWS documentation: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html")
+
 func (p *AWSTerraformProvider) CheckCredentialsExist() error {
 	_, err := p.session.Config.Credentials.Get()
 	if err == credentials.ErrNoValidProvidersFoundInChain {
-		return errors.New("Could not find a way to authenticate on AWS!\n" +
-			"Please refer to AWS documentation: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html\n\n" +
-			"To use a different cloud provider, use --to=\"gcp+tf\" for GCP or --to=\"azure+tf\" for Azure.")
+		return AWSCredentialsNotFoundError
 	}
 	if err != nil {
 		return err

--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -18,6 +18,7 @@ import (
 	"github.com/snyk/driftctl/build"
 	"github.com/snyk/driftctl/enumeration/alerter"
 	"github.com/snyk/driftctl/enumeration/remote"
+	"github.com/snyk/driftctl/enumeration/remote/aws"
 	"github.com/snyk/driftctl/enumeration/remote/common"
 	"github.com/snyk/driftctl/enumeration/terraform"
 	"github.com/snyk/driftctl/enumeration/terraform/lock"
@@ -293,6 +294,12 @@ func scanRun(opts *pkg.ScanOptions) error {
 
 	err := remote.Activate(opts.To, opts.ProviderVersion, alerter, providerLibrary, remoteLibrary, scanProgress, resFactory, opts.ConfigDir)
 	if err != nil {
+		if err == aws.AWSCredentialsNotFoundError {
+			// special case command-line advice, because AWS is the default cloud
+			// provider, and users may be confused by a cloud-specific error out of
+			// the box
+			return fmt.Errorf("%s\n\n%s", err, "To use a different cloud provider, use --to=\"gcp+tf\" for GCP or --to=\"azure+tf\" for Azure.")
+		}
 		return err
 	}
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | n/a
| ❓ Documentation  | no

## Description

Since AWS is the default cloud provider for `driftctl scan`, we give
users a hint on how to configure different providers with `--to` if
there is an error authenticating with AWS - since they might not have
even intended to use AWS in the first place.

Now that this functionality is inside the enumeration library, with
consumers other than `driftctl scan`, we remove this hint from the lower
layer and re-add it for the scan command only, to avoid confusing
non-driftctl users.