### PR TITLE
Only check owned repositories when running in owner mode

### DIFF
--- a/enumeration/remote/github/repository.go
+++ b/enumeration/remote/github/repository.go
@@ -116,7 +116,7 @@ type listRepoForOwnerQuery struct {
 				EndCursor   githubv4.String
 				HasNextPage bool
 			}
-		} `graphql:"repositories(first: 100, after: $cursor)"`
+		} `graphql:"repositories(first: 100, after: $cursor, ownerAffiliations: OWNER)"`
 	}
 }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   |  no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | N/A
| ❓ Documentation  | no

## Description

Before this change, using the GitHub provider on your own user account (and not on an organization) would list repositories owned by other users that the current user had commit access to, such as being marked a collaborator (personal repositories, that is). This then caused driftctl to usually crash trying to access things it shouldn't (it would prefix the owner's username to someone else's repository name).

This fix ensures that only repositories owned by the actual user queried get taken into account.

IMO, there is no situation where the previous behavior would be desired, even if the "prefix the owner's name before other person's repository" bug was fixed.