### PR TITLE
chore: ignore mpl 2.0 security vulnerability

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.1
+version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515:
@@ -11,100 +11,89 @@ ignore:
         created: 2030-11-22T16:25:33.580Z
   'snyk:lic:golang:github.com:hashicorp:go-checkpoint:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:go-cleanhttp:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:go-getter:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:go-multierror:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:go-plugin:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:go-retryablehttp:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:go-safetemp:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:go-slug:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:go-tfe:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:go-uuid:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:go-version:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:hcl:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:hcl:v2:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:terraform-json:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:terraform-svchost:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:yamux:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:r3labs:diff:v2:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   'snyk:lic:golang:github.com:hashicorp:errwrap:MPL-2.0':
     - '*':
-        reason: >-
-          This license is addressed by including acknowledgments in each release
+        reason: This license is addressed by including acknowledgments in each release
         created: 2021-12-09T16:40:21.832Z
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-2331920:
-    - 'github.com/hashicorp/terraform/terraform@0.14.0 > *':
+    - github.com/hashicorp/terraform/terraform@0.14.0 > *:
         reason: We do not use this part of terraform code
         created: 2022-01-11T09:46:06.556Z
-    - 'github.com/hashicorp/terraform/plugin@0.14.0 > *':
+    - github.com/hashicorp/terraform/plugin@0.14.0 > *:
         reason: We do not use this part of terraform plugin
         created: 2022-01-11T09:46:06.556Z
+  'snyk:lic:golang:github.com:hashicorp:terraform-exec:MPL-2.0':
+    - '*':
+        reason: This license is addressed by including acknowledgments in each release
+        created: 2022-09-09T14:25:05.042Z
+  'snyk:lic:golang:github.com:hashicorp:terraform:MPL-2.0':
+    - '*':
+        reason: This license is addressed by including acknowledgments in each release
+        created: 2022-09-09T14:25:05.042Z
 patch: {}
-


### PR DESCRIPTION
## Description

Snyk is flagging up https://spdx.org/licenses/MPL-2.0.html in the `go.mod` file of this repo. As the other ignores in the `.snyk` file say, this can be ignored.