### PR TITLE
 fix issue when scanning without any s3_account_public_access_block

### DIFF
--- a/enumeration/remote/aws/s3_account_public_access_block_enumerator.go
+++ b/enumeration/remote/aws/s3_account_public_access_block_enumerator.go
@@ -37,6 +37,10 @@ func (e *S3AccountPublicAccessBlockEnumerator) Enumerate() ([]*resource.Resource
 
 	results := make([]*resource.Resource, 0, 1)
 
+	if accountPublicAccessBlock == nil {
+		return results, nil
+	}
+
 	results = append(
 		results,
 		e.factory.CreateAbstractResource(


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | yes/no
| ❌ BC Break       | yes/no
| 🔗 Related issues | #1590 1590
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Describing s3_account_public_access_block when you never had this resource will result in a 404 that was not handled and thus failed the scan instead of just returning no resources