### PR TITLE
fix: aws_lb_listener cache key

### DIFF
--- a/enumeration/remote/aws/repository/elbv2_repository.go
+++ b/enumeration/remote/aws/repository/elbv2_repository.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
@@ -45,7 +47,8 @@ func (r *elbv2Repository) ListAllLoadBalancers() ([]*elbv2.LoadBalancer, error) 
 }
 
 func (r *elbv2Repository) ListAllLoadBalancerListeners(loadBalancerArn string) ([]*elbv2.Listener, error) {
-	if v := r.cache.Get("elbv2ListAllLoadBalancerListeners"); v != nil {
+	cacheKey := fmt.Sprintf("elbv2ListAllLoadBalancerListeners_%s", loadBalancerArn)
+	if v := r.cache.Get(cacheKey); v != nil {
 		return v.([]*elbv2.Listener), nil
 	}
 
@@ -60,6 +63,6 @@ func (r *elbv2Repository) ListAllLoadBalancerListeners(loadBalancerArn string) (
 	if err != nil {
 		return nil, err
 	}
-	r.cache.Put("elbv2ListAllLoadBalancerListeners", results)
+	r.cache.Put(cacheKey, results)
 	return results, err
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | https://github.com/snyk/driftctl/issues/1598
| ❓ Documentation  | no

## Description

Extends the cache key for load balancer listeners to correctly include the load balancer name, so that we don't return listeners belonging to other LBs.

The tests are currently structured around testing a single method call which won't test this issue, so I extended the tests to have multiple calls. Let me know if there are existing patterns or other ways you'd prefer this done.