### PR TITLE
Update to Go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/driftctl
 
-go 1.17
+go 1.18
 
 require (
 	cloud.google.com/go/asset v0.1.0


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

Editing go.mod was missing in https://github.com/snyk/driftctl/pull/1543. Was it intentional?