### PR TITLE
chore: change SSH key fingerprint for AUR publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
       steps:
           - checkout
           - snyk/scan:
-                severity-threshold: medium
+                severity-threshold: high
                 monitor-on-build: true
                 project: ${CIRCLE_PROJECT_REPONAME}
                 organization: snyk-iac-group-seceng
@@ -211,7 +211,7 @@ jobs:
           - checkout
           - snyk/scan:
                 command: code test
-                severity-threshold: medium
+                severity-threshold: high
                 monitor-on-build: false
                 project: ${CIRCLE_PROJECT_REPONAME}
                 organization: snyk-iac-group-seceng

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
       # This key is bound to user snyk on AUR
       - add_ssh_keys:
             fingerprints:
-                - "ba:05:09:d6:a6:2a:45:34:89:c4:5e:22:23:22:e8:9f"
+                - "75:59:a3:1d:81:9a:0f:44:98:4c:78:33:db:e5:51:6a"
       - run:
           name: Bump package version
           command: |


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Given the recent CircleCI breach we needed to rotate all keys.