### PR TITLE
fix: update gpg email in goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ before:
 signs:
     - signature: "${artifact}.gpg"
       artifacts: checksum
-      args: [ "--batch", "-u", "security@cloudskiff.com", "--output", "${signature}", "--detach-sign", "${artifact}" ]
+      args: [ "--batch", "-u", "team-cloud-config+security@snyk.io", "--output", "${signature}", "--detach-sign", "${artifact}" ]
 builds:
     - id: "driftctl"
       binary: driftctl


### PR DESCRIPTION
Change the email corresponding to the new gpg signing key in goreleaser config