### PR TITLE
Incorrect terraform provider downloaded

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/driftctl.iml
+++ b/.idea/driftctl.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/driftctl.iml" filepath="$PROJECT_DIR$/.idea/driftctl.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/enumeration/terraform/provider_config.go
+++ b/enumeration/terraform/provider_config.go
@@ -1,32 +1,29 @@
 package terraform
 
 import (
-	"fmt"
-	"runtime"
+    "fmt"
+    "runtime"
 )
 
 type ProviderConfig struct {
-	Key       string
-	Version   string
-	ConfigDir string
+    Key       string
+    Version   string
+    ConfigDir string
 }
 
 func (c *ProviderConfig) GetDownloadUrl() string {
-	arch := runtime.GOARCH
-	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-		arch = "amd64"
-	}
-	return fmt.Sprintf(
-		"https://releases.hashicorp.com/terraform-provider-%s/%s/terraform-provider-%s_%s_%s_%s.zip",
-		c.Key,
-		c.Version,
-		c.Key,
-		c.Version,
-		runtime.GOOS,
-		arch,
-	)
+    arch := runtime.GOARCH
+    return fmt.Sprintf(
+        "https://releases.hashicorp.com/terraform-provider-%s/%s/terraform-provider-%s_%s_%s_%s.zip",
+        c.Key,
+        c.Version,
+        c.Key,
+        c.Version,
+        runtime.GOOS,
+        arch,
+    )
 }
 
 func (c *ProviderConfig) GetBinaryName() string {
-	return fmt.Sprintf("terraform-provider-%s_v%s", c.Key, c.Version)
+    return fmt.Sprintf("terraform-provider-%s_v%s", c.Key, c.Version)
 }

--- a/enumeration/terraform/provider_config.go
+++ b/enumeration/terraform/provider_config.go
@@ -13,9 +13,6 @@ type ProviderConfig struct {
 
 func (c *ProviderConfig) GetDownloadUrl() string {
 	arch := runtime.GOARCH
-	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-		arch = "amd64"
-	}
 	return fmt.Sprintf(
 		"https://releases.hashicorp.com/terraform-provider-%s/%s/terraform-provider-%s_%s_%s_%s.zip",
 		c.Key,


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes

## Description

If runtime.GOARCH was "arm64" then would get set to "amd64"? Possible mistake?

Closes #1632