### PR TITLE
[CTX-601] chore: always retry terraform-destroy

### DIFF
--- a/pkg/resource/aws/aws_eip_association_test.go
+++ b/pkg/resource/aws/aws_eip_association_test.go
@@ -2,7 +2,6 @@ package aws_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/snyk/driftctl/test"
 	"github.com/snyk/driftctl/test/acceptance"
@@ -13,10 +12,6 @@ func TestAcc_Aws_EipAssociation(t *testing.T) {
 		TerraformVersion: "0.15.5",
 		Paths:            []string{"./testdata/acc/aws_eip_association"},
 		Args:             []string{"scan", "--deep"},
-		RetryDestroy: acceptance.RetryConfig{
-			Attempts: 3,
-			Delay:    5 * time.Second,
-		},
 		Checks: []acceptance.AccCheck{
 			{
 				Env: map[string]string{

--- a/pkg/resource/aws/aws_eip_test.go
+++ b/pkg/resource/aws/aws_eip_test.go
@@ -13,10 +13,6 @@ func TestAcc_Aws_Eip(t *testing.T) {
 		TerraformVersion: "0.15.5",
 		Paths:            []string{"./testdata/acc/aws_eip"},
 		Args:             []string{"scan", "--deep"},
-		RetryDestroy: acceptance.RetryConfig{
-			Attempts: 3,
-			Delay:    5 * time.Second,
-		},
 		Checks: []acceptance.AccCheck{
 			{
 				Env: map[string]string{

--- a/pkg/resource/aws/aws_internet_gateway_test.go
+++ b/pkg/resource/aws/aws_internet_gateway_test.go
@@ -13,10 +13,6 @@ func TestAcc_Aws_InternetGateway(t *testing.T) {
 		TerraformVersion: "0.15.5",
 		Paths:            []string{"./testdata/acc/aws_internet_gateway"},
 		Args:             []string{"scan", "--deep"},
-		RetryDestroy: acceptance.RetryConfig{
-			Attempts: 3,
-			Delay:    5 * time.Second,
-		},
 		Checks: []acceptance.AccCheck{
 			{
 				Env: map[string]string{

--- a/pkg/resource/aws/aws_route_table_association_test.go
+++ b/pkg/resource/aws/aws_route_table_association_test.go
@@ -2,7 +2,6 @@ package aws_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/snyk/driftctl/test"
 	"github.com/snyk/driftctl/test/acceptance"
@@ -13,10 +12,6 @@ func TestAcc_Aws_RouteTableAssociation(t *testing.T) {
 		TerraformVersion: "0.15.5",
 		Paths:            []string{"./testdata/acc/aws_route_table_association"},
 		Args:             []string{"scan", "--deep"},
-		RetryDestroy: acceptance.RetryConfig{
-			Attempts: 3,
-			Delay:    5 * time.Second,
-		},
 		Checks: []acceptance.AccCheck{
 			{
 				Env: map[string]string{

--- a/pkg/resource/aws/aws_route_test.go
+++ b/pkg/resource/aws/aws_route_test.go
@@ -13,10 +13,6 @@ func TestAcc_Aws_Route(t *testing.T) {
 		TerraformVersion: "0.15.5",
 		Paths:            []string{"./testdata/acc/aws_route"},
 		Args:             []string{"scan", "--deep"},
-		RetryDestroy: acceptance.RetryConfig{
-			Attempts: 3,
-			Delay:    5 * time.Second,
-		},
 		Checks: []acceptance.AccCheck{
 			{
 				Env: map[string]string{
@@ -41,10 +37,6 @@ func TestAcc_Aws_Route_With_PrefixListId(t *testing.T) {
 		TerraformVersion: "0.15.5",
 		Paths:            []string{"./testdata/acc/aws_route_with_prefix_list_id"},
 		Args:             []string{"scan", "--deep"},
-		RetryDestroy: acceptance.RetryConfig{
-			Attempts: 3,
-			Delay:    5 * time.Second,
-		},
 		Checks: []acceptance.AccCheck{
 			{
 				Env: map[string]string{


### PR DESCRIPTION
Many acceptance test failures are caused by stray resources left behind from previous runs. We think failed terraform-destroy cleanup might be to blame. This commit adds unconditional retry with a long exponential backoff to try to ensure that cleanup can work within cloud provider rate limits, reducing the maintenance burden.

Remove RetryConfig, which a small number of tests were using to optionally add retry behaviour.