### PR TITLE
[CTX-601] chore: fix some Google acceptance tests

### DIFF
--- a/pkg/resource/google/testdata/acc/google_compute_ssl_certificate/.terraform.lock.hcl
+++ b/pkg/resource/google/testdata/acc/google_compute_ssl_certificate/.terraform.lock.hcl
@@ -20,3 +20,22 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:e946561921e0279450e9b9f705de9354ce35562ed4cc0d4cd3512aa9eb1f6486",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/pkg/resource/google/testdata/acc/google_compute_ssl_certificate/terraform.tf
+++ b/pkg/resource/google/testdata/acc/google_compute_ssl_certificate/terraform.tf
@@ -1,19 +1,20 @@
 provider "google" {}
 
 terraform {
-    required_version = "~> 0.15.0"
-    required_providers {
-        google = {
-            version = "3.78.0"
-        }
+  required_version = "~> 0.15.0"
+  required_providers {
+    google = {
+      version = "3.78.0"
     }
+  }
 }
 
 resource "random_string" "postfix" {
-    length  = 6
-    upper   = false
-    special = false
+  length  = 6
+  upper   = false
+  special = false
 }
+
 resource "google_compute_ssl_certificate" "default" {
   name        = random_id.certificate.hex
   private_key = file("host.key")
@@ -22,10 +23,6 @@ resource "google_compute_ssl_certificate" "default" {
   lifecycle {
     create_before_destroy = true
   }
-}
-
-provider "google" {
-  project = "driftctl"
 }
 
 resource "random_id" "certificate" {

--- a/pkg/resource/google/testdata/acc/google_project_iam_member/terraform.tf
+++ b/pkg/resource/google/testdata/acc/google_project_iam_member/terraform.tf
@@ -11,10 +11,10 @@ terraform {
 
 resource "google_project_iam_member" "elie1" {
   role   = "roles/editor"
-  member = "user:cloud-context-team@snyk.io"
+  member = "group:cloud-context-team@snyk.io"
 }
 
 resource "google_project_iam_member" "will1" {
   role   = "roles/viewer"
-  member = "user:cloud-context-team@snyk.io"
+  member = "group:cloud-context-team@snyk.io"
 }

--- a/pkg/resource/google/testdata/acc/google_storage_bucket_iam_binding/terraform.tf
+++ b/pkg/resource/google/testdata/acc/google_storage_bucket_iam_binding/terraform.tf
@@ -24,7 +24,7 @@ resource "google_storage_bucket_iam_binding" "binding_admin_1" {
   bucket = google_storage_bucket.driftctl-unittest.name
   role   = "roles/storage.admin"
   members = [
-    "user:team-cloud-context@snyk.io",
+    "group:cloud-context-team@snyk.io",
   ]
 }
 
@@ -32,7 +32,7 @@ resource "google_storage_bucket_iam_binding" "binding_viewer_1" {
   bucket = google_storage_bucket.driftctl-unittest.name
   role   = "roles/storage.objectViewer"
   members = [
-    "user:team-cloud-context@snyk.io",
+    "group:cloud-context-team@snyk.io",
   ]
 }
 
@@ -45,6 +45,6 @@ resource "google_storage_bucket_iam_binding" "binding_admin_2" {
   bucket = google_storage_bucket.driftctl-unittest2.name
   role   = "roles/storage.admin"
   members = [
-    "user:team-cloud-context@snyk.io",
+    "group:cloud-context-team@snyk.io",
   ]
 }

--- a/pkg/resource/google/testdata/acc/google_storage_bucket_iam_member/terraform.tf
+++ b/pkg/resource/google/testdata/acc/google_storage_bucket_iam_member/terraform.tf
@@ -23,13 +23,13 @@ resource "google_storage_bucket" "driftctl-unittest" {
 resource "google_storage_bucket_iam_member" "elie1" {
   bucket = google_storage_bucket.driftctl-unittest.name
   role   = "roles/storage.admin"
-  member = "user:team-cloud-context@snyk.io"
+  member = "group:cloud-context-team@snyk.io"
 }
 
 resource "google_storage_bucket_iam_member" "will1" {
   bucket = google_storage_bucket.driftctl-unittest.name
   role   = "roles/storage.objectViewer"
-  member = "user:team-cloud-context@snyk.io"
+  member = "group:cloud-context-team@snyk.io"
 }
 
 resource "google_storage_bucket" "driftctl-unittest2" {
@@ -40,11 +40,11 @@ resource "google_storage_bucket" "driftctl-unittest2" {
 resource "google_storage_bucket_iam_member" "eli2" {
   bucket = google_storage_bucket.driftctl-unittest2.name
   role   = "roles/storage.objectViewer"
-  member = "user:team-cloud-context@snyk.io"
+  member = "group:cloud-context-team@snyk.io"
 }
 
 resource "google_storage_bucket_iam_member" "will2" {
   bucket = google_storage_bucket.driftctl-unittest2.name
   role   = "roles/storage.admin"
-  member = "user:team-cloud-context@snyk.io"
+  member = "group:cloud-context-team@snyk.io"
 }


### PR DESCRIPTION
One test fixture had a duplicate provider block, rendering it invalid. Others contained references to users that are actually groups, a recent regression in https://github.com/snyk/driftctl/pull/1662.

---

I haven't actually been able to run any of these, I can't quite figure out how from my laptop... I've tried ADC, and overrides using a service account key with `GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json CLOUDSDK_CORE_PROJECT=my-sandbox ...`. I'll run acceptance tests in circleCI on this branch.