### PR TITLE
chore: disable GitHub acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,10 +229,12 @@ workflows:
             parameters:
               pattern:
                 - TestAcc_Aws
-                - TestAcc_Github_
                 - TestAcc_Google
                 - TestAcc_Azure_
                 - TestAcc_StateReader_
+
+                # Disable this rather than create a new test org
+                # - TestAcc_Github_
           context:
             - driftctl-acc
     triggers:
@@ -252,10 +254,12 @@ workflows:
             parameters:
               pattern:
                 - TestAcc_Aws
-                - TestAcc_Github_
                 - TestAcc_Google
                 - TestAcc_Azure_
                 - TestAcc_StateReader_
+
+                # Disable this rather than create a new test org
+                # - TestAcc_Github_
           context:
             - driftctl-acc
   pullrequest:

--- a/pkg/resource/github/testdata/acc/github_branch_protection/terraform.tf
+++ b/pkg/resource/github/testdata/acc/github_branch_protection/terraform.tf
@@ -5,52 +5,52 @@ terraform {
   }
 }
 
-data "github_user" "eliecharra" {
-  username = "eliecharra"
+data "github_user" "craigfurman" {
+  username = "craigfurman"
 }
 
 resource "github_repository" "repo" {
-  count = 3
-  name = "repo${count.index}"
+  count     = 3
+  name      = "repo${count.index}"
   auto_init = true
 }
 
 resource "github_branch" "repo_toto" {
-  count = 3
-  branch = "toto"
-  repository = github_repository.repo[count.index].name
+  count         = 3
+  branch        = "toto"
+  repository    = github_repository.repo[count.index].name
   source_branch = "main"
 }
 
 resource "github_branch_protection" "main_repo" {
-  count = 3
-  pattern = "main"
-  repository_id = github_repository.repo[count.index].name
+  count          = 3
+  pattern        = "main"
+  repository_id  = github_repository.repo[count.index].name
   enforce_admins = true
   required_status_checks {
-    strict = false
+    strict   = false
     contexts = ["ci/travis"]
   }
 
   required_pull_request_reviews {
     dismiss_stale_reviews = true
     dismissal_restrictions = [
-      data.github_user.eliecharra.node_id
+      data.github_user.craigfurman.node_id
     ]
   }
 
   push_restrictions = [
-    data.github_user.eliecharra.node_id
+    data.github_user.craigfurman.node_id
   ]
 
-  allows_deletions = true
+  allows_deletions    = true
   allows_force_pushes = true
 }
 
 
 resource "github_branch_protection" "toto_repo" {
-  count = 3
-  repository_id     = github_repository.repo[count.index].name
-  pattern         = github_branch.repo_toto[count.index].branch
+  count          = 3
+  repository_id  = github_repository.repo[count.index].name
+  pattern        = github_branch.repo_toto[count.index].branch
   enforce_admins = true
 }

--- a/pkg/resource/github/testdata/acc/github_team_membership/terraform.tf
+++ b/pkg/resource/github/testdata/acc/github_team_membership/terraform.tf
@@ -5,27 +5,47 @@ terraform {
   }
 }
 
-data "github_user" "wbeuil" {
-  username = "wbeuil"
+resource "github_team" "test" {
+  name        = "acceptance-testing"
+  description = "Acceptance tests team"
 }
 
-data "github_user" "driftctl" {
-  username = "driftctl-acceptance-tester"
+data "github_user" "karniwl" {
+  username = "karniwl"
 }
 
-resource "github_team" "foo" {
-  name        = "foo"
-  description = "Foo team"
+data "github_user" "chdorner-snyk" {
+  username = "chdorner-snyk"
 }
 
-resource "github_team_membership" "foo" {
-  team_id  = github_team.foo.id
-  username = data.github_user.wbeuil.login
+data "github_user" "agatakrajewska" {
+  username = "agatakrajewska"
+}
+
+data "github_user" "craigfurman" {
+  username = "craigfurman"
+}
+
+resource "github_team_membership" "karniwl" {
+  team_id  = github_team.test.id
+  username = data.github_user.karniwl.login
   role     = "maintainer"
 }
 
-resource "github_team_membership" "bar" {
-  team_id  = github_team.foo.id
-  username = data.github_user.driftctl.login
+resource "github_team_membership" "chdorner-snyk" {
+  team_id  = github_team.test.id
+  username = data.github_user.chdorner-snyk.login
+  role     = "maintainer"
+}
+
+resource "github_team_membership" "agatakrajewska" {
+  team_id  = github_team.test.id
+  username = data.github_user.agatakrajewska.login
+  role     = "maintainer"
+}
+
+resource "github_team_membership" "craigfurman" {
+  team_id  = github_team.test.id
+  username = data.github_user.craigfurman.login
   role     = "maintainer"
 }


### PR DESCRIPTION
FYI @karniwl @agatakrajewska @chdorner-snyk 

Agata and I paired on recovering the acc test org and user, and failed. The token in circle is not an admin of that org. We have no choice but to abandon these. If we wanted, we could create new ones, but it doesn't seem worth the effort atm.