### PR TITLE
chore: don't disable acc test KMS keys

### DIFF
--- a/pkg/resource/aws/testdata/acc/aws_kms_alias/terraform.tf
+++ b/pkg/resource/aws/testdata/acc/aws_kms_alias/terraform.tf
@@ -10,7 +10,6 @@ terraform {
 
 resource "aws_kms_key" "key" {
   deletion_window_in_days = 7
-  is_enabled              = false
 }
 
 resource "aws_kms_alias" "foo" {
@@ -19,6 +18,6 @@ resource "aws_kms_alias" "foo" {
 }
 
 resource "aws_kms_alias" "baz" {
-  name_prefix          = "alias/baz"
+  name_prefix   = "alias/baz"
   target_key_id = aws_kms_key.key.key_id
 }

--- a/pkg/resource/aws/testdata/acc/aws_kms_key/terraform.tf
+++ b/pkg/resource/aws/testdata/acc/aws_kms_key/terraform.tf
@@ -10,23 +10,20 @@ terraform {
 
 resource "aws_kms_key" "foo" {
   description              = "Foo"
-  deletion_window_in_days = 7
-  is_enabled              = false
+  deletion_window_in_days  = 7
   customer_master_key_spec = "RSA_4096"
 }
 
 resource "aws_kms_key" "bar" {
   description              = "Bar"
-  deletion_window_in_days = 7
-  is_enabled              = false
+  deletion_window_in_days  = 7
   customer_master_key_spec = "RSA_2048"
-  key_usage = "SIGN_VERIFY"
+  key_usage                = "SIGN_VERIFY"
 }
 
 resource "aws_kms_key" "baz" {
   description             = "Baz"
   deletion_window_in_days = 7
-  is_enabled              = false
   tags = {
     "Foo" = "true"
   }


### PR DESCRIPTION
When applying acceptance test terraform for AWS KMS key resources, we often see errors of the form: `Failed to set KMS key ... status to false: "NotFoundException: Key '...' does not exist"`. Our current theory is that setting is_enabled=false (as we currently do) is causing terraform to have to perform 2 API operations: create the key, then disable it. Due to the "eventualy consistency" of this API we see this flaking quite often.

We don't actually need to disable the keys, so let's not, in an attempt to improve the reliability of this test.
