### PR TITLE
chore: some acceptance test tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ coverage: test
 
 .PHONY: acc
 acc:
-	DRIFTCTL_ACC=true $(GOTEST) --format testname --junitfile unit-tests-acc.xml -- -coverprofile=cover-acc.out -test.timeout 5h -coverpkg=./pkg/... -run=$(ACC_PATTERN) ./pkg/...
+	DRIFTCTL_ACC=true $(GOTEST) --format standard-verbose --junitfile unit-tests-acc.xml -- -coverprofile=cover-acc.out -test.timeout 5h -coverpkg=./pkg/... -run=$(ACC_PATTERN) ./pkg/...
 
 .PHONY: mocks
 mocks:

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ lint:
 
 .PHONY: install-tools
 install-tools:
-	$(GOINSTALL) gotest.tools/gotestsum@v1.6.3
+	$(GOINSTALL) gotest.tools/gotestsum@v1.10.0
 	$(GOINSTALL) github.com/vektra/mockery/v2@latest
 
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.3
 	github.com/aws/aws-sdk-go v1.44.122
 	github.com/bmatcuk/doublestar/v4 v4.0.1
-	github.com/eapache/go-resiliency v1.2.0
+	github.com/eapache/go-resiliency v1.3.0
 	github.com/fatih/color v1.9.0
 	github.com/getkin/kin-openapi v0.75.0
 	github.com/getsentry/sentry-go v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dylanmei/iso8601 v0.1.0/go.mod h1:w9KhXSgIyROl1DefbMYIE7UVSIvELTbMrCfx+QkYnoQ=
 github.com/dylanmei/winrmtest v0.0.0-20190225150635-99b7fe2fddf1/go.mod h1:lcy9/2gH1jn/VCLouHA6tOEwLoNVd4GW6zhuKLmHC2Y=
-github.com/eapache/go-resiliency v1.2.0 h1:v7g92e/KSN71Rq7vSThKaWIq68fL4YHvWyiUKorFR1Q=
-github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
+github.com/eapache/go-resiliency v1.3.0 h1:RRL0nge+cWGlxXbUzJ7yMcq6w2XBEr19dCN6HECGaT0=
+github.com/eapache/go-resiliency v1.3.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/test/acceptance/testing.go
+++ b/test/acceptance/testing.go
@@ -58,6 +58,7 @@ type AccTestCase struct {
 }
 
 func (c *AccTestCase) initTerraformExecutor() error {
+	logrus.Debug("Initializing terraform...")
 	installPath := path.Join(os.TempDir(), "terraform-bin", c.TerraformVersion)
 	binPath := path.Join(installPath, "terraform")
 	execPathFinderOptions := make([]tfinstall.ExecPathFinder, 0)
@@ -208,13 +209,8 @@ func (c *AccTestCase) terraformApply() error {
 }
 
 func (c *AccTestCase) terraformDestroy() error {
-	r := retrier.New(retrier.ExponentialBackoff(10, time.Second*5), nil)
-	return r.Run(c.doDestroy)
-
-}
-
-func (c *AccTestCase) doDestroy() error {
 	if c.ShouldRefreshBeforeDestroy {
+		logrus.Debug("Running terraform refresh...")
 		if err := c.terraformRefresh(); err != nil {
 			return err
 		}
@@ -336,23 +332,28 @@ func Run(t *testing.T, c AccTestCase) {
 	checkpoint := os.Getenv("CHECKPOINT_DISABLE")
 	os.Setenv("CHECKPOINT_DISABLE", "true")
 
+	// Retry after 2s, 4s, 8s, 16s, 32s, 64s, 2m, 2m, 2m, 2m
+	// Try tweaking the backoff interval limit and/or the retry count limit in
+	// response to flaky tests.
+	limitedExponentialBackoff := retrier.New(retrier.LimitedExponentialBackoff(10, time.Second*2, time.Minute*2), nil)
+
 	if !c.DoNotRunTerraform {
 		// Execute terraform init if .terraform folder is not found in test folder
-		err := c.terraformInit()
+		err := limitedExponentialBackoff.Run(c.terraformInit)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		defer func() {
 			c.restoreEnv()
-			err := c.terraformDestroy()
+			err := limitedExponentialBackoff.Run(c.terraformDestroy)
 			os.Setenv("CHECKPOINT_DISABLE", checkpoint)
 			if err != nil {
 				t.Fatal(err)
 			}
 		}()
 
-		err = c.terraformApply()
+		err = limitedExponentialBackoff.Run(c.terraformApply)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION


**chore: update gotestsum**




**chore: stream acceptance test output in CI**

We see reasonably frequent acceptance flakes in CircleCI due to out job
being terminated due to 10 minutes passing without output:
https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-

As well as making that test flaky, the SIGKILL (which does not give us a
chance to clean up, even if we handled other signals during tests),
often causes resources to be left in the acc testing cloud accounts,
producing further failures on the next run, and manual cleanup work for
the team.

We could adjust this time limit, but this commit changes the gotestsum
output to be streaming (like `go test -v`) instead. We still output a
junit xml with gotestsum to be able to look at structured failures in
CircleCI.

We've recently introduced some long backoff/retry loops to try to squash
other flakes, and it would be useful to see which of these are taking a
long time in the test output.



**chore: retry all terraform operations in acc tests**

Add some retry behaviour (and backoff) for downloading terraform itself,
terraform-init, and apply. We already had retry behaviour for destroy.
This aims to reduce acceptance test flakes in which terraform-apply
fails when creating resources that depend on recently-created resources
from the same terraform run. We think that sometimes these cloud APIs
are a bit _too_ eventually consistent, not acknowledging the existence
of these resources that were just created.

There is opt-in retry behaviour for the driftctl-scan itself already,
that this commit doesn't change. Only some tests use it. Anecdotally, we
don't see many flakes on the scan. If we want to always retry at this
level, we should validate that we can distinguish between a retryable
flake (e.g. cloud API rate limiting) and a real error (e.g. actual
unmanaged drift) and use the appropriate error classifier for the
retrier.

