### PR TITLE
[CTX-613] chore: move ownership from cloud context to IaC+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
   notify_slack_on_failure:
     steps:
       - slack/notify:
-          channel: team-cloud-context-alerts
+          channel: group-infrastructure-as-code-alerts
           event: fail
           custom: |
               {

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/cloud-context
+* @snyk/cloud-dev-ex


### PR DESCRIPTION


**chore: move ownership from cloud context to IaC+**

As part of the Cloud Group consolidation, this repositry's Cloud Context
ownership is moving to the IaC+ team.



**chore: move failed acceptance test notifications**

To the IaC+ Slack alerts channel, following the Cloud Context team
split.

