### PR TITLE
chore: retry AWS VPC acceptance test

### DIFF
--- a/pkg/resource/aws/aws_vpc_test.go
+++ b/pkg/resource/aws/aws_vpc_test.go
@@ -2,6 +2,7 @@ package aws_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/snyk/driftctl/test"
 
@@ -18,6 +19,7 @@ func TestAcc_Aws_VPC(t *testing.T) {
 				Env: map[string]string{
 					"AWS_REGION": "us-east-1",
 				},
+				ShouldRetry: acceptance.LinearBackoff(10 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)


### PR DESCRIPTION
Seems like this recent acceptance test failure was a flake again that should most likely be more stable by retrying the check. Similar to #1675