### PR TITLE
alerts: fix 'occured' -> 'occurred' in error format strings

### DIFF
--- a/enumeration/remote/alerts/alerts.go
+++ b/enumeration/remote/alerts/alerts.go
@@ -31,21 +31,21 @@ func NewRemoteAccessDeniedAlert(provider string, scanErr *remoteerror.ResourceSc
 	switch scanningPhase {
 	case EnumerationPhase:
 		message = fmt.Sprintf(
-			"An error occured listing %s: listing %s is forbidden: %s",
+			"An error occurred listing %s: listing %s is forbidden: %s",
 			scanErr.Resource(),
 			scanErr.ListedTypeError(),
 			scanErr.RootCause().Error(),
 		)
 	case DetailsFetchingPhase:
 		message = fmt.Sprintf(
-			"An error occured listing %s: reading details of %s is forbidden: %s",
+			"An error occurred listing %s: reading details of %s is forbidden: %s",
 			scanErr.Resource(),
 			scanErr.ListedTypeError(),
 			scanErr.RootCause().Error(),
 		)
 	default:
 		message = fmt.Sprintf(
-			"An error occured listing %s: %s",
+			"An error occurred listing %s: %s",
 			scanErr.Resource(),
 			scanErr.RootCause().Error(),
 		)


### PR DESCRIPTION
Three error format strings in `enumeration/remote/alerts/alerts.go` (lines 34, 41, 48) read `An error occured listing`. Fixed to `occurred`. String-literal-only change.