### PR TITLE
fix: add timeout to gRPC provider Cleanup to prevent scan hang

### DIFF
--- a/enumeration/remote/terraform/provider.go
+++ b/enumeration/remote/terraform/provider.go
@@ -219,6 +219,20 @@ func (p *TerraformProvider) Cleanup() {
 		logrus.WithFields(logrus.Fields{
 			"alias": alias,
 		}).Debug("Closing gRPC client")
-		client.Close()
+		done := make(chan struct{})
+		go func(c *plugin.GRPCProvider) {
+			c.Close()
+			close(done)
+		}(client)
+		select {
+		case <-done:
+			logrus.WithFields(logrus.Fields{
+				"alias": alias,
+			}).Debug("gRPC client closed")
+		case <-time.After(5 * time.Second):
+			logrus.WithFields(logrus.Fields{
+				"alias": alias,
+			}).Warn("gRPC client close timed out, forcing exit")
+		}
 	}
 }


### PR DESCRIPTION
Fixes #1653

## Problem
`driftctl scan` hangs after completing all resource enumeration in certain
environments (containerised, slow networks, CI). The scan completes
successfully but the process never exits.

## Root Cause
`Cleanup()` in `enumeration/remote/terraform/provider.go` calls
`client.Close()` as a bare blocking call with no timeout:

```go
func (p *TerraformProvider) Cleanup() {
    for alias, client := range p.grpcProviders {
        logrus.WithFields(...).Debug("Closing gRPC client")
        client.Close()  // blocks indefinitely
    }
}
```

The debug output from affected users confirms the scan completes and
reaches "Closing gRPC client alias=eu-north-1" — the hang is on that
call in environments where gRPC shutdown does not return cleanly.

## Fix
Wrap `client.Close()` in a goroutine with a 5-second timeout. If the
close does not complete within the timeout, a warning is logged and
execution continues rather than blocking forever.

No new imports required — `time` and `plugin` are already imported.

## Testing
Existing test suite unchanged. The fix is isolated to the shutdown path
and does not affect any resource enumeration or drift detection logic.