### PR TITLE
fix: replace Alpine runtime with distroless to eliminate BusyBox CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,11 @@ RUN go mod download
 COPY . .
 RUN SINGLE_TARGET=true make release
 
-FROM alpine:3.21.2
+FROM gcr.io/distroless/static AS runner
 
 ARG OS="linux"
 ARG ARCH="amd64"
 
 WORKDIR /app
 COPY --from=builder /go/src/app/bin/driftctl_${OS}_${ARCH}/driftctl /bin/driftctl
-RUN chmod +x /bin/driftctl
 ENTRYPOINT ["/bin/driftctl"]


### PR DESCRIPTION
Fixes #1716

## Problem
The container image uses `alpine:3.21.2` as the runtime base, which
bundles BusyBox. Two CVEs are present:

- **CVE-2022-28391** (CVSS 8.8) — RCE via BusyBox `netstat`
- **CVE-2022-30065** — Use-after-free in BusyBox `awk`

## Fix
driftctl is a statically compiled Go binary with no runtime dependencies
on Alpine or BusyBox. Switching to `gcr.io/distroless/static` eliminates
the entire BusyBox attack surface.

Changes:
- Replace `FROM alpine:3.21.2` with `FROM gcr.io/distroless/static`
- Remove `RUN chmod +x` — unnecessary since binary permissions are
  preserved from the builder stage and distroless has no shell

The builder stage (`golang:1.23`) is unchanged.

## Testing
Image builds and runs identically — only the runtime base layer changes.
The binary entrypoint is unaffected.